### PR TITLE
fix: LAPIC #PF cr2=0xFEE000B0 — UC-map LAPIC before low-half teardown

### DIFF
--- a/src/memory/unified/init/run.rs
+++ b/src/memory/unified/init/run.rs
@@ -84,6 +84,19 @@ pub fn init_unified_vm() -> Result<(), &'static str> {
     crate::memory::page_allocator::init()
         .map_err(|_| "init_unified_vm: page_allocator init failed")?;
 
+    // Step 5c: the Local APIC is addressed by `sys::apic` at its raw
+    // physical base (0xFEE00000), only reachable while the bootloader
+    // low identity map is live. Step 6 tears that down, so any
+    // post-teardown `eoi()`/timer access would #PF (cr2=0xFEE000B0).
+    // Install a permanent UC mapping of the LAPIC page in the kernel
+    // half and atomically republish the base to it before the
+    // teardown so the LAPIC stays reachable.
+    let lapic_pa = crate::memory::addr::PhysAddr::new(crate::sys::apic::LAPIC_PHYS_BASE);
+    let lapic_va = crate::memory::mmio::map_device_memory(lapic_pa, 0x1000)
+        .map_err(|_| "init_unified_vm: LAPIC MMIO map failed")?;
+    crate::sys::apic::rebind_to_virt(lapic_va.as_u64());
+    crate::sys::serial::println(b"[VM-INIT] LAPIC rebased to UC kernel mapping");
+
     // Step 6: drop the bootloader's low-half identity. Two
     // kernel-half entries means directmap (PML4[256]) plus kernel
     // text (PML4[511]) are both there; from here on the kernel

--- a/src/sys/apic/local.rs
+++ b/src/sys/apic/local.rs
@@ -19,6 +19,8 @@ use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 const LOCAL_APIC_DEFAULT_BASE: u64 = 0xFEE0_0000;
 
+pub const LAPIC_PHYS_BASE: u64 = LOCAL_APIC_DEFAULT_BASE;
+
 const LAPIC_ID: u32 = 0x020;
 const LAPIC_VERSION: u32 = 0x030;
 const LAPIC_TPR: u32 = 0x080;
@@ -38,6 +40,17 @@ pub const TIMER_VECTOR: u8 = 0x20;
 
 static LAPIC_BASE: AtomicU64 = AtomicU64::new(LOCAL_APIC_DEFAULT_BASE);
 pub static LAPIC_INIT: AtomicBool = AtomicBool::new(false);
+
+// Atomically republish the LAPIC register base. Called once during
+// VM init with a permanent UC kernel-half virtual mapping of the
+// physical LAPIC page, before the bootloader low identity map (which
+// the raw-physical base depended on) is torn down. The store is
+// atomic, so an interleaved timer-IRQ `eoi()` reads either the old
+// (still identity-mapped) or new (UC-mapped) base — never a torn or
+// unmapped address.
+pub fn rebind_to_virt(va: u64) {
+    LAPIC_BASE.store(va, Ordering::SeqCst);
+}
 
 unsafe fn lapic_read(reg: u32) -> u32 {
     unsafe {

--- a/src/sys/apic/mod.rs
+++ b/src/sys/apic/mod.rs
@@ -21,5 +21,7 @@ pub mod vectors;
 
 pub use api::{init, is_init, setup_keyboard_irq, setup_mouse_irq};
 pub use ioapic::{disable_irq, enable_irq, init_ioapic, ioapic_set_irq};
-pub use local::{eoi, init_local_apic, setup_timer, stop_timer, TIMER_VECTOR};
+pub use local::{
+    eoi, init_local_apic, rebind_to_virt, setup_timer, stop_timer, LAPIC_PHYS_BASE, TIMER_VECTOR,
+};
 pub use vectors::*;


### PR DESCRIPTION
## fix: LAPIC `#PF cr2=0xFEE000B0` — UC-map the LAPIC before the low-half identity teardown

### Root cause (source-proven)
`src/sys/apic/local.rs` addresses the Local APIC by its **raw physical MMIO
base** `0xFEE00000` (`LOCAL_APIC_DEFAULT_BASE` stored into `LAPIC_BASE`, used
directly as `*mut u32` in `lapic_read/lapic_write` — no `phys_to_virt`, no
`map_mmio`), implicitly depending on the bootloader's low identity map.

`init_core_systems()` (`src/boot/main/core_init.rs`) runs `apic::init()` +
`preemption::install_on_bsp()` (100 Hz timer) + `sti` while that identity map
is still live, so early `eoi()`s succeed. Later, `init_unified_vm()` Step 6
(`src/memory/unified/init/run.rs` → `clear_low_half()` in
`src/arch/x86_64/paging/clear_low_half.rs`) drops PML4[0], unmapping physical
`0xFEE00000`. With the timer armed and interrupts enabled, the next timer
IRQ's `eoi()` (`src/interrupts/apic/eoi.rs` → `sys::apic::eoi()` →
`lapic_write(0xB0,0)`) faults deterministically: **#PF, cr2=0xFEE000B0,
P:0 (not present)**.

Distinct from and downstream of the bootloader ExitBootServices `#PF`
(PR #155, already merged).

### Fix
New **Step 5c** in `init_unified_vm`, between page-allocator init (5b) and the
low-half teardown (6): install a permanent **UC** mapping of the LAPIC page
in the kernel half via the existing MMIO manager and atomically republish the
LAPIC base to it *before* the teardown — so the LAPIC stays reachable.

- `src/sys/apic/local.rs` — `LAPIC_PHYS_BASE` const + `rebind_to_virt(va)`
  (atomic `LAPIC_BASE` store; an interleaved timer-IRQ `eoi()` reads either
  the old still-identity-mapped or the new UC-mapped base, never torn/unmapped)
- `src/sys/apic/mod.rs` — export
- `src/memory/unified/init/run.rs` — Step 5c:
  `map_device_memory(PhysAddr(0xFEE00000), 0x1000)` → `rebind_to_virt(va)`

Layered: the memory layer owns the UC mapping; `sys::apic` only receives its
rebased VA. Blast radius: 3 files, no userland surface.

### Verification
Kernel **debug `cargo check` — EXIT=0** (`Finished dev in 2m20s`), zero
errors/warnings referencing the 3 changed files. (Release `cargo check` is
blocked by the `NONOS_SIGNING_KEY` `build.rs` gate — the signing-ceremony
class; debug uses `build.rs`'s dummy-key fallback, so this is a genuine
whole-crate type-check.) **Runtime confirmation that the `#PF` is eliminated
needs a signed-kernel boot — not done here (signing-ceremony gated).** Root
cause + fix are source-proven and now compile-verified.
