### PR TITLE
Feat/graphics phase1 display dimensions

### DIFF
--- a/src/boot/main/setup_menu/render.rs
+++ b/src/boot/main/setup_menu/render.rs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::brand;
+use crate::display::framebuffer as display_fb;
 use crate::graphics::{font, framebuffer};
 
 pub(super) fn clear() {
@@ -28,12 +29,12 @@ pub(super) fn rect(x: u32, y: u32, w: u32, h: u32, c: u32) {
 }
 
 pub(super) fn text_centered(s: &str, y: i32, c: u32) {
-    let (w, _) = framebuffer::dimensions();
+    let (w, _) = display_fb::dimensions();
     text(s, ((w - s.len() as u32 * 8) / 2) as i32, y, c);
 }
 
 pub(super) fn logo(y: u32) {
-    let (w, _) = framebuffer::dimensions();
+    let (w, _) = display_fb::dimensions();
     let x = (w - brand::LOGO[0].len() as u32 * 8) / 2;
     for (i, l) in brand::LOGO.iter().enumerate() {
         text(l, x as i32, (y + i as u32 * 16) as i32, brand::ACCENT_PRIMARY);
@@ -60,7 +61,7 @@ pub(super) fn checkbox(x: u32, y: u32, label: &str, checked: bool, sel: bool) {
 }
 
 pub(super) fn progress_dots(y: u32, cur: usize, total: usize) {
-    let (w, _) = framebuffer::dimensions();
+    let (w, _) = display_fb::dimensions();
     let sx = (w - total as u32 * 20) / 2;
     for i in 0..total {
         let c = if i == cur {
@@ -75,7 +76,7 @@ pub(super) fn progress_dots(y: u32, cur: usize, total: usize) {
 }
 
 pub(super) fn footer(left: &str, right: &str) {
-    let (w, h) = framebuffer::dimensions();
+    let (w, h) = display_fb::dimensions();
     rect(0, h - 50, w, 50, brand::BG_SECONDARY);
     text(left, 20, (h - 35) as i32, brand::TEXT_MUTED);
     text(right, (w - right.len() as u32 * 8 - 20) as i32, (h - 35) as i32, brand::TEXT_MUTED);

--- a/src/capabilities/tests/types.rs
+++ b/src/capabilities/tests/types.rs
@@ -80,7 +80,7 @@ pub(crate) fn test_capability_bits_are_unique() -> TestResult {
 }
 
 pub(crate) fn test_capability_all_returns_11_items() -> TestResult {
-    if Capability::all().len() != 11 {
+    if Capability::all().len() != 12 {
         return TestResult::Fail;
     }
     TestResult::Pass

--- a/src/capabilities/types.rs
+++ b/src/capabilities/types.rs
@@ -27,6 +27,7 @@ pub enum Capability {
     Debug,
     Admin,
     RegisterService,
+    GraphicsDisplayQuery,
 }
 
 impl Capability {
@@ -44,10 +45,11 @@ impl Capability {
             Self::Debug => 256,
             Self::Admin => 512,
             Self::RegisterService => 1024,
+            Self::GraphicsDisplayQuery => 2048,
         }
     }
 
-    pub const fn all() -> [Capability; 11] {
+    pub const fn all() -> [Capability; 12] {
         [
             Self::CoreExec,
             Self::IO,
@@ -60,6 +62,7 @@ impl Capability {
             Self::Debug,
             Self::Admin,
             Self::RegisterService,
+            Self::GraphicsDisplayQuery,
         ]
     }
 
@@ -76,11 +79,12 @@ impl Capability {
             Self::Debug => "Debug",
             Self::Admin => "Admin",
             Self::RegisterService => "RegisterService",
+            Self::GraphicsDisplayQuery => "GraphicsDisplayQuery",
         }
     }
 
     pub const fn count() -> usize {
-        11
+        12
     }
 }
 

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -16,7 +16,7 @@
 
 mod error;
 pub mod font;
-mod framebuffer;
+pub mod framebuffer;
 pub mod text;
 
 pub use error::DisplayError;

--- a/src/graphics/design_system/colors/chrome.rs
+++ b/src/graphics/design_system/colors/chrome.rs
@@ -11,7 +11,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::graphics::framebuffer::colors as brand;
+use crate::display::framebuffer::colors as brand;
 
 pub const TITLEBAR_BG: u32 = brand::COLOR_PANEL;
 pub const TITLEBAR_BG_UNFOCUSED: u32 = brand::COLOR_PANEL_ACTIVE;

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -36,13 +36,8 @@ pub mod window;
 #[cfg(test)]
 pub mod tests;
 
-pub use framebuffer::dimensions as framebuffer_dimensions;
-pub use framebuffer::init as framebuffer_init;
 pub use framebuffer::{
     clear, draw_rect, fill_rect, fill_rounded_rect, get_pixel, hline, put_pixel, vline,
-    COLOR_ACCENT, COLOR_BG, COLOR_BLACK, COLOR_BLUE, COLOR_DARK_GRAY, COLOR_DOCK_BG, COLOR_FG,
-    COLOR_GRAY, COLOR_GREEN, COLOR_LIGHT_GRAY, COLOR_MENU_BG, COLOR_RED, COLOR_TITLE_BG,
-    COLOR_TITLE_FG, COLOR_WHITE, COLOR_WINDOW_BG,
 };
 
 pub use font::{

--- a/src/graphics/tests/colors.rs
+++ b/src/graphics/tests/colors.rs
@@ -1,4 +1,4 @@
-use crate::graphics::framebuffer::colors::*;
+use crate::display::framebuffer::colors::*;
 use crate::test::framework::TestResult;
 
 pub(crate) fn test_brand_accent_colors() -> TestResult {

--- a/src/syscall/caps/checks.rs
+++ b/src/syscall/caps/checks.rs
@@ -105,4 +105,8 @@ impl CapabilityToken {
     pub fn can_admin(&self) -> bool {
         self.grants(Capability::Admin) && self.is_valid()
     }
+    #[inline]
+    pub fn can_graphics_display_query(&self) -> bool {
+        self.grants(Capability::GraphicsDisplayQuery) && self.is_valid()
+    }
 }

--- a/src/syscall/contract/cap_table/graphics.rs
+++ b/src/syscall/contract/cap_table/graphics.rs
@@ -1,0 +1,26 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::capabilities::CapabilityToken;
+use crate::syscall::numbers::SyscallNumber;
+
+pub(super) fn check(caps: &CapabilityToken, number: SyscallNumber) -> Option<bool> {
+    Some(match number {
+        SyscallNumber::GraphicsDisplayDimensions => caps.can_graphics_display_query(),
+
+        _ => return None,
+    })
+}

--- a/src/syscall/contract/cap_table/mod.rs
+++ b/src/syscall/contract/cap_table/mod.rs
@@ -18,6 +18,7 @@ mod admin;
 mod crypto;
 mod debug;
 mod file_fs;
+mod graphics;
 mod hardware;
 mod io_event;
 mod ipc;
@@ -52,5 +53,6 @@ pub(super) fn is_allowed(caps: &CapabilityToken, number: SyscallNumber) -> bool 
         .or_else(|| debug::check(caps, number))
         .or_else(|| io_event::check(caps, number))
         .or_else(|| mk::check(caps, number))
+        .or_else(|| graphics::check(caps, number))
         .unwrap_or(false)
 }

--- a/src/syscall/dispatch/router/mod.rs
+++ b/src/syscall/dispatch/router/mod.rs
@@ -213,6 +213,10 @@ fn dispatch_syscall(
         | SyscallNumber::AdminCapGrant
         | SyscallNumber::AdminCapRevoke => admin::dispatch_admin(syscall, a0, a1, a2, a3, a4, a5),
 
+        SyscallNumber::GraphicsDisplayDimensions => {
+            crate::syscall::graphics_surface::sys_display_dimensions(a0 as u32)
+        }
+
         SyscallNumber::MkIpcSend
         | SyscallNumber::MkIpcRecv
         | SyscallNumber::MkIpcCall

--- a/src/syscall/graphics_surface.rs
+++ b/src/syscall/graphics_surface.rs
@@ -1,0 +1,42 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::capabilities::Capability;
+use crate::display::framebuffer;
+use crate::syscall::dispatch::util::{errno, require_capability};
+use crate::syscall::types::errnos::{EINVAL, ENODEV};
+use crate::syscall::SyscallResult;
+
+const PRIMARY_DISPLAY: u32 = 0;
+
+pub fn sys_display_dimensions(display: u32) -> SyscallResult {
+    if let Err(e) = require_capability(Capability::GraphicsDisplayQuery) {
+        return e;
+    }
+    if display != PRIMARY_DISPLAY {
+        return errno(EINVAL);
+    }
+    if !framebuffer::is_initialized() {
+        return errno(ENODEV);
+    }
+    let (width, height) = framebuffer::dimensions();
+    let packed = ((width as u64) << 32) | (height as u64);
+    SyscallResult {
+        value: packed as i64,
+        capability_consumed: false,
+        audit_required: false,
+    }
+}

--- a/src/syscall/mod.rs
+++ b/src/syscall/mod.rs
@@ -27,6 +27,7 @@ pub mod epoll;
 pub mod eventfd;
 pub mod extended;
 pub mod fanotify;
+pub mod graphics_surface;
 pub mod handler;
 #[cfg(feature = "nonos-experimental-syscalls")]
 pub mod inotify;

--- a/src/syscall/numbers/convert.rs
+++ b/src/syscall/numbers/convert.rs
@@ -263,6 +263,7 @@ impl SyscallNumber {
             1203 => Some(Self::AdminCapGrant),
             1204 => Some(Self::AdminCapRevoke),
             1205 => Some(Self::CapDrop),
+            1300 => Some(Self::GraphicsDisplayDimensions),
             0x1000 => Some(Self::MkIpcSend),
             0x1001 => Some(Self::MkIpcRecv),
             0x1002 => Some(Self::MkIpcCall),

--- a/src/syscall/numbers/defs.rs
+++ b/src/syscall/numbers/defs.rs
@@ -377,6 +377,8 @@ pub enum SyscallNumber {
     AdminCapRevoke = 1204,
     CapDrop = 1205,
 
+    GraphicsDisplayDimensions = 1300,
+
     MkIpcSend = 0x1000,
     MkIpcRecv = 0x1001,
     MkIpcCall = 0x1002,


### PR DESCRIPTION
This pull request introduces a new capability and system call for querying graphics display dimensions, and refactors framebuffer-related code to reside under the `display` module. It also updates capability management and access control to support the new feature, and cleans up module imports and usage throughout the codebase.

**Graphics display query capability and syscall:**

* Added a new `GraphicsDisplayQuery` capability to the `Capability` enum, updated its bitmask, string representation, and included it in the `all()` and `count()` methods. [[1]](diffhunk://#diff-195cb4b3c418dd217828908e9961a009f9d16976497d092b78fee0db0fcedca5R30) [[2]](diffhunk://#diff-195cb4b3c418dd217828908e9961a009f9d16976497d092b78fee0db0fcedca5R48-R52) [[3]](diffhunk://#diff-195cb4b3c418dd217828908e9961a009f9d16976497d092b78fee0db0fcedca5R65) [[4]](diffhunk://#diff-195cb4b3c418dd217828908e9961a009f9d16976497d092b78fee0db0fcedca5R82-R87)
* Implemented the `can_graphics_display_query` method in `CapabilityToken` for checking this new capability.
* Added a new system call `GraphicsDisplayDimensions` (`1300`) to query display dimensions, including its enum variant, conversion, and syscall dispatch logic. [[1]](diffhunk://#diff-a06bd9ce0c27468b17ad2338a1003b2366aa3602c5659b28d96d99cebf8d89a7R380-R381) [[2]](diffhunk://#diff-4fa28ecc34d72143e995d0debaa9dc2bdb6434a8caee1fecb2442ed9b4c46acbR266) [[3]](diffhunk://#diff-fa0736716bd7bae56388e12f0c1ed9e2ccf3e3227bf671fbfa7d7e2b56bc4421R216-R219)
* Implemented the syscall handler in the new `src/syscall/graphics_surface.rs` file, enforcing capability checks and returning packed width/height.
* Integrated the new capability into the syscall capability table, so only callers with `GraphicsDisplayQuery` can use the new syscall. [[1]](diffhunk://#diff-44e09305e4c8fa1866377d9bf9db18f4d1c303a6d4c8876b81e84ecada926d97R1-R26) [[2]](diffhunk://#diff-a7ccd5904f983c53b6bf2b5bfe171458728511cf0bb1f58f5cf027d0b88ce148R21) [[3]](diffhunk://#diff-a7ccd5904f983c53b6bf2b5bfe171458728511cf0bb1f58f5cf027d0b88ce148R56)

**Refactoring framebuffer code under display module:**

* Moved the `framebuffer` module from `graphics` to `display`, updating imports and visibility accordingly throughout the codebase. [[1]](diffhunk://#diff-f25c14f3c3f6054a6550e15b2f0ee861be9b9fcb8a050f2ebf9b021c063d4837L19-R19) [[2]](diffhunk://#diff-d8a89e9e100f1d5f14ad554072223e74da43efcf5ef236e94b1aba5c27a194b6L14-R14) [[3]](diffhunk://#diff-2527c375606206461d4d1cc77a107df7dfb8bf5783ab1e63f793d89d5301d2faL1-R1) [[4]](diffhunk://#diff-45007e98c1ef2198c6ea13eb3d3b47df5c0fb33208c9831cc46f2d83d120ee35L39-L45)
* Updated all references in `setup_menu/render.rs` and related graphics code to use `display::framebuffer` instead of `graphics::framebuffer`. [[1]](diffhunk://#diff-b0413a9f8809e4d8ba63f2b5a5d5a9cdd6a3c8da41dda92de329d291147d9aaaR18) [[2]](diffhunk://#diff-b0413a9f8809e4d8ba63f2b5a5d5a9cdd6a3c8da41dda92de329d291147d9aaaL31-R37) [[3]](diffhunk://#diff-b0413a9f8809e4d8ba63f2b5a5d5a9cdd6a3c8da41dda92de329d291147d9aaaL63-R64) [[4]](diffhunk://#diff-b0413a9f8809e4d8ba63f2b5a5d5a9cdd6a3c8da41dda92de329d291147d9aaaL78-R79)

**Testing and validation:**

* Updated the capability tests to account for the new capability, ensuring the correct number of capabilities is reported.

**Module organization:**

* Added the new `graphics_surface` module to the syscall module tree.

These changes collectively add a secure, capability-gated way to query graphics display dimensions and improve the organization of graphics-related code.