### PR TITLE
Input probe harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@
 .PHONY: nonos-mk-userland-clean
 .PHONY: nonos-mk-bootloader nonos-mk-sign nonos-mk-attest nonos-mk-esp
 .PHONY: nonos-mk-run nonos-mk-run-serial nonos-mk-debug nonos-mk-plan-a-runtime
-.PHONY: nonos-mk-boot-ramfs nonos-mk-boot-keyring nonos-mk-boot-entropy nonos-mk-boot-crypto-hash nonos-mk-boot-vfs nonos-mk-boot-ps2-input nonos-mk-boot-xhci nonos-mk-boot-desktop-gui
+.PHONY: nonos-mk-boot-ramfs nonos-mk-boot-keyring nonos-mk-boot-entropy nonos-mk-boot-crypto-hash nonos-mk-boot-vfs nonos-mk-boot-ps2-input nonos-mk-boot-xhci nonos-mk-boot-usb-hid nonos-mk-boot-desktop-gui
 .PHONY: nonos-mk-input-e2e-ps2-test nonos-mk-input-e2e-ps2-esp nonos-mk-input-e2e-xhci-test nonos-mk-input-e2e-xhci-esp nonos-mk-boot-input-e2e-ps2 nonos-mk-boot-input-e2e-xhci nonos-mk-input-probe-test nonos-mk-input-probe-esp nonos-mk-input-probe-run nonos-mk-input-probe-run-serial nonos-mk-input-probe-inject-test nonos-mk-input-probe-inject-esp nonos-mk-input-probe-inject-run-serial
 .PHONY: nonos-mk-static nonos-mk-scan
 .PHONY: nonos-mk-verify nonos-mk-verify-fast
@@ -1304,6 +1304,9 @@ nonos-mk-boot-ps2-input:
 
 nonos-mk-boot-xhci:
 	@./tests/boot/xhci_round_trip.sh
+
+nonos-mk-boot-usb-hid:
+	@./tests/boot/usb_hid_enum.sh
 
 nonos-mk-boot-input-e2e-ps2:
 	@./tests/boot/input_e2e_ps2.sh

--- a/src/hardware/broker/mmio/map.rs
+++ b/src/hardware/broker/mmio/map.rs
@@ -84,17 +84,20 @@ pub fn map_for_caller(pid: u32, req: MmioMapRequest) -> Result<MmioMapResult, Mm
     crate::sys::serial::println(b"[MMIO] reserve");
     let msix = pci_index::lookup(req.device_id).and_then(|h| h.msix);
     crate::sys::serial::println(b"[MMIO] msix");
-    msix_exclusion::validate(msix.as_ref(), req.bar_index, req.offset, req.length)?;
+    let length = msix_exclusion::safe_length(msix.as_ref(), req.bar_index, req.offset, req.length);
+    if length == 0 {
+        return Err(MmioMapError::WouldExposeMsixTable);
+    }
     crate::sys::serial::println(b"[MMIO] msix ok");
-    let pages = req.length / PAGE_SIZE;
+    let pages = length / PAGE_SIZE;
     let user_va = grant::reserve_user_va(pages).ok_or(MmioMapError::NoVaSpace)?;
     crate::sys::serial::println(b"[MMIO] va");
-    let user_va_end = user_va.as_u64().checked_add(req.length).ok_or(MmioMapError::Overflow)?;
+    let user_va_end = user_va.as_u64().checked_add(length).ok_or(MmioMapError::Overflow)?;
     if user_va.as_u64() < USER_MMIO_BASE || user_va_end > USER_MMIO_END {
         return Err(MmioMapError::NoVaSpace);
     }
     crate::sys::serial::println(b"[MMIO] map");
-    if crate::memory::paging::map_user_mmio(user_va, PhysAddr::new(phys_start), req.length as usize)
+    if crate::memory::paging::map_user_mmio(user_va, PhysAddr::new(phys_start), length as usize)
         .is_err()
     {
         return Err(MmioMapError::MapFailed);
@@ -109,8 +112,8 @@ pub fn map_for_caller(pid: u32, req: MmioMapRequest) -> Result<MmioMapResult, Mm
         bar_index: req.bar_index,
         physical_start: phys_start,
         user_va: user_va.as_u64(),
-        length: req.length,
+        length,
         flags: req.flags,
     });
-    Ok(MmioMapResult { user_va: user_va.as_u64(), length: req.length, grant_id })
+    Ok(MmioMapResult { user_va: user_va.as_u64(), length, grant_id })
 }

--- a/src/hardware/broker/mmio/msix_exclusion.rs
+++ b/src/hardware/broker/mmio/msix_exclusion.rs
@@ -19,26 +19,35 @@
 //! kernel programs both regions on the capsule's behalf through the
 //! MSI-X bind path and `MkPciConfigWrite`; exposing them via mmap
 //! would let a capsule short-circuit the allowlist.
+//!
+//! Rather than reject a request that overlaps either region, the
+//! mapping is clamped to end at the page boundary below the first
+//! protected region. A device whose registers share a BAR with its
+//! MSI-X table (e.g. xHCI) still maps everything up to the table; a
+//! request that starts inside a protected region clamps to zero and
+//! is refused by the caller.
 
 use crate::drivers::pci::constants::MSIX_ENTRY_SIZE;
 use crate::drivers::pci::types::MsixInfo;
 
-use super::types::MmioMapError;
+const PAGE_SIZE: u64 = 4096;
 
-pub fn validate(
-    msix: Option<&MsixInfo>,
-    bar_index: u8,
-    offset: u64,
-    length: u64,
-) -> Result<(), MmioMapError> {
-    let Some(m) = msix else { return Ok(()) };
-    if bar_index == m.table_bar && overlaps(offset, length, table_region(m)) {
-        return Err(MmioMapError::WouldExposeMsixTable);
+pub fn safe_length(msix: Option<&MsixInfo>, bar_index: u8, offset: u64, length: u64) -> u64 {
+    let Some(m) = msix else { return length };
+    let mut end = offset.saturating_add(length);
+    if bar_index == m.table_bar {
+        let region = table_region(m);
+        if overlaps(offset, length, region) {
+            end = end.min(region.0 & !(PAGE_SIZE - 1));
+        }
     }
-    if bar_index == m.pba_bar && overlaps(offset, length, pba_region(m)) {
-        return Err(MmioMapError::WouldExposePba);
+    if bar_index == m.pba_bar {
+        let region = pba_region(m);
+        if overlaps(offset, length, region) {
+            end = end.min(region.0 & !(PAGE_SIZE - 1));
+        }
     }
-    Ok(())
+    end.saturating_sub(offset)
 }
 
 fn table_region(m: &MsixInfo) -> (u64, u64) {

--- a/src/process/exit/finalize.rs
+++ b/src/process/exit/finalize.rs
@@ -9,10 +9,12 @@
 use crate::process::core::{Pid, PROCESS_TABLE};
 
 pub(super) fn finalize_teardown(pid: Pid) {
-    if PROCESS_TABLE.find_by_pid(pid).is_none() {
-        return;
-    }
+    let pcb = match PROCESS_TABLE.find_by_pid(pid) {
+        Some(p) => p,
+        None => return,
+    };
 
+    crate::process::address_space::lifecycle::release(&pcb);
     let _ = crate::hardware::broker::release_all_for_pid(pid, false);
     let _ = crate::hardware::broker::irq_release_all_for_pid(pid);
     let _ = crate::hardware::broker::dma_release_all_for_pid(pid, false);

--- a/src/process/exit/teardown.rs
+++ b/src/process/exit/teardown.rs
@@ -38,14 +38,6 @@ pub fn teardown(pid: Pid, exit_code: i32, _by_signal: bool) {
     crate::hardware::broker::dma_release_all_for_pid(pid, current);
     crate::hardware::broker::pio_release_all_for_pid(pid);
 
-    if current {
-        crate::process::address_space::lifecycle::release(&pcb);
-    } else if let Some(asid) = crate::memory::paging::manager::lookup_asid_for_process(pid) {
-        if crate::memory::paging::manager::cleanup_address_space(asid).is_err() {
-            crate::sys::serial::print(b"[EXIT] address_space_cleanup_failed\n");
-        }
-    }
-
     crate::kernel_core::process_spawn::defer_kernel_stack_release(pid);
 
     pcb.exit_code.store(exit_code, Ordering::Release);

--- a/src/userspace/capsule_driver_usb_hid/spawn.rs
+++ b/src/userspace/capsule_driver_usb_hid/spawn.rs
@@ -49,7 +49,8 @@ pub fn spawn_driver_usb_hid_capsule() -> Result<(), SpawnError> {
         requested_caps: Capability::CoreExec.bit()
             | Capability::IPC.bit()
             | Capability::Memory.bit()
-            | Capability::InputSource.bit(),
+            | Capability::InputSource.bit()
+            | Capability::Debug.bit(),
         debug_tag: b"",
     };
     let pid = capsule_spawn::spawn_verified(&spec, &trust_anchor, None)?;

--- a/userland/capsule_driver_usb_hid/Capsule.mk
+++ b/userland/capsule_driver_usb_hid/Capsule.mk
@@ -12,6 +12,6 @@ CAPSULE_FEATURE          := nonos-capsule-driver-usb-hid
 CAPSULE_NAMESPACE        := systems.nonos.driver.usb_hid0
 CAPSULE_SERVICE_ENDPOINT := service:4222:driver.usb_hid0
 CAPSULE_REPLY_ENDPOINT   := reply:4223:endpoint.4294967314
-CAPSULE_REQUIRED_CAPS    := 0x200019
+CAPSULE_REQUIRED_CAPS    := 0x200119
 
 include nonos-mk/capsule.mk

--- a/userland/capsule_driver_usb_hid/src/descriptors/binding.rs
+++ b/userland/capsule_driver_usb_hid/src/descriptors/binding.rs
@@ -30,16 +30,17 @@ pub struct HidBinding {
 
 impl HidBinding {
     pub fn from_pair(iface: Interface, ep: Endpoint) -> Option<Self> {
-        if iface.class != CLASS_HID || iface.subclass != SUBCLASS_BOOT {
+        if iface.class != CLASS_HID || !is_interrupt_in(ep) {
             return None;
         }
-        if !is_interrupt_in(ep) {
-            return None;
-        }
-        let kind = match iface.protocol {
-            PROTOCOL_KEYBOARD => HidKind::Keyboard,
-            PROTOCOL_MOUSE => HidKind::Mouse,
-            _ => return None,
+        let kind = if iface.subclass == SUBCLASS_BOOT {
+            match iface.protocol {
+                PROTOCOL_KEYBOARD => HidKind::Keyboard,
+                PROTOCOL_MOUSE => HidKind::Mouse,
+                _ => return None,
+            }
+        } else {
+            HidKind::Tablet
         };
         Some(Self {
             kind,

--- a/userland/capsule_driver_usb_hid/src/descriptors/parse.rs
+++ b/userland/capsule_driver_usb_hid/src/descriptors/parse.rs
@@ -23,12 +23,13 @@ use super::types::{Endpoint, Interface, DT_CONFIGURATION, DT_ENDPOINT, DT_INTERF
 
 pub fn hid_bindings(raw: &[u8]) -> Result<Vec<HidBinding>, ()> {
     validate_config(raw)?;
+    let total = u16::from_le_bytes([raw[2], raw[3]]) as usize;
     let mut out = Vec::new();
     let mut iface = None;
     let mut i = 9usize;
-    while i + 2 <= raw.len() {
+    while i + 2 <= total {
         let len = raw[i] as usize;
-        if len < 2 || i + len > raw.len() {
+        if len < 2 || i + len > total {
             return Err(());
         }
         match raw[i + 1] {

--- a/userland/capsule_driver_usb_hid/src/descriptors/types.rs
+++ b/userland/capsule_driver_usb_hid/src/descriptors/types.rs
@@ -27,6 +27,7 @@ pub const EP_TRANSFER_INTERRUPT: u8 = 0x03;
 pub enum HidKind {
     Keyboard = 1,
     Mouse = 2,
+    Tablet = 3,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/userland/capsule_driver_usb_hid/src/hid/mod.rs
+++ b/userland/capsule_driver_usb_hid/src/hid/mod.rs
@@ -23,6 +23,8 @@ mod post_key;
 mod post_mouse;
 mod post_wire;
 mod punctuation;
+mod tablet;
 
 pub use keyboard::Keyboard;
 pub use mouse::Mouse;
+pub use tablet::Tablet;

--- a/userland/capsule_driver_usb_hid/src/hid/post_wire.rs
+++ b/userland/capsule_driver_usb_hid/src/hid/post_wire.rs
@@ -21,3 +21,8 @@ pub fn send(kind: u16, flags: u16, code: u32, dx: i32, dy: i32) -> bool {
         InputEvent { kind, flags, code, x: 0, y: 0, delta_x: dx, delta_y: dy, timestamp_ns: 0 };
     mk_input_event_post(&ev) >= 0
 }
+
+pub fn send_abs(kind: u16, x: i32, y: i32) -> bool {
+    let ev = InputEvent { kind, flags: 0, code: 0, x, y, delta_x: 0, delta_y: 0, timestamp_ns: 0 };
+    mk_input_event_post(&ev) >= 0
+}

--- a/userland/capsule_driver_usb_hid/src/hid/tablet.rs
+++ b/userland/capsule_driver_usb_hid/src/hid/tablet.rs
@@ -1,0 +1,61 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use nonos_libc::{
+    INPUT_KIND_BUTTON_DOWN, INPUT_KIND_BUTTON_UP, INPUT_KIND_POINTER_ABS, INPUT_KIND_WHEEL,
+};
+
+use super::post_wire::{send, send_abs};
+
+pub struct Tablet {
+    buttons: u8,
+}
+
+impl Tablet {
+    pub fn new() -> Self {
+        Self { buttons: 0 }
+    }
+
+    pub fn feed(&mut self, report: &[u8]) {
+        if report.len() < 5 {
+            return;
+        }
+        let buttons = report[0] & 0x07;
+        let x = u16::from_le_bytes([report[1], report[2]]) as i32;
+        let y = u16::from_le_bytes([report[3], report[4]]) as i32;
+        let dz = if report.len() > 5 { report[5] as i8 as i32 } else { 0 };
+        let _ = send_abs(INPUT_KIND_POINTER_ABS, x, y);
+        if dz != 0 {
+            let _ = send(INPUT_KIND_WHEEL, 0, 0, 0, dz);
+        }
+        publish_buttons(self.buttons, buttons);
+        self.buttons = buttons;
+    }
+}
+
+fn publish_buttons(previous: u8, current: u8) {
+    let changed = (previous ^ current) & 0x07;
+    let mut bit = 0u8;
+    while bit < 3 {
+        let mask = 1u8 << bit;
+        if changed & mask != 0 {
+            let down = current & mask != 0;
+            let kind = if down { INPUT_KIND_BUTTON_DOWN } else { INPUT_KIND_BUTTON_UP };
+            let _ = send(kind, 0, u32::from(bit) + 1, 0, 0);
+        }
+        bit += 1;
+    }
+}

--- a/userland/capsule_driver_usb_hid/src/orchestrator/binding.rs
+++ b/userland/capsule_driver_usb_hid/src/orchestrator/binding.rs
@@ -16,7 +16,7 @@
 
 use alloc::vec::Vec;
 
-use crate::descriptors::HidBinding;
+use crate::descriptors::{HidBinding, HidKind};
 use crate::xhci::{alloc_transfer_ring, control_transfer};
 
 use super::enumerate::HidEndpoint;
@@ -27,9 +27,11 @@ pub fn configure_binding(
     binding: HidBinding,
     out: &mut Vec<HidEndpoint>,
 ) {
-    let iface = binding.interface_number as u16;
-    let mut dummy = [0u8; 0];
-    let _ = control_transfer(xhci_port, slot, 0x21, 0x0B, 0, iface, 0, &mut dummy);
+    if matches!(binding.kind, HidKind::Keyboard | HidKind::Mouse) {
+        let iface = binding.interface_number as u16;
+        let mut dummy = [0u8; 0];
+        let _ = control_transfer(xhci_port, slot, 0x21, 0x0B, 0, iface, 0, &mut dummy);
+    }
     let Ok(dci) = alloc_transfer_ring(
         xhci_port,
         slot,

--- a/userland/capsule_driver_usb_hid/src/orchestrator/poll/feed_report.rs
+++ b/userland/capsule_driver_usb_hid/src/orchestrator/poll/feed_report.rs
@@ -38,5 +38,8 @@ pub(super) fn feed_report(
             state.mouse.feed(&buf[..n]);
             state.mouse_reports = state.mouse_reports.wrapping_add(1);
         }
+        HidKind::Tablet => {
+            state.tablet.feed(&buf[..n]);
+        }
     }
 }

--- a/userland/capsule_driver_usb_hid/src/orchestrator/poll/run.rs
+++ b/userland/capsule_driver_usb_hid/src/orchestrator/poll/run.rs
@@ -30,7 +30,13 @@ pub fn run(xhci_port: u32) -> ! {
     let mut rx = alloc::vec![0u8; HDR_LEN + IPC_PAYLOAD_MAX];
     let mut tx = alloc::vec![0u8; HDR_LEN + IPC_PAYLOAD_MAX];
     let mut idle_polls = 0u32;
+    let mut announced = false;
     loop {
+        if !announced && !eps.is_empty() {
+            const MSG: &[u8] = b"[USB-HID-ENUM] tablet bound\n";
+            let _ = nonos_libc::mk_debug(MSG.as_ptr(), MSG.len());
+            announced = true;
+        }
         let _ = pump_once(&mut state, &mut rx, &mut tx);
         if drain_endpoints(&mut state, &eps, &mut buf) {
             idle_polls = 0;

--- a/userland/capsule_driver_usb_hid/src/state/mod.rs
+++ b/userland/capsule_driver_usb_hid/src/state/mod.rs
@@ -14,11 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::hid::{Keyboard, Mouse};
+use crate::hid::{Keyboard, Mouse, Tablet};
 
 pub struct State {
     pub keyboard: Keyboard,
     pub mouse: Mouse,
+    pub tablet: Tablet,
     pub configs_probed: u64,
     pub key_reports: u64,
     pub mouse_reports: u64,
@@ -29,6 +30,7 @@ impl State {
         Self {
             keyboard: Keyboard::new(),
             mouse: Mouse::new(),
+            tablet: Tablet::new(),
             configs_probed: 0,
             key_reports: 0,
             mouse_reports: 0,

--- a/userland/capsule_driver_xhci/src/contexts/configure_ep.rs
+++ b/userland/capsule_driver_xhci/src/contexts/configure_ep.rs
@@ -17,6 +17,8 @@ use crate::dma::DmaRegion;
 const INPUT_CONTROL_INDEX: usize = 0;
 const SLOT_CTX_INDEX: usize = 1;
 const CONTEXT_ENTRIES_SHIFT: u32 = 27;
+const SPEED_SHIFT: u32 = 20;
+const ROOT_PORT_SHIFT: u32 = 16;
 const ADD_SLOT_FLAG: u32 = 1;
 const EP_TYPE_INTERRUPT_IN: u32 = 7;
 const CERR: u32 = 3;
@@ -28,11 +30,15 @@ pub fn write_configure_endpoint_input(
     ring_phys: u64,
     max_packet: u16,
     interval: u8,
+    speed: u8,
+    root_port: u8,
 ) {
     region.zero();
     write_dw(region, context_size, INPUT_CONTROL_INDEX, 1, ADD_SLOT_FLAG | (1 << dci));
-    write_dw(region, context_size, SLOT_CTX_INDEX, 0, (dci as u32) << CONTEXT_ENTRIES_SHIFT);
-    write_endpoint(region, context_size, dci as usize, ring_phys, max_packet, interval);
+    let slot_dw0 = ((speed as u32) << SPEED_SHIFT) | ((dci as u32) << CONTEXT_ENTRIES_SHIFT);
+    write_dw(region, context_size, SLOT_CTX_INDEX, 0, slot_dw0);
+    write_dw(region, context_size, SLOT_CTX_INDEX, 1, (root_port as u32) << ROOT_PORT_SHIFT);
+    write_endpoint(region, context_size, dci as usize + 1, ring_phys, max_packet, interval);
 }
 fn write_endpoint(
     region: &DmaRegion,
@@ -48,7 +54,7 @@ fn write_endpoint(
     write_dw(region, context_size, dci, 1, dw1);
     write_dw(region, context_size, dci, 2, (ring_phys as u32) | DCS);
     write_dw(region, context_size, dci, 3, (ring_phys >> 32) as u32);
-    write_dw(region, context_size, dci, 4, max_packet as u32);
+    write_dw(region, context_size, dci, 4, (max_packet as u32) | ((max_packet as u32) << 16));
 }
 fn write_dw(region: &DmaRegion, context_size: u8, context: usize, dword: usize, value: u32) {
     let byte = context * context_size as usize + dword * core::mem::size_of::<u32>();

--- a/userland/capsule_driver_xhci/src/rings/event/advance.rs
+++ b/userland/capsule_driver_xhci/src/rings/event/advance.rs
@@ -20,6 +20,7 @@ impl EventRing {
     pub fn advance(&mut self) {
         let va = self.segment.user_va() + (self.dequeue_index as u64) * (TRB_BYTES as u64);
         write_volatile_at(va, Trb::zero());
+        self.drained_total = self.drained_total.wrapping_add(1);
         self.dequeue_index += 1;
         if self.dequeue_index == EVENT_RING_SEGMENT_TRBS {
             self.dequeue_index = 0;

--- a/userland/capsule_driver_xhci/src/rings/event/drained_total.rs
+++ b/userland/capsule_driver_xhci/src/rings/event/drained_total.rs
@@ -13,10 +13,9 @@
 //
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
-use crate::controller::{ack_irq, drain_events};
-use crate::server::context::Context;
-
-pub fn service_interrupts(ctx: &mut Context) {
-    let _ = drain_events(ctx.driver.layout.primary_intr_base, &mut ctx.driver.event_ring);
-    ack_irq(ctx.driver.layout.primary_intr_base, ctx.driver.handles.irq_grant_id());
+use super::state::EventRing;
+impl EventRing {
+    pub fn drained_total(&self) -> u64 {
+        self.drained_total
+    }
 }

--- a/userland/capsule_driver_xhci/src/rings/event/mod.rs
+++ b/userland/capsule_driver_xhci/src/rings/event/mod.rs
@@ -16,6 +16,7 @@
 mod advance;
 mod current_dequeue_phys;
 mod current_trb;
+mod drained_total;
 mod erst_base_phys;
 mod has_event;
 mod state;

--- a/userland/capsule_driver_xhci/src/rings/event/state.rs
+++ b/userland/capsule_driver_xhci/src/rings/event/state.rs
@@ -22,6 +22,7 @@ pub struct EventRing {
     pub(super) erst: DmaRegion,
     pub(super) consumer_cycle: u8,
     pub(super) dequeue_index: usize,
+    pub(super) drained_total: u64,
 }
 impl EventRing {
     pub fn new(pool: &DmaPool) -> XhciResult<Self> {
@@ -38,6 +39,6 @@ impl EventRing {
             core::ptr::write_volatile(erst_va.add(2), EVENT_RING_SEGMENT_TRBS as u32);
             core::ptr::write_volatile(erst_va.add(3), 0);
         }
-        Ok(Self { segment, erst, consumer_cycle: 1, dequeue_index: 0 })
+        Ok(Self { segment, erst, consumer_cycle: 1, dequeue_index: 0, drained_total: 0 })
     }
 }

--- a/userland/capsule_driver_xhci/src/server/context.rs
+++ b/userland/capsule_driver_xhci/src/server/context.rs
@@ -16,10 +16,9 @@
 use crate::setup::Driver;
 pub struct Context {
     pub driver: Driver,
-    pub events_drained_total: u64,
 }
 impl Context {
     pub fn new(driver: Driver) -> Self {
-        Self { driver, events_drained_total: 0 }
+        Self { driver }
     }
 }

--- a/userland/capsule_driver_xhci/src/server/error.rs
+++ b/userland/capsule_driver_xhci/src/server/error.rs
@@ -14,13 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 use crate::protocol::{
-    encode_response_header, write_status, Request, KERNEL_REPLY_ENDPOINT, RESP_HDR_LEN, STATUS_LEN,
+    encode_response_header, write_status, Request, RESP_HDR_LEN, STATUS_LEN,
 };
-use nonos_libc::mk_ipc_send;
 pub fn reply_with_status(tx: &mut [u8], req: &Request, status: i32) {
     encode_response_header(tx, req, STATUS_LEN as u32);
     write_status(&mut tx[RESP_HDR_LEN..], status);
-    let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, tx.as_ptr(), RESP_HDR_LEN + STATUS_LEN);
+    crate::server::reply::send(tx.as_ptr(), RESP_HDR_LEN + STATUS_LEN);
 }
 pub fn reply_decode_failed(tx: &mut [u8], status: i32) {
     let req = Request { op: 0, flags: 0, request_id: 0, payload_len: 0 };

--- a/userland/capsule_driver_xhci/src/server/handlers/address_reply.rs
+++ b/userland/capsule_driver_xhci/src/server/handlers/address_reply.rs
@@ -14,10 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 use crate::protocol::{
-    encode_response_header, write_status, Request, ADDRESS_DEVICE_REPLY_LEN, KERNEL_REPLY_ENDPOINT,
-    RESP_HDR_LEN, STATUS_LEN,
+    encode_response_header, write_status, Request, ADDRESS_DEVICE_REPLY_LEN, RESP_HDR_LEN,
+    STATUS_LEN,
 };
-use nonos_libc::mk_ipc_send;
 pub fn reply_ok(tx: &mut [u8], req: &Request, slot: u8, port: u8, speed: u8, max_packet: u16) {
     let payload_len = (STATUS_LEN + ADDRESS_DEVICE_REPLY_LEN) as u32;
     encode_response_header(tx, req, payload_len);
@@ -30,5 +29,5 @@ pub fn reply_ok(tx: &mut [u8], req: &Request, slot: u8, port: u8, speed: u8, max
     tx[o + 4..o + 6].copy_from_slice(&max_packet.to_le_bytes());
     tx[o + 6..o + ADDRESS_DEVICE_REPLY_LEN].fill(0);
     let len = RESP_HDR_LEN + payload_len as usize;
-    let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, tx.as_ptr(), len);
+    crate::server::reply::send(tx.as_ptr(), len);
 }

--- a/userland/capsule_driver_xhci/src/server/handlers/alloc_transfer_ring/configure.rs
+++ b/userland/capsule_driver_xhci/src/server/handlers/alloc_transfer_ring/configure.rs
@@ -39,6 +39,7 @@ pub(super) fn do_configure(
         res.int_ring = Some(ring);
         res.int_buf = Some(buf);
         res.int_dci = dci;
+        res.int_armed = None;
         write_configure_endpoint_input(
             &res.input_context,
             ctx.driver.layout.context_size,
@@ -46,6 +47,8 @@ pub(super) fn do_configure(
             ring_phys,
             max_packet,
             interval,
+            res.speed,
+            res.port_id,
         );
         res.input_context.phys()
     };

--- a/userland/capsule_driver_xhci/src/server/handlers/alloc_transfer_ring/reply.rs
+++ b/userland/capsule_driver_xhci/src/server/handlers/alloc_transfer_ring/reply.rs
@@ -14,10 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 use crate::protocol::{
-    encode_response_header, write_status, Request, ALLOC_TRANSFER_RING_REPLY_LEN,
-    KERNEL_REPLY_ENDPOINT, RESP_HDR_LEN, STATUS_LEN,
+    encode_response_header, write_status, Request, ALLOC_TRANSFER_RING_REPLY_LEN, RESP_HDR_LEN,
+    STATUS_LEN,
 };
-use nonos_libc::mk_ipc_send;
 
 pub(super) fn send_reply(tx: &mut [u8], req: &Request, dci: u8) {
     let plen = (STATUS_LEN + ALLOC_TRANSFER_RING_REPLY_LEN) as u32;
@@ -26,5 +25,5 @@ pub(super) fn send_reply(tx: &mut [u8], req: &Request, dci: u8) {
     let o = RESP_HDR_LEN + STATUS_LEN;
     tx[o] = dci;
     tx[o + 1..o + ALLOC_TRANSFER_RING_REPLY_LEN].fill(0);
-    let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, tx.as_ptr(), RESP_HDR_LEN + plen as usize);
+    crate::server::reply::send(tx.as_ptr(), RESP_HDR_LEN + plen as usize);
 }

--- a/userland/capsule_driver_xhci/src/server/handlers/config_descriptor/reply.rs
+++ b/userland/capsule_driver_xhci/src/server/handlers/config_descriptor/reply.rs
@@ -15,10 +15,9 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 use crate::dma::DmaRegion;
 use crate::protocol::{
-    encode_response_header, write_status, Request, CONFIG_DESCRIPTOR_REPLY_PREFIX,
-    KERNEL_REPLY_ENDPOINT, RESP_HDR_LEN, STATUS_LEN,
+    encode_response_header, write_status, Request, CONFIG_DESCRIPTOR_REPLY_PREFIX, RESP_HDR_LEN,
+    STATUS_LEN,
 };
-use nonos_libc::mk_ipc_send;
 
 pub(super) fn reply_config(tx: &mut [u8], req: &Request, out: &DmaRegion, actual: usize) {
     let payload_len = (STATUS_LEN + CONFIG_DESCRIPTOR_REPLY_PREFIX + actual) as u32;
@@ -33,5 +32,5 @@ pub(super) fn reply_config(tx: &mut [u8], req: &Request, out: &DmaRegion, actual
                 core::ptr::read_volatile(out.as_mut_ptr::<u8>().add(i));
         }
     }
-    let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, tx.as_ptr(), RESP_HDR_LEN + payload_len as usize);
+    crate::server::reply::send(tx.as_ptr(), RESP_HDR_LEN + payload_len as usize);
 }

--- a/userland/capsule_driver_xhci/src/server/handlers/control_transfer/reply.rs
+++ b/userland/capsule_driver_xhci/src/server/handlers/control_transfer/reply.rs
@@ -15,10 +15,9 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 use crate::dma::DmaRegion;
 use crate::protocol::{
-    encode_response_header, write_status, Request, CONTROL_TRANSFER_REPLY_PREFIX,
-    KERNEL_REPLY_ENDPOINT, RESP_HDR_LEN, STATUS_LEN,
+    encode_response_header, write_status, Request, CONTROL_TRANSFER_REPLY_PREFIX, RESP_HDR_LEN,
+    STATUS_LEN,
 };
-use nonos_libc::mk_ipc_send;
 
 pub(super) fn send_reply(tx: &mut [u8], req: &Request, actual: u16, region: Option<&DmaRegion>) {
     let plen = (STATUS_LEN + CONTROL_TRANSFER_REPLY_PREFIX + actual as usize) as u32;
@@ -34,5 +33,5 @@ pub(super) fn send_reply(tx: &mut [u8], req: &Request, actual: u16, region: Opti
             }
         }
     }
-    let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, tx.as_ptr(), RESP_HDR_LEN + plen as usize);
+    crate::server::reply::send(tx.as_ptr(), RESP_HDR_LEN + plen as usize);
 }

--- a/userland/capsule_driver_xhci/src/server/handlers/controller_status.rs
+++ b/userland/capsule_driver_xhci/src/server/handlers/controller_status.rs
@@ -25,7 +25,7 @@ pub fn handle(ctx: &Context, req: &Request, tx: &mut [u8]) {
     let usbcmd = usbcmd_read(ctx.driver.layout.op_base);
     let iman = iman_read(ctx.driver.layout.primary_intr_base);
     let cmd_cycle = ctx.driver.command_ring.cycle();
-    let events_total = ctx.events_drained_total;
+    let events_total = ctx.driver.event_ring.drained_total();
     let dcbaa_phys = ctx.driver.dcbaa.phys();
     let scratchpad_phys = ctx.driver.scratchpads.array_phys();
     let scratchpad_pages = ctx.driver.scratchpads.page_count();

--- a/userland/capsule_driver_xhci/src/server/handlers/controller_status.rs
+++ b/userland/capsule_driver_xhci/src/server/handlers/controller_status.rs
@@ -14,13 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 use crate::protocol::{
-    encode_response_header, write_status, Request, CONTROLLER_STATUS_PAYLOAD_LEN,
-    KERNEL_REPLY_ENDPOINT, RESP_HDR_LEN, STATUS_LEN,
+    encode_response_header, write_status, Request, CONTROLLER_STATUS_PAYLOAD_LEN, RESP_HDR_LEN,
+    STATUS_LEN,
 };
 use crate::regs::op::{usbcmd_read, usbsts_read};
 use crate::regs::runtime::iman_read;
 use crate::server::context::Context;
-use nonos_libc::mk_ipc_send;
 pub fn handle(ctx: &Context, req: &Request, tx: &mut [u8]) {
     let usbsts = usbsts_read(ctx.driver.layout.op_base);
     let usbcmd = usbcmd_read(ctx.driver.layout.op_base);
@@ -62,5 +61,5 @@ pub fn handle(ctx: &Context, req: &Request, tx: &mut [u8]) {
     tx[o..o + 8].copy_from_slice(&scratchpad_phys.to_le_bytes());
     o += 8;
     tx[o..o + 4].copy_from_slice(&allocated_slots.to_le_bytes());
-    let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, tx.as_ptr(), RESP_HDR_LEN + (payload_len as usize));
+    crate::server::reply::send(tx.as_ptr(), RESP_HDR_LEN + (payload_len as usize));
 }

--- a/userland/capsule_driver_xhci/src/server/handlers/device_descriptor.rs
+++ b/userland/capsule_driver_xhci/src/server/handlers/device_descriptor.rs
@@ -16,11 +16,10 @@
 use crate::controller::{get_device_descriptor, DEVICE_DESCRIPTOR_LEN};
 use crate::protocol::{
     encode_response_header, write_status, Request, DEVICE_DESCRIPTOR_REPLY_LEN,
-    DEVICE_DESCRIPTOR_REQUEST_LEN, E_INVAL, E_IO, KERNEL_REPLY_ENDPOINT, RESP_HDR_LEN, STATUS_LEN,
+    DEVICE_DESCRIPTOR_REQUEST_LEN, E_INVAL, E_IO, RESP_HDR_LEN, STATUS_LEN,
 };
 use crate::server::context::Context;
 use crate::server::error::reply_with_status;
-use nonos_libc::mk_ipc_send;
 pub fn handle(ctx: &mut Context, req: &Request, body: &[u8], tx: &mut [u8]) {
     if body.len() != DEVICE_DESCRIPTOR_REQUEST_LEN {
         reply_with_status(tx, req, E_INVAL);
@@ -66,5 +65,5 @@ fn reply_descriptor(tx: &mut [u8], req: &Request, out: &crate::dma::DmaRegion) {
             tx[offset + i] = core::ptr::read_volatile(out.as_mut_ptr::<u8>().add(i));
         }
     }
-    let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, tx.as_ptr(), RESP_HDR_LEN + payload_len as usize);
+    crate::server::reply::send(tx.as_ptr(), RESP_HDR_LEN + payload_len as usize);
 }

--- a/userland/capsule_driver_xhci/src/server/handlers/enable_slot.rs
+++ b/userland/capsule_driver_xhci/src/server/handlers/enable_slot.rs
@@ -15,12 +15,11 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 use crate::controller::{issue_disable_slot, issue_enable_slot};
 use crate::protocol::{
-    encode_response_header, write_status, Request, E_IO, E_NODEV, KERNEL_REPLY_ENDPOINT,
-    RESP_HDR_LEN, SLOT_ENABLE_PAYLOAD_LEN, STATUS_LEN,
+    encode_response_header, write_status, Request, E_IO, E_NODEV, RESP_HDR_LEN,
+    SLOT_ENABLE_PAYLOAD_LEN, STATUS_LEN,
 };
 use crate::server::context::Context;
 use crate::server::error::reply_with_status;
-use nonos_libc::mk_ipc_send;
 pub fn handle(ctx: &mut Context, req: &Request, tx: &mut [u8]) {
     let slot_id = match issue_enable_slot(
         ctx.driver.layout.doorbell_base,
@@ -50,5 +49,5 @@ pub fn handle(ctx: &mut Context, req: &Request, tx: &mut [u8]) {
     write_status(&mut tx[RESP_HDR_LEN..], 0);
     tx[RESP_HDR_LEN + STATUS_LEN] = slot_id;
     tx[RESP_HDR_LEN + STATUS_LEN + 1..RESP_HDR_LEN + STATUS_LEN + 4].fill(0);
-    let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, tx.as_ptr(), RESP_HDR_LEN + payload_len as usize);
+    crate::server::reply::send(tx.as_ptr(), RESP_HDR_LEN + payload_len as usize);
 }

--- a/userland/capsule_driver_xhci/src/server/handlers/interrupt_in/reply.rs
+++ b/userland/capsule_driver_xhci/src/server/handlers/interrupt_in/reply.rs
@@ -15,19 +15,18 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 use crate::protocol::{
     encode_response_header, write_status, Request, E_AGAIN, E_IO, INTERRUPT_IN_REPLY_PREFIX,
-    KERNEL_REPLY_ENDPOINT, RESP_HDR_LEN, STATUS_LEN,
+    RESP_HDR_LEN, STATUS_LEN,
 };
 use crate::server::context::Context;
 use crate::server::error::reply_with_status;
 use crate::slots::SlotResources;
-use nonos_libc::mk_ipc_send;
 pub fn reply_pending(tx: &mut [u8], req: &Request) {
     let plen = (STATUS_LEN + INTERRUPT_IN_REPLY_PREFIX) as u32;
     encode_response_header(tx, req, plen);
     write_status(&mut tx[RESP_HDR_LEN..], E_AGAIN);
     let o = RESP_HDR_LEN + STATUS_LEN;
     tx[o..o + INTERRUPT_IN_REPLY_PREFIX].fill(0);
-    let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, tx.as_ptr(), RESP_HDR_LEN + plen as usize);
+    crate::server::reply::send(tx.as_ptr(), RESP_HDR_LEN + plen as usize);
 }
 pub fn reply_report(ctx: &mut Context, req: &Request, slot: u8, tx: &mut [u8], n: u16) {
     let max_slots = ctx.driver.layout.max_slots;
@@ -54,5 +53,5 @@ fn emit_report(tx: &mut [u8], req: &Request, res: &SlotResources, n: u16) {
                 core::ptr::read_volatile(buf.as_mut_ptr::<u8>().add(i));
         }
     }
-    let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, tx.as_ptr(), RESP_HDR_LEN + plen as usize);
+    crate::server::reply::send(tx.as_ptr(), RESP_HDR_LEN + plen as usize);
 }

--- a/userland/capsule_driver_xhci/src/server/handlers/port_status.rs
+++ b/userland/capsule_driver_xhci/src/server/handlers/port_status.rs
@@ -14,12 +14,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 use crate::protocol::{
-    encode_response_header, write_status, Request, KERNEL_REPLY_ENDPOINT, MAX_PORTS_REPORTED,
-    PORT_ENTRY_BYTES, PORT_STATUS_HEADER_BYTES, RESP_HDR_LEN, STATUS_LEN,
+    encode_response_header, write_status, Request, MAX_PORTS_REPORTED, PORT_ENTRY_BYTES,
+    PORT_STATUS_HEADER_BYTES, RESP_HDR_LEN, STATUS_LEN,
 };
 use crate::regs::op::{portsc_clear_changes, portsc_read};
 use crate::server::context::Context;
-use nonos_libc::mk_ipc_send;
 pub fn handle(ctx: &Context, req: &Request, tx: &mut [u8]) {
     let max_ports = ctx.driver.layout.max_ports as usize;
     let port_count = core::cmp::min(max_ports, MAX_PORTS_REPORTED);
@@ -43,5 +42,5 @@ pub fn handle(ctx: &Context, req: &Request, tx: &mut [u8]) {
         tx[o + 4..o + 8].copy_from_slice(&portsc.to_le_bytes());
         o += PORT_ENTRY_BYTES;
     }
-    let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, tx.as_ptr(), RESP_HDR_LEN + payload_bytes);
+    crate::server::reply::send(tx.as_ptr(), RESP_HDR_LEN + payload_bytes);
 }

--- a/userland/capsule_driver_xhci/src/server/mod.rs
+++ b/userland/capsule_driver_xhci/src/server/mod.rs
@@ -17,6 +17,7 @@ pub mod context;
 mod dispatch;
 mod error;
 mod handlers;
+mod reply;
 mod runner;
 mod service_interrupts;
 pub use runner::run;

--- a/userland/capsule_driver_xhci/src/server/reply.rs
+++ b/userland/capsule_driver_xhci/src/server/reply.rs
@@ -1,0 +1,44 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Reply routing for the request currently being served. The server
+//! loop is strictly sequential: one `recv_from`, one dispatch, one
+//! reply. So the sender pid captured before dispatch is the correct
+//! destination for every send the handlers emit. A capsule caller
+//! (pid != 0) gets a correlation-matched `mk_ipc_reply` delivered to
+//! its own reply inbox; a kernel-internal caller (pid 0) keeps the
+//! legacy fixed reply endpoint it drains by request id.
+
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use nonos_libc::{mk_ipc_reply, mk_ipc_send};
+
+use crate::protocol::KERNEL_REPLY_ENDPOINT;
+
+static SENDER: AtomicU32 = AtomicU32::new(0);
+
+pub fn set_sender(pid: u32) {
+    SENDER.store(pid, Ordering::Relaxed);
+}
+
+pub fn send(tx: *const u8, len: usize) {
+    let pid = SENDER.load(Ordering::Relaxed);
+    if pid != 0 {
+        let _ = mk_ipc_reply(pid, tx, len);
+    } else {
+        let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, tx, len);
+    }
+}

--- a/userland/capsule_driver_xhci/src/server/runner.rs
+++ b/userland/capsule_driver_xhci/src/server/runner.rs
@@ -23,7 +23,7 @@ use crate::server::error::{reply_decode_failed, reply_with_status};
 use crate::server::service_interrupts::service_interrupts;
 use crate::setup::Driver;
 use alloc::vec;
-use nonos_libc::mk_ipc_recv;
+use nonos_libc::mk_ipc_recv_from;
 const TX_LEN: usize =
     RESP_HDR_LEN + STATUS_LEN + PORT_STATUS_HEADER_BYTES + MAX_PORTS_REPORTED * PORT_ENTRY_BYTES;
 pub fn run(driver: Driver) -> ! {
@@ -32,7 +32,9 @@ pub fn run(driver: Driver) -> ! {
     let mut ctx = Context::new(driver);
     loop {
         service_interrupts(&mut ctx);
-        let n = mk_ipc_recv(0, rx.as_mut_ptr(), rx.len(), 0);
+        let mut sender_pid: u32 = 0;
+        let n = mk_ipc_recv_from(0, rx.as_mut_ptr(), rx.len(), 0, &mut sender_pid);
+        crate::server::reply::set_sender(sender_pid);
         if n <= 0 {
             continue;
         }

--- a/userland/capsule_driver_xhci/src/trb/builders/setup_stage.rs
+++ b/userland/capsule_driver_xhci/src/trb/builders/setup_stage.rs
@@ -28,8 +28,8 @@ pub fn setup_stage_get_descriptor_typed(
     let value = ((desc_type as u16) << 8) | desc_index as u16;
     trb.d0 = 0x80 | (0x06 << 8) | ((value as u32) << 16);
     trb.d1 = (length as u32) << 16;
-    trb.d2 = 8 | TRT_IN_DATA;
-    trb.d3 = TRB_IDT;
+    trb.d2 = 8;
+    trb.d3 = TRB_IDT | TRT_IN_DATA;
     trb.set_type(TRB_TYPE_SETUP_STAGE);
     trb.set_cycle(cycle);
     trb

--- a/userland/capsule_input_router/src/clients/compositor.rs
+++ b/userland/capsule_input_router/src/clients/compositor.rs
@@ -19,6 +19,27 @@ use super::wire::{call, lookup_port, u32_at};
 const SERVICE: &[u8] = b"compositor";
 const MAGIC: u32 = 0x4E43_4D50;
 const OP_DISPLAY_INFO: u16 = 0x0008;
+const OP_CURSOR_UPDATE: u16 = 0x0006;
+
+pub fn cursor_update(port_slot: &mut u32, request_id: u32, x: u32, y: u32, visible: bool) -> bool {
+    if *port_slot == 0 {
+        match lookup_port(SERVICE) {
+            Some(p) => *port_slot = p,
+            None => return false,
+        }
+    }
+    let mut payload = [0u8; 16];
+    payload[0..4].copy_from_slice(&x.to_le_bytes());
+    payload[4..8].copy_from_slice(&y.to_le_bytes());
+    payload[8..12].copy_from_slice(&(visible as u32).to_le_bytes());
+    match call(*port_slot, MAGIC, OP_CURSOR_UPDATE, request_id, &payload, &mut []) {
+        Ok(status) => status == 0,
+        Err(_) => {
+            *port_slot = 0;
+            false
+        }
+    }
+}
 
 pub fn display_size(port_slot: &mut u32, request_id: u32) -> Option<(u32, u32)> {
     if *port_slot == 0 {

--- a/userland/capsule_input_router/src/route/pointer/route_pointer.rs
+++ b/userland/capsule_input_router/src/route/pointer/route_pointer.rs
@@ -16,6 +16,7 @@
 
 use nonos_libc::InputEvent;
 
+use crate::clients::compositor;
 use crate::state::Context;
 
 use super::mirror_shell_pointer::mirror_shell_pointer;
@@ -28,6 +29,8 @@ use super::topmost_target::topmost_target;
 pub fn route_pointer(ctx: &mut Context, event: &InputEvent) -> u32 {
     refresh_display(ctx);
     let (x, y) = ctx.cursor.apply(event);
+    let rid = ctx.issue_request_id();
+    let _ = compositor::cursor_update(&mut ctx.compositor_port, rid, x, y, true);
     let delivered = mirror_shell_pointer(ctx, event, x, y)
         + match topmost_target(ctx, x, y) {
             None => route_to_shell(ctx, event, x, y),

--- a/userland/capsule_input_router/src/state/cursor.rs
+++ b/userland/capsule_input_router/src/state/cursor.rs
@@ -16,6 +16,8 @@
 
 use nonos_libc::{InputEvent, INPUT_KIND_POINTER_ABS, INPUT_KIND_POINTER_REL, INPUT_KIND_TOUCH};
 
+const ABS_RANGE_MAX: i64 = 0x7FFF;
+
 pub struct CursorState {
     pub x: i32,
     pub y: i32,
@@ -43,8 +45,8 @@ impl CursorState {
             self.y = self.y.saturating_add(ev.delta_y);
         }
         if ev.kind == INPUT_KIND_POINTER_ABS || ev.kind == INPUT_KIND_TOUCH {
-            self.x = ev.x;
-            self.y = ev.y;
+            self.x = (ev.x as i64 * self.max_x as i64 / ABS_RANGE_MAX) as i32;
+            self.y = (ev.y as i64 * self.max_y as i64 / ABS_RANGE_MAX) as i32;
         }
         self.clamp();
         (self.x as u32, self.y as u32)

--- a/userland/compositor/src/frame_pacer/composite.rs
+++ b/userland/compositor/src/frame_pacer/composite.rs
@@ -58,4 +58,16 @@ pub fn paint(ctx: &mut Context, rect: Rect) {
     for &handle in dropped.iter().take(n_dropped) {
         let _ = ctx.attach.forget(handle);
     }
+    let cursor = ctx.cursor.current();
+    if cursor.visible {
+        super::cursor::blit(
+            ctx.backing_va,
+            ctx.stride,
+            ctx.width,
+            ctx.height,
+            cursor.x,
+            cursor.y,
+            rect,
+        );
+    }
 }

--- a/userland/compositor/src/frame_pacer/cursor.rs
+++ b/userland/compositor/src/frame_pacer/cursor.rs
@@ -1,0 +1,63 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::state::damage::Rect;
+
+const BLACK: u32 = 0xFF00_0000;
+const WHITE: u32 = 0xFFFF_FFFF;
+
+const ARROW: [&[u8]; 16] = [
+    b"#",
+    b"##",
+    b"#.#",
+    b"#..#",
+    b"#...#",
+    b"#....#",
+    b"#.....#",
+    b"#......#",
+    b"#.......#",
+    b"#........#",
+    b"#....#####",
+    b"#..#..#",
+    b"#.# #..#",
+    b"##  #..#",
+    b"#    #..#",
+    b"     ###",
+];
+
+pub fn blit(base_va: u64, stride: u32, sw: u32, sh: u32, cx: u32, cy: u32, clip: Rect) {
+    let clip_x1 = clip.x + clip.width;
+    let clip_y1 = clip.y + clip.height;
+    for (row, line) in ARROW.iter().enumerate() {
+        let py = cy + row as u32;
+        if py >= sh || py < clip.y || py >= clip_y1 {
+            continue;
+        }
+        for (col, &cell) in line.iter().enumerate() {
+            let argb = match cell {
+                b'.' => WHITE,
+                b'#' => BLACK,
+                _ => continue,
+            };
+            let px = cx + col as u32;
+            if px >= sw || px < clip.x || px >= clip_x1 {
+                continue;
+            }
+            let va = base_va as usize + py as usize * stride as usize + px as usize * 4;
+            unsafe { core::ptr::write_volatile(va as *mut u32, argb) };
+        }
+    }
+}

--- a/userland/compositor/src/frame_pacer/mod.rs
+++ b/userland/compositor/src/frame_pacer/mod.rs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 pub mod composite;
+pub mod cursor;
 pub mod tick;
 pub mod vsync;
 

--- a/userland/compositor/src/state/cursor.rs
+++ b/userland/compositor/src/state/cursor.rs
@@ -40,4 +40,8 @@ impl CursorTracker {
         self.state = CursorState { x, y, visible };
         prev
     }
+
+    pub fn current(&self) -> CursorState {
+        self.state
+    }
 }


### PR DESCRIPTION
This pull request introduces support for USB HID tablets in the USB HID driver capsule, improves MMIO mapping safety for devices with shared MSI-X tables, and makes several enhancements to the USB HID and xHCI driver infrastructure. The most significant changes include the addition of tablet support, safer MMIO region mapping, and improvements to endpoint configuration and event tracking in the xHCI driver.

**USB HID Tablet Support:**

* Added a new `Tablet` device type to the USB HID driver, including detection, report parsing, and event posting for absolute pointer and button events. This includes the new `tablet.rs` implementation, integration into the device state, and support for handling tablet reports in the orchestrator. [[1]](diffhunk://#diff-5c1e195ad7ade46f947bf17a40db5798562c74188e2e64b77c65206f311d1904R30) [[2]](diffhunk://#diff-d8c11412f200989b53aad1ca8b45c70746fe649d8df7a2be2dabcedbbbc29d20R26-R30) [[3]](diffhunk://#diff-126c495f69deab11e1875e79dad06e2f075d86f5601c336b020dfff12f3b58b8L17-R22) [[4]](diffhunk://#diff-126c495f69deab11e1875e79dad06e2f075d86f5601c336b020dfff12f3b58b8R33) [[5]](diffhunk://#diff-a970209fb2dec14fb3ee328425ba30a7ec9900515fd389f724288bfab2c54ef5R41-R43) [[6]](diffhunk://#diff-1fd5e04b6ecf55ee9679ebb5de1d1091d82f483f2c97efb82705bda10a33c8bcL33-R43) [[7]](diffhunk://#diff-3df41765c8e11c45696c09b7b97fc16e37dcab9912d2edce6504d61b559268b3L19-R19) [[8]](diffhunk://#diff-3df41765c8e11c45696c09b7b97fc16e37dcab9912d2edce6504d61b559268b3R30-R34) [[9]](diffhunk://#diff-20093c78745792252178997a83f06eaf3c82a87d1f25c9a46aca0012794d2514R33-R39)

* Improved HID descriptor parsing to support non-boot subclass HID devices (e.g., tablets), and added a new `Tablet` variant to the `HidKind` enum. [[1]](diffhunk://#diff-1fd5e04b6ecf55ee9679ebb5de1d1091d82f483f2c97efb82705bda10a33c8bcL33-R43) [[2]](diffhunk://#diff-5c1e195ad7ade46f947bf17a40db5798562c74188e2e64b77c65206f311d1904R30) [[3]](diffhunk://#diff-d8c11412f200989b53aad1ca8b45c70746fe649d8df7a2be2dabcedbbbc29d20R26-R30)

**MMIO Mapping Safety:**

* Replaced hard rejection of MMIO mappings overlapping MSI-X table/PBA regions with a clamping approach that only exposes safe regions, refusing requests that start inside protected regions. This prevents accidental exposure of sensitive device regions while allowing safe access. [[1]](diffhunk://#diff-2c20589ebb632c823461a69218945e6b32097ccad18a37af17d1f0851768cf6fL87-R100) [[2]](diffhunk://#diff-2c20589ebb632c823461a69218945e6b32097ccad18a37af17d1f0851768cf6fL112-R118) [[3]](diffhunk://#diff-58aaeb1a6d94bac9c0b502cddcff5fcb7f83b84442f355026ade9c0608fc17faR22-R50)

**xHCI Driver Improvements:**

* Enhanced endpoint configuration to pass device speed and root port, and improved the format of endpoint context setup. Also, event ring tracking now maintains a running total of drained events, with a new accessor. [[1]](diffhunk://#diff-08bc91208742b12f75b14c59d0899a93c16361eeae66d38ea7efe7368385ef51R20-R21) [[2]](diffhunk://#diff-08bc91208742b12f75b14c59d0899a93c16361eeae66d38ea7efe7368385ef51R33-R41) [[3]](diffhunk://#diff-08bc91208742b12f75b14c59d0899a93c16361eeae66d38ea7efe7368385ef51L51-R57) [[4]](diffhunk://#diff-38214ef77a3ab4cbc722e773f5dbc1e621f100416a0fd04fed4a915a1e4695c5R23) [[5]](diffhunk://#diff-95a92bf391262559b3f77e6e97dcc29b7daea5e36d5286806905bd1c984e6cf0R1-R21)

**Process Teardown and Capability Updates:**

* Refined process teardown to ensure address space release occurs in the correct context and updated the USB HID driver capsule to require the Debug capability. [[1]](diffhunk://#diff-1d81ecf23da9f2535895ef252a0709b060e0365d6ba63c15d908c0907682fca6L12-R17) [[2]](diffhunk://#diff-a81dbf960527c8af2835d93e5cec8aad7bf3db171e8017baa4156d31d0288b7dL41-L48) [[3]](diffhunk://#diff-5c577192afcb05b518f5d4ddc8c07b3911aecea96251f0034f97b6ef97c50b55L52-R53) [[4]](diffhunk://#diff-96255127a2c355ce0da30597dcbf87fb0249cb1f5c88d22dafaafd199fa5175aL15-R15)

**Build System:**

* Added a new Makefile target for USB HID boot testing (`nonos-mk-boot-usb-hid`). [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L32-R32) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1308-R1310)