### PR TITLE
Feat/graphics phase4 m4 present rect

### DIFF
--- a/src/syscall/contract/cap_table/graphics.rs
+++ b/src/syscall/contract/cap_table/graphics.rs
@@ -24,6 +24,7 @@ pub(super) fn check(caps: &CapabilityToken, number: SyscallNumber) -> Option<boo
         SyscallNumber::GraphicsSurfaceDestroy => caps.can_graphics_surface_create(),
         SyscallNumber::GraphicsSurfaceMap => caps.can_graphics_surface_map(),
         SyscallNumber::GraphicsSurfacePresentFull => caps.can_graphics_present(),
+        SyscallNumber::GraphicsSurfacePresentRect => caps.can_graphics_present(),
 
         _ => return None,
     })

--- a/src/syscall/dispatch/router/mod.rs
+++ b/src/syscall/dispatch/router/mod.rs
@@ -228,6 +228,11 @@ fn dispatch_syscall(
         SyscallNumber::GraphicsSurfacePresentFull => {
             crate::syscall::graphics_surface::sys_surface_present_full(a0 as u32, a1)
         }
+        SyscallNumber::GraphicsSurfacePresentRect => {
+            crate::syscall::graphics_surface::sys_surface_present_rect(
+                a0 as u32, a1, a2 as u32, a3 as u32, a4 as u32, a5 as u32,
+            )
+        }
 
         SyscallNumber::MkIpcSend
         | SyscallNumber::MkIpcRecv

--- a/src/syscall/graphics_surface/mod.rs
+++ b/src/syscall/graphics_surface/mod.rs
@@ -20,6 +20,7 @@ mod display_dimensions;
 mod map;
 mod pixel_format;
 mod present;
+mod present_rect;
 mod reclaim;
 mod registry;
 
@@ -28,4 +29,5 @@ pub use destroy::sys_surface_destroy;
 pub use display_dimensions::sys_display_dimensions;
 pub use map::sys_surface_map;
 pub use present::sys_surface_present_full;
+pub use present_rect::sys_surface_present_rect;
 pub use reclaim::release_for;

--- a/src/syscall/graphics_surface/present_rect.rs
+++ b/src/syscall/graphics_surface/present_rect.rs
@@ -1,0 +1,86 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::capabilities::Capability;
+use crate::display::framebuffer;
+use crate::memory::unified::phys_to_virt;
+use crate::syscall::dispatch::util::{errno, require_capability};
+use crate::syscall::types::errnos::{EINVAL, ENODEV};
+use crate::syscall::SyscallResult;
+
+use super::registry::{snapshot, SurfaceId};
+
+const PAGE_SIZE: u64 = 4096;
+
+pub fn sys_surface_present_rect(
+    display: u32,
+    id: SurfaceId,
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+) -> SyscallResult {
+    if let Err(e) = require_capability(Capability::GraphicsPresent) {
+        return e;
+    }
+    if display != 0 {
+        return errno(EINVAL);
+    }
+    if !framebuffer::is_initialized() {
+        return errno(ENODEV);
+    }
+    let Some(proc) = crate::process::current_process() else {
+        return errno(EINVAL);
+    };
+    let Some(view) = snapshot(id, proc.pid()) else {
+        return errno(EINVAL);
+    };
+
+    if x >= view.width || y >= view.height || w == 0 || h == 0 {
+        return errno(EINVAL);
+    }
+    let Some(x_end) = x.checked_add(w) else { return errno(EINVAL) };
+    let Some(y_end) = y.checked_add(h) else { return errno(EINVAL) };
+    if x_end > view.width || y_end > view.height {
+        return errno(EINVAL);
+    }
+
+    let bpp = view.fmt.bytes_per_pixel() as u64;
+    let (fb_w, fb_h) = framebuffer::dimensions();
+    let fb_addr = framebuffer::addr();
+    let fb_pitch = framebuffer::pitch() as u64;
+    let copy_w = w.min(fb_w.saturating_sub(x));
+    let copy_h = h.min(fb_h.saturating_sub(y));
+    let src_row_bytes = view.width as u64 * bpp;
+
+    for row in 0..copy_h {
+        for col in 0..copy_w {
+            let sx = (x + col) as u64;
+            let sy = (y + row) as u64;
+            let src_byte = sy * src_row_bytes + sx * bpp;
+            let frame_idx = (src_byte / PAGE_SIZE) as usize;
+            let frame_off = src_byte % PAGE_SIZE;
+            let src_va = phys_to_virt(view.frames[frame_idx]).as_u64() + frame_off;
+            let dst = fb_addr + sy * fb_pitch + sx * bpp;
+            unsafe {
+                let pixel = core::ptr::read_volatile(src_va as *const u32);
+                core::ptr::write_volatile(dst as *mut u32, pixel);
+            }
+        }
+    }
+
+    SyscallResult { value: 0, capability_consumed: false, audit_required: true }
+}

--- a/src/syscall/numbers/convert.rs
+++ b/src/syscall/numbers/convert.rs
@@ -268,6 +268,7 @@ impl SyscallNumber {
             1302 => Some(Self::GraphicsSurfaceDestroy),
             1303 => Some(Self::GraphicsSurfaceMap),
             1304 => Some(Self::GraphicsSurfacePresentFull),
+            1305 => Some(Self::GraphicsSurfacePresentRect),
             0x1000 => Some(Self::MkIpcSend),
             0x1001 => Some(Self::MkIpcRecv),
             0x1002 => Some(Self::MkIpcCall),

--- a/src/syscall/numbers/defs.rs
+++ b/src/syscall/numbers/defs.rs
@@ -382,6 +382,7 @@ pub enum SyscallNumber {
     GraphicsSurfaceDestroy = 1302,
     GraphicsSurfaceMap = 1303,
     GraphicsSurfacePresentFull = 1304,
+    GraphicsSurfacePresentRect = 1305,
 
     MkIpcSend = 0x1000,
     MkIpcRecv = 0x1001,

--- a/userland/libc/src/graphics/mod.rs
+++ b/userland/libc/src/graphics/mod.rs
@@ -19,9 +19,11 @@ mod surface_create;
 mod surface_destroy;
 mod surface_map;
 mod surface_present;
+mod surface_present_rect;
 
 pub use display_dimensions::nonos_display_dimensions;
 pub use surface_create::{nonos_surface_create, NONOS_PIXEL_FMT_ARGB8888};
 pub use surface_destroy::nonos_surface_destroy;
 pub use surface_map::nonos_surface_map;
 pub use surface_present::nonos_surface_present_full;
+pub use surface_present_rect::nonos_surface_present_rect;

--- a/userland/libc/src/graphics/surface_present_rect.rs
+++ b/userland/libc/src/graphics/surface_present_rect.rs
@@ -14,15 +14,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-mod bridge;
-mod numbers;
-mod raw;
+use crate::syscall::{call_raw, N_GFX_SURFACE_PRESENT_RECT};
 
-pub(crate) use bridge::{call_diverging, call_raw};
-pub use numbers::N_RT_SIGRETURN;
-pub(crate) use numbers::{
-    N_BRK, N_CRYPTO_DECRYPT, N_CRYPTO_ENCRYPT, N_CRYPTO_RANDOM, N_EXIT,
-    N_GFX_DISPLAY_DIMENSIONS, N_GFX_SURFACE_CREATE, N_GFX_SURFACE_DESTROY, N_GFX_SURFACE_MAP,
-    N_GFX_SURFACE_PRESENT_FULL, N_GFX_SURFACE_PRESENT_RECT, N_MK_IPC_CALL, N_MK_IPC_RECV, N_MK_IPC_SEND, N_MMAP, N_READ,
-    N_WRITE,
-};
+#[no_mangle]
+pub extern "C" fn nonos_surface_present_rect(
+    display: u32,
+    id: u64,
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+) -> i64 {
+    call_raw(
+        N_GFX_SURFACE_PRESENT_RECT,
+        [display as u64, id, x as u64, y as u64, w as u64, h as u64],
+    )
+}

--- a/userland/libc/src/lib.rs
+++ b/userland/libc/src/lib.rs
@@ -29,7 +29,7 @@ mod unistd;
 pub use crypto::{crypto_decrypt, crypto_encrypt, crypto_random};
 pub use graphics::{
     nonos_display_dimensions, nonos_surface_create, nonos_surface_destroy, nonos_surface_map,
-    nonos_surface_present_full, NONOS_PIXEL_FMT_ARGB8888,
+    nonos_surface_present_full, nonos_surface_present_rect, NONOS_PIXEL_FMT_ARGB8888,
 };
 pub use heap::{init as heap_init, HeapError};
 pub use ipc::{mk_ipc_call, mk_ipc_recv, mk_ipc_send};

--- a/userland/libc/src/syscall/numbers.rs
+++ b/userland/libc/src/syscall/numbers.rs
@@ -35,3 +35,4 @@ pub(crate) const N_GFX_SURFACE_CREATE: i64 = 1301;
 pub(crate) const N_GFX_SURFACE_DESTROY: i64 = 1302;
 pub(crate) const N_GFX_SURFACE_MAP: i64 = 1303;
 pub(crate) const N_GFX_SURFACE_PRESENT_FULL: i64 = 1304;
+pub(crate) const N_GFX_SURFACE_PRESENT_RECT: i64 = 1305;


### PR DESCRIPTION
This pull request adds support for presenting a rectangular region of a graphics surface to the display, introducing a new syscall (`GraphicsSurfacePresentRect`) and corresponding userland API. The changes include both kernel and userland updates to enable partial surface presentation, improving graphics performance and flexibility.

**Graphics Surface Presentation Enhancements:**

* Added a new syscall `GraphicsSurfacePresentRect` to present a rectangular region of a graphics surface, including its implementation in the kernel (`present_rect.rs`) and integration into the syscall dispatch and capability checks. [[1]](diffhunk://#diff-d0134edb4c5368ea06fd6894df03b4a747a84d0dcf297ddc198c0eeca9f035faR1-R86) [[2]](diffhunk://#diff-fa0736716bd7bae56388e12f0c1ed9e2ccf3e3227bf671fbfa7d7e2b56bc4421R231-R235) [[3]](diffhunk://#diff-44e09305e4c8fa1866377d9bf9db18f4d1c303a6d4c8876b81e84ecada926d97R27)
* Registered the new syscall number (`1305`) in both kernel and userland syscall number definitions. [[1]](diffhunk://#diff-a06bd9ce0c27468b17ad2338a1003b2366aa3602c5659b28d96d99cebf8d89a7R385) [[2]](diffhunk://#diff-4fa28ecc34d72143e995d0debaa9dc2bdb6434a8caee1fecb2442ed9b4c46acbR271) [[3]](diffhunk://#diff-0379bbee34fbc9f70eba5b739bce6978cedb474bf754f151c044d2168dbb5f61R38)

**Userland Library Updates:**

* Introduced the `nonos_surface_present_rect` function in the userland graphics library, exposing the new syscall to applications. [[1]](diffhunk://#diff-3785b29ce0540b3b0463160d2a2ac24f5f495527554e811a6d3a8f9612495a73R1-R32) [[2]](diffhunk://#diff-5d030654768e73f54ca6c46de506067c6416aecf2a198aa46bf179e7c7c9b339R22-R29)
* Updated public exports in the userland graphics and libc modules to include the new function and syscall constant. [[1]](diffhunk://#diff-3bccd0bace144c9d92933e26ba8e4279698d80b29dbbbda169ee65a6a6b6fb1bL32-R32) [[2]](diffhunk://#diff-727fa01636db78d61403cd09d460f8253f36d133ac0e51bfa617cd7df17fe820L26-R26)

**Module Organization:**

* Added new module files and updated mod declarations for `present_rect` in both kernel and userland graphics code. [[1]](diffhunk://#diff-f87e7d34fac7d5e5ea7b21ab006fad4ae690c634459aa04e200a3d10a89902a6R23) [[2]](diffhunk://#diff-f87e7d34fac7d5e5ea7b21ab006fad4ae690c634459aa04e200a3d10a89902a6R32) [[3]](diffhunk://#diff-5d030654768e73f54ca6c46de506067c6416aecf2a198aa46bf179e7c7c9b339R22-R29)

These changes collectively enable applications to efficiently update only portions of the display, reducing unnecessary framebuffer operations and improving rendering performance.