### PR TITLE
fix: working keyboard under macOS hvf (PS/2 input path)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1242,6 +1242,16 @@ nonos-mk-run: nonos-mk-desktop-gui-prod nonos-mk-esp $(QEMU_BLK_IMG) $(QEMU_OVMF
 		$(QEMU_BLK) $(QEMU_GPU) $(QEMU_NET) $(QEMU_USB) $(QEMU_RNG) \
 		-serial mon:stdio -vga none -no-reboot
 
+nonos-mk-run-wizard: nonos-mk-setup-wizard-esp $(QEMU_BLK_IMG) $(QEMU_OVMF_VARS_RW)
+	@echo "Booting NONOS (first-boot setup wizard) in QEMU..."
+	@echo "  Drive it with the host keyboard; Quit: Ctrl+A then X"
+	@$(QEMU) -m $(QEMU_MEM) -accel hvf -cpu host,+rdrand,+rdseed -smp 1 -machine q35 \
+		-drive "format=raw,file=fat:rw:$(TARGET_DIR)/esp-setup-wizard" \
+		-drive if=pflash,format=raw,unit=0,readonly=on,file="$(OVMF)" \
+		-drive if=pflash,format=raw,unit=1,file="$(QEMU_OVMF_VARS_RW)" \
+		$(QEMU_BLK) $(QEMU_GPU) $(QEMU_NET) $(QEMU_USB) $(QEMU_RNG) \
+		-serial mon:stdio -vga none -no-reboot
+
 nonos-mk-terminal-only-run: nonos-mk-terminal-only-prod nonos-mk-esp $(QEMU_OVMF_VARS_RW)
 	@echo "Booting NONOS terminal-only in QEMU..."
 	@echo "  Quit: Ctrl+A then X"
@@ -1455,6 +1465,7 @@ help:
 	@echo
 	@echo "Run:"
 	@echo "  make nonos-mk-run             QEMU + OVMF (SSH:2222, HTTP:8080)"
+	@echo "  make nonos-mk-run-wizard      QEMU + OVMF, first-boot setup wizard"
 	@echo "  make nonos-mk-run-serial      headless serial-only"
 	@echo "  make nonos-mk-debug           QEMU + GDB on :1234"
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,10 @@ QEMU_OVMF_VARS_RW := $(TARGET_DIR)/qemu-OVMF_VARS.fd
 QEMU_NET := -device virtio-net-pci,netdev=net0 -netdev user,id=net0,hostfwd=tcp::$(QEMU_HOST_SSH_PORT)-:22,hostfwd=tcp::$(QEMU_HOST_HTTP_PORT)-:80
 QEMU_BLK := -drive "file=$(QEMU_BLK_IMG),if=none,id=vd0,format=raw" -device virtio-blk-pci,drive=vd0
 QEMU_GPU := -device virtio-vga,disable-modern=on,vectors=0,xres=1024,yres=768
-QEMU_USB := -device qemu-xhci,id=xhci -device usb-kbd,bus=xhci.0 -device usb-mouse,bus=xhci.0
+# Keyboard/mouse via the q35 i8042 (PS/2). USB HID interrupt-IN transfers
+# are not serviced under macOS hvf, so usb-kbd/usb-mouse never deliver input
+# there; the xHCI controller stays for the USB stack/storage paths.
+QEMU_USB := -device qemu-xhci,id=xhci
 QEMU_RNG := -device virtio-rng-pci
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")

--- a/userland/capsule_driver_ps2_input/src/server/pump.rs
+++ b/userland/capsule_driver_ps2_input/src/server/pump.rs
@@ -25,17 +25,16 @@ pub fn pump(ctx: &mut Context, prev_buttons: &mut u8) {
     let kbd = poll_seq(ctx.driver.irq_grant_id);
     let aux = poll_seq(ctx.driver.aux_irq_grant_id);
     let fired = kbd != ctx.last_kbd_seq || aux != ctx.last_aux_seq;
-    let unbound = ctx.driver.irq_grant_id == 0 && ctx.driver.aux_irq_grant_id == 0;
-    if fired || unbound {
-        drain(
-            ctx.driver.pio_grant_id,
-            &mut ctx.drainer,
-            &mut ctx.ring,
-            &mut ctx.mouse,
-            &mut ctx.mouse_ring,
-        );
-        ctx.last_kbd_seq = poll_seq(ctx.driver.irq_grant_id);
-        ctx.last_aux_seq = poll_seq(ctx.driver.aux_irq_grant_id);
+    drain(
+        ctx.driver.pio_grant_id,
+        &mut ctx.drainer,
+        &mut ctx.ring,
+        &mut ctx.mouse,
+        &mut ctx.mouse_ring,
+    );
+    ctx.last_kbd_seq = kbd;
+    ctx.last_aux_seq = aux;
+    if fired {
         let _ = mk_irq_ack(ctx.driver.irq_grant_id);
         let _ = mk_irq_ack(ctx.driver.aux_irq_grant_id);
     }


### PR DESCRIPTION
## Problem

The keyboard does not work in `make nonos-mk-run` / the setup wizard on macOS (hvf) — no keys, no Enter.

## Root cause (two independent bugs, both confirmed empirically)

1. **usb-kbd is dead under hvf.** The run targets routed the keyboard through `usb-kbd → xHCI interrupt-IN`. The device enumerates and *binds* fine (control transfers work), but **interrupt-IN transfers deliver zero HID reports under Apple's hypervisor**. Instrumented probe under hvf: keyboard bound, 18 QMP-injected keystrokes → **0** driver reports → **0** kernel input-ring posts. Same mechanism that disables the usb-tablet pointer under hvf.
2. **PS/2 pump starvation.** The `ps2_kbd` pump only drained the i8042 when an IRQ-seq advanced; hvf doesn't deliver IRQ1, so scancodes sat unread forever.

## Fix

- `fix(driver-ps2)`: poll-drain the i8042 on every pump tick; ack the IRQ only when it actually fired, so the IRQ-driven path is unchanged where interrupts arrive (KVM/real HW) while a missing IRQ no longer starves input (hvf). Reading port 0x60 during the drain de-asserts the i8042 IRQ, so no EOI is needed on hvf.
- `build(qemu)`: switch `QEMU_USB` to PS/2 (`-device qemu-xhci,id=xhci`; drop `usb-kbd`/`usb-mouse`) so host keystrokes route to the q35 i8042. The xHCI controller stays for the USB stack/storage paths.
- `build`: add `make nonos-mk-run-wizard` to boot the first-boot wizard with `nonos-mk-run`'s QEMU config (leaving `nonos-mk-run` untouched).

## Verification

- PS/2-only probe under hvf: 18 injected keys → **36** kernel posts (18 KEY_DOWN + 18 KEY_UP).
- **End-to-end, pixel-proven** under hvf via `nonos-mk-run-wizard` config: 5× `j` moved the wizard language selection **English → Portuguese** (QMP screendump before/after).

## Caveats

- **hvf-targeted.** `usb-kbd`/`usb-tablet` remain non-functional under hvf by design of this change; they need KVM or a real xHCI interrupt-IN servicing fix.
- **KVM unverified.** The fix is designed to preserve KVM's IRQ-driven path, but I could not test on a KVM host (dev1 lacks `/dev/kvm` access). Reasoned-safe, not measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)