### PR TITLE
Update x86_64-nonos.json

### DIFF
--- a/x86_64-nonos.json
+++ b/x86_64-nonos.json
@@ -3,7 +3,7 @@
   "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
   "arch": "x86_64",
   "target-endian": "little",
-  "target-pointer-width": "64",
+  "target-pointer-width": 64,
   "target-c-int-width": 32,
   "os": "none",
   "executables": true,


### PR DESCRIPTION
fix pointer_width type in target spec-remove quotes so Rust parses correctly