### PR TITLE
switch to stable rust, disable overflow checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ opt-level = 0
 lto = false
 debug = true
 codegen-units = 1
-overflow-checks = true
+overflow-checks = false
 incremental = true
 
 # crypto fast even in dev (when enabled)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"
 components = ["rust-src", "llvm-tools-preview", "clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION



prevents integer-overflow panics that kill local build on windows