### PR TITLE
bootloader: fix ExitBootServices #PF — identity window must reach firmware image load phys (>4 GiB on OVMF/QEMU 10.2)

### DIFF
--- a/nonos-bootloader/src/handoff/exit/orchestrate.rs
+++ b/nonos-bootloader/src/handoff/exit/orchestrate.rs
@@ -48,10 +48,12 @@ pub fn exit_and_jump(
 
     // Build the kernel paging contract while UEFI Boot Services
     // can still hand us page-table frames. The new PML4 carries
-    // a low-4 GiB identity range (so bootloader text/data, the
-    // loaded kernel ELF, the handoff struct, the boot stack, the
-    // memory map area, and the framebuffer all stay reachable
-    // through the CR3 swap) plus a 256-GiB linear directmap at
+    // a low identity range over [0, IDENTITY_LOW_BYTES) (so
+    // bootloader text/data, the loaded kernel ELF, the handoff
+    // struct, the boot stack, the memory map area, and the
+    // framebuffer all stay reachable through the CR3 swap — the
+    // window is sized to reach firmware image loads above 4 GiB)
+    // plus a 256-GiB linear directmap at
     // PML4[256] (the `phys_to_virt` window the kernel asserts
     // on first VM init).
     com1_marker(b"PT0");

--- a/nonos-bootloader/src/paging/build.rs
+++ b/nonos-bootloader/src/paging/build.rs
@@ -26,9 +26,11 @@ use super::table::PageTable;
 use super::verify::verify_kernel_pml4;
 
 // Build the kernel paging contract that NØNOS hands off to the
-// kernel: a fresh PML4 with low-4 GiB identity (so bootloader
-// text/data, handoff struct, stack, mmap area, and framebuffer
-// stay reachable across the CR3 swap), a 256 GiB linear directmap
+// kernel: a fresh PML4 with low identity over [0,
+// IDENTITY_LOW_BYTES) (so bootloader text/data, handoff struct,
+// stack, mmap area, and framebuffer stay reachable across the CR3
+// swap even when firmware loads the image > 4 GiB), a 256 GiB
+// linear directmap
 // rooted at PML4[256] (the kernel's `phys_to_virt` window), and
 // per-PT_LOAD phys -> virt mappings rooted at PML4[511] for the
 // upper-half kernel image.

--- a/nonos-bootloader/src/paging/constants.rs
+++ b/nonos-bootloader/src/paging/constants.rs
@@ -28,12 +28,19 @@ pub const PAGE_TABLE_ENTRIES: usize = 512;
 pub const DIRECTMAP_BASE: u64 = 0xFFFF_8000_0000_0000;
 pub const DIRECTMAP_SIZE: u64 = 0x0000_0040_0000_0000;
 
-// Identity-map the full first 4 GiB so kernel ELF, bootloader
-// text/data, handoff struct, mmap area, framebuffer, and any
-// UEFI-allocated low-memory region all stay reachable through
-// the CR3 swap. Production hardware with > 4 GiB RAM still gets
-// full coverage via the upper-half directmap.
-pub const IDENTITY_LOW_BYTES: u64 = 0x1_0000_0000;
+// Identity-map low physical memory so the kernel ELF, bootloader
+// text/data (the RIP that keeps executing across `mov cr3`), the
+// handoff struct, boot stack, mmap area, and framebuffer all stay
+// reachable through the CR3 swap. This must cover wherever the UEFI
+// firmware physically placed the bootloader image: edk2/OVMF on
+// QEMU 10.2.0 loads it above 4 GiB (observed RIP ~0x1_4001_F000),
+// so a 4 GiB window faults on the instruction right after the CR3
+// write. 64 GiB = 64 1-GiB hugepage entries in PML4[0]'s single
+// PDPT (cap 512 GiB); the directmap (PML4[256]) does not help here
+// because the bootloader executes at its firmware load phys, not
+// the directmap window. The kernel tears this window down after its
+// directmap probe regardless of size.
+pub const IDENTITY_LOW_BYTES: u64 = 0x10_0000_0000;
 
 // Bit positions for x86_64 page-table entries.
 pub const PTE_P: u64 = 1 << 0;

--- a/nonos-bootloader/src/paging/map_identity.rs
+++ b/nonos-bootloader/src/paging/map_identity.rs
@@ -24,14 +24,15 @@ use super::table::PageTable;
 // bootloader's text/data, the kernel's loaded ELF range (ET_DYN
 // at low phys), the handoff struct, the boot stack, the memory
 // map area, and the framebuffer (if low-mapped) all live here on
-// every UEFI platform we ship. Identity-mapping the entire 4 GiB
-// keeps every `mov rax, [imm]` and every `jmp rip+offset` valid
-// across the CR3 swap, which is the only way the bootloader can
-// switch CR3 and immediately call `jump_to_kernel` without a
-// fault.
+// every UEFI platform we ship. Identity-mapping [0,
+// IDENTITY_LOW_BYTES) keeps every `mov rax, [imm]` and every
+// `jmp rip+offset` valid across the CR3 swap, which is the only
+// way the bootloader can switch CR3 and immediately call
+// `jump_to_kernel` without a fault. The window must reach the
+// firmware's image load phys (OVMF/QEMU 10.2.0 places it > 4 GiB).
 //
-// 1 GiB hugepages: 4 entries in PML4[0]'s PDPT cover the whole
-// region.
+// 1 GiB hugepages: IDENTITY_LOW_BYTES / 1 GiB entries in PML4[0]'s
+// single PDPT (cap 512 GiB) cover the whole region.
 pub fn map_identity_low(bs: &BootServices, pml4: PageTable) -> Result<(), &'static str> {
     let count = (IDENTITY_LOW_BYTES / HUGE_1G) as usize;
     map_huge_1g_run(bs, pml4, 0, 0, count, PTE_RW)


### PR DESCRIPTION
## Problem

On QEMU 10.2.0 + edk2/OVMF (`edk2-x86_64-code.fd`), every boot dies with a
firmware-level page fault at ExitBootServices, before the kernel runs:

```
X64 Exception Type - 0E (#PF)   RIP = CR2 = 0x000000014001FCFB
err = 0x2 (instruction fetch, page not present)
```

after `[EBS1]`/`[MMAP1]`, with no `[CR3OK]`.

Root cause: the post-ExitBootServices identity window is `[0, 4 GiB)`
(`IDENTITY_LOW_BYTES = 0x1_0000_0000`), but edk2/OVMF on QEMU 10.2 loads the
bootloader image **above 4 GiB** (observed RIP ~`0x1_4001_F000`, ≈ 5.37 GiB).
The instruction immediately after `mov cr3` in `switch_to_kernel_pml4` is then
unmapped → `#PF`. `main` is currently unbootable on this firmware/QEMU.

## Fix

`IDENTITY_LOW_BYTES` 4 GiB → 64 GiB (64 × 1-GiB hugepage entries in PML4[0]'s
single PDPT; cap 512 GiB). The directmap (PML4[256]) cannot help — the
bootloader executes at its firmware load phys, not the directmap window. The
kernel still tears the identity window down after its directmap probe,
regardless of size. Only `map_identity.rs` consumes the constant;
`verify_kernel_pml4` checks presence not size; `map_huge_1g_run` already
handles the larger count in one PDPT. Stale "4 GiB" docs in `build.rs` /
`map_identity.rs` / `orchestrate.rs` corrected to match.

4 files, +32 −20, scoped entirely to `nonos-bootloader/src/paging|handoff`.

## Verification

- Conflict-free, linear on top of `main` (`main` confirmed still 4 GiB).
- `cargo check --release --target x86_64-unknown-uefi` clean on the `main` base.
- Runtime: rebuilt `nonos_boot.efi`; serial now shows
  `[EBS1] → [MMAP1] → [CR3OK] → NX64 → [NONOS] Handoff OK` (no `0E #PF`),
  full boot through `[INIT] Capsules spawned` / `[wm] boot` /
  `[desktop_shell] boot`.
