### PR TITLE
Fix/capsule integrity fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ input-probe-inject = []
 # Boot smoketests. Each one drives a real round trip on the boot
 # serial and emits PASS/FAIL markers consumed by the matching
 # `tests/boot/*.sh` harness.
-nonos-ramfs-smoketest             = ["nonos-capsule-ramfs", "nonos-user-entry-proof"]
+nonos-ramfs-smoketest             = ["nonos-capsule-ramfs", "nonos-capsule-entropy", "nonos-capsule-crypto", "nonos-user-entry-proof"]
 nonos-keyring-smoketest           = ["nonos-capsule-keyring", "nonos-user-entry-proof"]
 nonos-entropy-smoketest           = ["nonos-capsule-entropy", "nonos-user-entry-proof"]
 nonos-crypto-hash-smoketest       = ["nonos-capsule-crypto", "nonos-user-entry-proof"]

--- a/Makefile
+++ b/Makefile
@@ -580,6 +580,7 @@ nonos-mk-driver-virtio-rng-test: $(proof-io_ARTIFACTS) $(driver-virtio-rng_ARTIF
 		--no-default-features --features microkernel-driver-virtio-rng-smoketest
 
 nonos-mk-ramfs-test: $(proof-io_ARTIFACTS) $(ramfs_BIN) \
+		$(entropy_ARTIFACTS) $(crypto_ARTIFACTS) \
 		nonos-mk-check-deps nonos-mk-ensure-signing-key
 	@echo "Building kernel (ramfs smoketest)..."
 	@$(SDK_FLAGS) NONOS_SIGNING_KEY=$(KERNEL_SIGNING_KEY) \

--- a/src/process/scheduler/selection/select.rs
+++ b/src/process/scheduler/selection/select.rs
@@ -20,6 +20,9 @@ use core::sync::atomic::{AtomicU32, Ordering};
 
 pub static LAST_SCHEDULED_PID: AtomicU32 = AtomicU32::new(0);
 
+static LAST_PER_BAND: [AtomicU32; 5] =
+    [AtomicU32::new(0), AtomicU32::new(0), AtomicU32::new(0), AtomicU32::new(0), AtomicU32::new(0)];
+
 pub fn select_next_process() -> Option<u32> {
     use crate::process::nonos_core::CURRENT_PID;
     let current = CURRENT_PID.load(Ordering::Relaxed);
@@ -65,10 +68,14 @@ pub fn select_next_process() -> Option<u32> {
             crate::sys::serial::traceln(b"]");
         }
     }
-    for prio in
+    for (idx, prio) in
         [Priority::RealTime, Priority::High, Priority::Normal, Priority::Low, Priority::Idle]
+            .into_iter()
+            .enumerate()
     {
-        if let Some(pid) = select_by_priority(&runnable, last, current, prio) {
+        let band_last = LAST_PER_BAND[idx].load(Ordering::Relaxed);
+        if let Some(pid) = select_by_priority(&runnable, band_last, current, prio) {
+            LAST_PER_BAND[idx].store(pid, Ordering::Relaxed);
             LAST_SCHEDULED_PID.store(pid, Ordering::Relaxed);
             {
                 static PICKED_SHOWN: AtomicU32 = AtomicU32::new(0);

--- a/src/security/entropy_capsule/client/get_random.rs
+++ b/src/security/entropy_capsule/client/get_random.rs
@@ -14,17 +14,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use super::super::capability::gate_read;
 use super::super::error::EntropyCapsuleError;
 use super::super::protocol::{encode_request, MAX_RANDOM_BYTES, OP_GET_RANDOM};
 use super::seq::next_request_id;
 use super::transport::round_trip;
 
 // Fill `out` with random bytes from the entropy capsule. Returns the
-// count written on success. Cap-gated by `CAP_ENTROPY`; over-sized
-// requests are rejected without round-tripping.
+// count written on success. Authorization is the caller's CAP_CRYPTO at
+// the CryptoRandom syscall gate; over-sized requests are rejected
+// without round-tripping.
 pub fn get_random(out: &mut [u8]) -> Result<usize, EntropyCapsuleError> {
-    let _caller = gate_read()?;
     if out.len() > MAX_RANDOM_BYTES as usize {
         return Err(EntropyCapsuleError::OversizedRequest);
     }

--- a/src/userspace/init/entry.rs
+++ b/src/userspace/init/entry.rs
@@ -21,8 +21,8 @@ pub fn run_init() -> ! {
     boot_log::ok("INIT", "Starting");
     run_user_entry_proof();
     spawn_plan::spawn_ramfs();
-    spawn_plan::run_ramfs_smoketest();
     spawn_plan::spawn_core_after_ramfs();
+    spawn_plan::run_ramfs_smoketest();
     spawn_plan::spawn_drivers();
     spawn_plan::spawn_vfs();
     spawn_plan::spawn_network();

--- a/userland/capsule_attest/src/server/runner.rs
+++ b/userland/capsule_attest/src/server/runner.rs
@@ -16,7 +16,7 @@
 
 use alloc::vec;
 
-use nonos_libc::{mk_ipc_recv, mk_ipc_send, mk_yield};
+use nonos_libc::{mk_ipc_recv_from, mk_ipc_reply, mk_yield};
 
 use super::handlers::route;
 use crate::protocol::IPC_PAYLOAD_MAX;
@@ -28,19 +28,21 @@ pub fn run() -> ! {
     let mut in_buf = vec![0u8; IPC_PAYLOAD_MAX];
     let mut out_buf = vec![0u8; IPC_PAYLOAD_MAX];
     loop {
-        let received = mk_ipc_recv(
+        let mut sender_pid = 0u32;
+        let received = mk_ipc_recv_from(
             SERVICE_PORT,
             in_buf.as_mut_ptr(),
             in_buf.len(),
             RECV_TIMEOUT_MS,
+            &mut sender_pid,
         );
-        if received <= 0 {
+        if received <= 0 || sender_pid == 0 {
             mk_yield();
             continue;
         }
         let n = route(&in_buf[..received as usize], &mut out_buf);
         if n > 0 {
-            let _ = mk_ipc_send(SERVICE_PORT, out_buf.as_ptr(), n);
+            let _ = mk_ipc_reply(sender_pid, out_buf.as_ptr(), n);
         }
     }
 }

--- a/userland/capsule_boot_splash/src/main.rs
+++ b/userland/capsule_boot_splash/src/main.rs
@@ -51,18 +51,21 @@ fn run() -> i32 {
         return 6;
     }
     let _ = scene::damage(comp, 4, w, h);
-    let router = proto::lookup(b"input_router");
-    if let Some(rp) = router {
-        let _ = input::subscribe(rp, 10);
-        let _ = input::grab(rp, 11);
-    }
-    interact(comp, base, w, h, stride, &att, badge);
-    if let Some(rp) = router {
-        let _ = input::release(rp, 12);
-    }
+    grabbed_interact(comp, base, w, h, stride, &att, badge);
     let _ = scene::remove(comp, 5);
     let _ = mk_surface_release(handle);
     0
+}
+
+fn grabbed_interact(comp: u32, base: u64, w: u32, h: u32, stride: u32, att: &AttestStatus, badge: Option<bool>) {
+    let router = match proto::lookup(b"input_router") {
+        Some(rp) => rp,
+        None => return interact(comp, base, w, h, stride, att, badge),
+    };
+    let _ = input::subscribe(router, 10);
+    let _ = input::grab(router, 11);
+    interact(comp, base, w, h, stride, att, badge);
+    let _ = input::release(router, 12);
 }
 
 fn wait_compositor() -> Option<u32> {

--- a/userland/capsule_clipboard/src/server/runner.rs
+++ b/userland/capsule_clipboard/src/server/runner.rs
@@ -15,7 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use alloc::vec;
-use nonos_libc::{mk_ipc_recv, mk_ipc_send, mk_time_millis, mk_yield};
+use nonos_libc::{mk_ipc_recv_from, mk_ipc_reply, mk_time_millis, mk_yield};
 
 use super::handlers::route;
 use crate::protocol::{DEFAULT_IDLE_TIMEOUT_MS, IPC_PAYLOAD_MAX, MAX_DEPTH, MAX_TOTAL_BYTES};
@@ -31,13 +31,15 @@ pub fn run() -> ! {
     let mut out_buf = vec![0u8; IPC_PAYLOAD_MAX];
     loop {
         clipboard.expire_if_idle(read_time());
-        let received = mk_ipc_recv(
+        let mut sender_pid = 0u32;
+        let received = mk_ipc_recv_from(
             SERVICE_PORT,
             in_buf.as_mut_ptr(),
             in_buf.len(),
             RECV_TIMEOUT_MS,
+            &mut sender_pid,
         );
-        if received <= 0 {
+        if received <= 0 || sender_pid == 0 {
             mk_yield();
             continue;
         }
@@ -45,7 +47,7 @@ pub fn run() -> ! {
         let payload = &in_buf[..received as usize];
         let n = route(&mut clipboard, payload, &mut out_buf, now);
         if n > 0 {
-            let _ = mk_ipc_send(SERVICE_PORT, out_buf.as_ptr(), n);
+            let _ = mk_ipc_reply(sender_pid, out_buf.as_ptr(), n);
         }
     }
 }

--- a/userland/capsule_crypto/Cargo.lock
+++ b/userland/capsule_crypto/Cargo.lock
@@ -564,6 +564,7 @@ checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
  "rand_core",
+ "zeroize",
 ]
 
 [[package]]
@@ -571,3 +572,17 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/userland/capsule_crypto/Cargo.toml
+++ b/userland/capsule_crypto/Cargo.toml
@@ -29,7 +29,7 @@ aead   = { version = "0.5", default-features = false, features = ["alloc"] }
 chacha20poly1305 = { version = "0.10", default-features = false, features = ["alloc"] }
 aes-gcm          = { version = "0.10", default-features = false, features = ["alloc", "aes"] }
 ed25519-dalek    = { version = "2.1.1", default-features = false, features = ["alloc", "zeroize"] }
-x25519-dalek     = { version = "2", default-features = false, features = ["static_secrets"] }
+x25519-dalek     = { version = "2", default-features = false, features = ["static_secrets", "zeroize"] }
 
 [profile.release]
 panic    = "abort"

--- a/userland/capsule_crypto/src/server/handlers/aead_frame/mod.rs
+++ b/userland/capsule_crypto/src/server/handlers/aead_frame/mod.rs
@@ -19,5 +19,5 @@ mod constants;
 mod parse;
 mod types;
 
-pub(crate) use parse::{parse_open, parse_seal};
+pub(crate) use parse::{nonce_is_degenerate, parse_open, parse_seal};
 pub(crate) use types::FrameError;

--- a/userland/capsule_crypto/src/server/handlers/aead_frame/parse.rs
+++ b/userland/capsule_crypto/src/server/handlers/aead_frame/parse.rs
@@ -26,6 +26,14 @@ pub(crate) fn parse_seal(payload: &[u8]) -> Result<SealFrame<'_>, FrameError> {
     Ok(SealFrame { key: parts.key, nonce: parts.nonce, aad: parts.aad, plaintext: parts.body })
 }
 
+pub(crate) fn nonce_is_degenerate(nonce: &[u8]) -> bool {
+    let mut acc: u8 = 0;
+    for byte in nonce {
+        acc |= *byte;
+    }
+    acc == 0
+}
+
 pub(crate) fn parse_open(payload: &[u8]) -> Result<OpenFrame<'_>, FrameError> {
     let parts = parse_common(payload)?;
     if parts.body.len() < TAG_LEN {

--- a/userland/capsule_crypto/src/server/handlers/aes256_gcm_seal.rs
+++ b/userland/capsule_crypto/src/server/handlers/aes256_gcm_seal.rs
@@ -19,7 +19,7 @@ use alloc::vec::Vec;
 use aes_gcm::aead::{Aead, KeyInit, Payload};
 use aes_gcm::{Aes256Gcm, Key, Nonce};
 
-use super::aead_frame::{parse_seal, FrameError};
+use super::aead_frame::{nonce_is_degenerate, parse_seal, FrameError};
 use crate::protocol::{encode_response, Request, EINVAL, EIO, EMSGSIZE, OP_AES256_GCM_SEAL};
 
 pub fn aes256_gcm_seal(req: Request<'_>) -> Vec<u8> {
@@ -38,6 +38,9 @@ pub fn aes256_gcm_seal(req: Request<'_>) -> Vec<u8> {
             );
         }
     };
+    if nonce_is_degenerate(frame.nonce) {
+        return encode_response(OP_AES256_GCM_SEAL, req.flags, req.request_id, EINVAL, &[]);
+    }
     let key = Key::<Aes256Gcm>::from_slice(frame.key);
     let nonce = Nonce::<aes_gcm::aes::cipher::consts::U12>::from_slice(frame.nonce);
     let cipher = Aes256Gcm::new(key);

--- a/userland/capsule_crypto/src/server/handlers/chacha20_poly1305_seal.rs
+++ b/userland/capsule_crypto/src/server/handlers/chacha20_poly1305_seal.rs
@@ -19,7 +19,7 @@ use alloc::vec::Vec;
 use chacha20poly1305::aead::{Aead, KeyInit, Payload};
 use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 
-use super::aead_frame::{parse_seal, FrameError};
+use super::aead_frame::{nonce_is_degenerate, parse_seal, FrameError};
 use crate::protocol::{encode_response, Request, EINVAL, EIO, EMSGSIZE, OP_CHACHA20_POLY1305_SEAL};
 
 pub fn chacha20_poly1305_seal(req: Request<'_>) -> Vec<u8> {
@@ -44,6 +44,15 @@ pub fn chacha20_poly1305_seal(req: Request<'_>) -> Vec<u8> {
             );
         }
     };
+    if nonce_is_degenerate(frame.nonce) {
+        return encode_response(
+            OP_CHACHA20_POLY1305_SEAL,
+            req.flags,
+            req.request_id,
+            EINVAL,
+            &[],
+        );
+    }
     let key = Key::from_slice(frame.key);
     let nonce = Nonce::from_slice(frame.nonce);
     let cipher = ChaCha20Poly1305::new(key);

--- a/userland/capsule_crypto/src/server/handlers/x25519_shared.rs
+++ b/userland/capsule_crypto/src/server/handlers/x25519_shared.rs
@@ -18,6 +18,7 @@ use alloc::vec::Vec;
 use x25519_dalek::{PublicKey, StaticSecret};
 
 use crate::protocol::{encode_response, Request, EINVAL, OP_X25519_SHARED, X25519_KEY_BYTES};
+use crate::server::wipe::wipe;
 
 pub fn x25519_shared(req: Request<'_>) -> Vec<u8> {
     if req.payload.len() != X25519_KEY_BYTES * 2 {
@@ -30,5 +31,7 @@ pub fn x25519_shared(req: Request<'_>) -> Vec<u8> {
     let secret = StaticSecret::from(private);
     let peer = PublicKey::from(public);
     let shared = secret.diffie_hellman(&peer);
-    encode_response(OP_X25519_SHARED, req.flags, req.request_id, 0, shared.as_bytes())
+    let resp = encode_response(OP_X25519_SHARED, req.flags, req.request_id, 0, shared.as_bytes());
+    wipe(&mut private);
+    resp
 }

--- a/userland/capsule_crypto/src/server/runner.rs
+++ b/userland/capsule_crypto/src/server/runner.rs
@@ -19,6 +19,7 @@ use alloc::vec;
 use nonos_libc::{mk_ipc_recv, mk_ipc_send};
 
 use super::dispatch::dispatch;
+use super::wipe::wipe;
 use crate::protocol::{
     decode_request, encode_response, EINVAL, HDR_LEN, KERNEL_REPLY_ENDPOINT, MAX_PAYLOAD_BYTES,
 };
@@ -38,5 +39,6 @@ pub fn run() -> ! {
             Err(_) => encode_response(0, 0, 0, EINVAL, &[]),
         };
         let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, resp.as_ptr(), resp.len());
+        wipe(&mut buf[..n]);
     }
 }

--- a/userland/capsule_crypto/src/server/wipe.rs
+++ b/userland/capsule_crypto/src/server/wipe.rs
@@ -14,9 +14,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-mod dispatch;
-mod handlers;
-mod runner;
-mod wipe;
+use core::sync::atomic::{compiler_fence, Ordering};
 
-pub use runner::run;
+pub(super) fn wipe(buf: &mut [u8]) {
+    for byte in buf.iter_mut() {
+        unsafe { core::ptr::write_volatile(byte, 0) };
+    }
+    compiler_fence(Ordering::SeqCst);
+}

--- a/userland/capsule_driver_virtio_gpu/src/server/handlers/attach_backing.rs
+++ b/userland/capsule_driver_virtio_gpu/src/server/handlers/attach_backing.rs
@@ -46,6 +46,10 @@ pub fn handle(driver: &Driver, sender_pid: u32, req: &Request, body: &[u8], tx: 
         respond::status(sender_pid, req, E_BUSY, tx);
         return;
     }
+    if !owns_backing(driver, backing_addr, backing_len) {
+        respond::status(sender_pid, req, E_INVAL, tx);
+        return;
+    }
     let fence_id = driver.fences.issue();
     if cmd::attach_backing(
         &driver.control_queue,
@@ -64,4 +68,16 @@ pub fn handle(driver: &Driver, sender_pid: u32, req: &Request, body: &[u8], tx: 
         r.backing_len = backing_len as u32;
     });
     respond::status(sender_pid, req, 0, tx);
+}
+fn owns_backing(driver: &Driver, addr: u64, len: u64) -> bool {
+    let Some(primary) = driver.primary.as_ref() else {
+        return false;
+    };
+    let Some(req_end) = addr.checked_add(len) else {
+        return false;
+    };
+    let Some(owned_end) = primary.backing_addr.checked_add(primary.backing_len) else {
+        return false;
+    };
+    addr >= primary.backing_addr && req_end <= owned_end
 }

--- a/userland/capsule_driver_virtio_gpu/src/setup/primary_surface/create.rs
+++ b/userland/capsule_driver_virtio_gpu/src/setup/primary_surface/create.rs
@@ -67,5 +67,7 @@ pub fn create(
         width: scanout.width,
         height: scanout.height,
         stride: geom.stride,
+        backing_addr: dma.device_addr,
+        backing_len: dma.length,
     }))
 }

--- a/userland/capsule_driver_virtio_gpu/src/setup/primary_surface/state.rs
+++ b/userland/capsule_driver_virtio_gpu/src/setup/primary_surface/state.rs
@@ -20,4 +20,6 @@ pub struct Primary {
     pub width: u32,
     pub height: u32,
     pub stride: u32,
+    pub backing_addr: u64,
+    pub backing_len: u64,
 }

--- a/userland/capsule_entropy/src/pool/fill.rs
+++ b/userland/capsule_entropy/src/pool/fill.rs
@@ -15,11 +15,28 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 use core::sync::atomic::Ordering;
 
-use nonos_libc::crypto_random;
-
 use crate::protocol::MAX_RANDOM_BYTES;
 
 use super::types::Pool;
+
+#[target_feature(enable = "rdrand")]
+unsafe fn rdrand_fill(out: &mut [u8]) -> bool {
+    let mut filled = 0;
+    while filled < out.len() {
+        let mut word: u64 = 0;
+        let mut tries = 0;
+        while core::arch::x86_64::_rdrand64_step(&mut word) != 1 {
+            tries += 1;
+            if tries >= 32 {
+                return false;
+            }
+        }
+        let take = core::cmp::min(8, out.len() - filled);
+        out[filled..filled + take].copy_from_slice(&word.to_le_bytes()[..take]);
+        filled += take;
+    }
+    true
+}
 
 impl Pool {
     pub fn fill(&self, out: &mut [u8]) -> i64 {
@@ -28,13 +45,12 @@ impl Pool {
         if want == 0 {
             return 0;
         }
-        let n = crypto_random(out.as_mut_ptr(), want);
         self.requests.fetch_add(1, Ordering::Relaxed);
-        if n < 0 {
+        if !unsafe { rdrand_fill(&mut out[..want]) } {
             self.source_failures.fetch_add(1, Ordering::Relaxed);
-            return n;
+            return -5;
         }
-        self.bytes_served.fetch_add(n as u64, Ordering::Relaxed);
-        n
+        self.bytes_served.fetch_add(want as u64, Ordering::Relaxed);
+        want as i64
     }
 }

--- a/userland/capsule_file_manager/src/fm/refresh.rs
+++ b/userland/capsule_file_manager/src/fm/refresh.rs
@@ -25,15 +25,6 @@ pub fn refresh(state: &mut State) {
     if state.owner_pid == 0 {
         state.owner_pid = lookup_service(b"app.file_manager").map(|peer| peer.pid).unwrap_or(0);
     }
-    if state.owner_pid == 0 {
-        if state.entries.is_empty() {
-            state.cursor = 0;
-            state.status = b"vfs unavailable";
-        } else {
-            state.status = b"refresh deferred";
-        }
-        return;
-    }
     match list_paths(state.owner_pid, state.prefix.as_bytes()) {
         Ok(paths) => {
             state.entries = build_entries(state.prefix.as_str(), &paths);

--- a/userland/capsule_input_router/src/protocol/errno.rs
+++ b/userland/capsule_input_router/src/protocol/errno.rs
@@ -15,4 +15,5 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 pub const E_INVAL: i32 = -22;
+pub const E_ACCES: i32 = -13;
 pub const E_BAD_OP: i32 = -38;

--- a/userland/capsule_input_router/src/protocol/mod.rs
+++ b/userland/capsule_input_router/src/protocol/mod.rs
@@ -26,7 +26,7 @@ mod read_u32;
 pub use decode::parse;
 pub use delivery::{encode_delivery, DELIVERY_LEN};
 pub use encode::{response_header, write_status};
-pub use errno::{E_BAD_OP, E_INVAL};
+pub use errno::{E_ACCES, E_BAD_OP, E_INVAL};
 pub use header::{Request, HDR_LEN, MAGIC, VERSION};
 pub use limits::{IPC_PAYLOAD_MAX, STATUS_LEN, SUBSCRIBE_REQ_LEN};
 pub use ops::{OP_GRAB_RELEASE, OP_GRAB_REQUEST, OP_HEALTHCHECK, OP_SUBSCRIBE};

--- a/userland/capsule_input_router/src/server/handlers/grab_request.rs
+++ b/userland/capsule_input_router/src/server/handlers/grab_request.rs
@@ -14,14 +14,25 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::protocol::{read_u32, Request, E_INVAL};
+use crate::clients::wire::lookup_pid;
+use crate::protocol::{read_u32, Request, E_INVAL, E_ACCES};
 use crate::server::respond;
 use crate::state::Context;
 
 const E_BUSY: i32 = -16;
 const REQ_LEN: usize = 8;
 
+const GRABBERS: [&[u8]; 3] = [b"app.boot_splash", b"app.setup_wizard", b"app.input_probe"];
+
+fn is_trusted_grabber(sender_pid: u32) -> bool {
+    GRABBERS.iter().any(|name| lookup_pid(name) == Some(sender_pid))
+}
+
 pub fn handle(ctx: &mut Context, sender_pid: u32, req: &Request, body: &[u8], tx: &mut [u8]) {
+    if !is_trusted_grabber(sender_pid) {
+        let _ = respond::status(sender_pid, req, E_ACCES, tx);
+        return;
+    }
     if body.len() != REQ_LEN {
         let _ = respond::status(sender_pid, req, E_INVAL, tx);
         return;

--- a/userland/capsule_keyring/src/server/caller.rs
+++ b/userland/capsule_keyring/src/server/caller.rs
@@ -14,21 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use alloc::vec::Vec;
-
-use crate::protocol::{encode_response, Request, EACCES, EINVAL};
-use crate::store::Store;
-
-pub fn count(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
-    if req.payload.len() != 4 {
-        return encode_response(req.seq, EINVAL, &[]);
+pub(super) fn resolve_caller(payload_pid: u32, sender_pid: u32) -> Option<u32> {
+    if sender_pid == 0 {
+        return Some(payload_pid);
     }
-    let p = req.payload;
-    let payload_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
-    let caller_pid = match super::super::caller::resolve_caller(payload_pid, sender_pid) {
-        Some(pid) => pid,
-        None => return encode_response(req.seq, EACCES, &[]),
-    };
-    let n = store.count_owned_by(caller_pid);
-    encode_response(req.seq, 0, &n.to_le_bytes())
+    if payload_pid == sender_pid {
+        return Some(sender_pid);
+    }
+    None
 }

--- a/userland/capsule_keyring/src/server/dispatch.rs
+++ b/userland/capsule_keyring/src/server/dispatch.rs
@@ -24,20 +24,20 @@ use crate::protocol::{
 };
 use crate::store::Store;
 
-pub fn dispatch(store: &mut Store, req: Request<'_>) -> Vec<u8> {
+pub fn dispatch(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     match req.op {
-        OP_STORE => handlers::store(store, req),
-        OP_RETRIEVE => handlers::retrieve(store, req),
-        OP_DELETE => handlers::delete(store, req),
-        OP_LOCK => handlers::lock(store, req),
-        OP_UNLOCK => handlers::unlock(store, req),
-        OP_METADATA => handlers::metadata(store, req),
-        OP_COUNT => handlers::count(store, req),
-        OP_WALLET_IMPORT => handlers::wallet_import(store, req),
-        OP_WALLET_GENERATE => handlers::wallet_generate(store, req),
-        OP_WALLET_ADDRESS => handlers::wallet_address(store, req),
-        OP_SIGN_NOX_RECEIPT => handlers::sign_receipt(store, req),
-        OP_SIGN_NOX_APPROVE => handlers::sign_approve(store, req),
+        OP_STORE => handlers::store(store, req, sender_pid),
+        OP_RETRIEVE => handlers::retrieve(store, req, sender_pid),
+        OP_DELETE => handlers::delete(store, req, sender_pid),
+        OP_LOCK => handlers::lock(store, req, sender_pid),
+        OP_UNLOCK => handlers::unlock(store, req, sender_pid),
+        OP_METADATA => handlers::metadata(store, req, sender_pid),
+        OP_COUNT => handlers::count(store, req, sender_pid),
+        OP_WALLET_IMPORT => handlers::wallet_import(store, req, sender_pid),
+        OP_WALLET_GENERATE => handlers::wallet_generate(store, req, sender_pid),
+        OP_WALLET_ADDRESS => handlers::wallet_address(store, req, sender_pid),
+        OP_SIGN_NOX_RECEIPT => handlers::sign_receipt(store, req, sender_pid),
+        OP_SIGN_NOX_APPROVE => handlers::sign_approve(store, req, sender_pid),
         _ => encode_response(req.seq, EINVAL, &[]),
     }
 }

--- a/userland/capsule_keyring/src/server/handlers/delete.rs
+++ b/userland/capsule_keyring/src/server/handlers/delete.rs
@@ -19,12 +19,16 @@ use alloc::vec::Vec;
 use crate::protocol::{encode_response, Request, EACCES, EINVAL, ENOENT};
 use crate::store::{Store, StoreError};
 
-pub fn delete(store: &mut Store, req: Request<'_>) -> Vec<u8> {
+pub fn delete(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     if req.payload.len() != 8 {
         return encode_response(req.seq, EINVAL, &[]);
     }
     let p = req.payload;
-    let caller_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let payload_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let caller_pid = match super::super::caller::resolve_caller(payload_pid, sender_pid) {
+        Some(pid) => pid,
+        None => return encode_response(req.seq, EACCES, &[]),
+    };
     let id = u32::from_le_bytes([p[4], p[5], p[6], p[7]]);
     match store.delete(id, caller_pid) {
         Ok(()) => encode_response(req.seq, 0, &[]),

--- a/userland/capsule_keyring/src/server/handlers/lock.rs
+++ b/userland/capsule_keyring/src/server/handlers/lock.rs
@@ -19,12 +19,16 @@ use alloc::vec::Vec;
 use crate::protocol::{encode_response, Request, EACCES, EINVAL, ENOENT};
 use crate::store::{Store, StoreError};
 
-pub fn lock(store: &mut Store, req: Request<'_>) -> Vec<u8> {
+pub fn lock(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     if req.payload.len() != 8 {
         return encode_response(req.seq, EINVAL, &[]);
     }
     let p = req.payload;
-    let caller_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let payload_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let caller_pid = match super::super::caller::resolve_caller(payload_pid, sender_pid) {
+        Some(pid) => pid,
+        None => return encode_response(req.seq, EACCES, &[]),
+    };
     let id = u32::from_le_bytes([p[4], p[5], p[6], p[7]]);
     match store.lock(id, caller_pid) {
         Ok(()) => encode_response(req.seq, 0, &[]),

--- a/userland/capsule_keyring/src/server/handlers/metadata.rs
+++ b/userland/capsule_keyring/src/server/handlers/metadata.rs
@@ -19,12 +19,16 @@ use alloc::vec::Vec;
 use crate::protocol::{encode_response, Request, EACCES, EINVAL, ENOENT};
 use crate::store::{KeyMetadata, Store, StoreError};
 
-pub fn metadata(store: &mut Store, req: Request<'_>) -> Vec<u8> {
+pub fn metadata(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     if req.payload.len() != 8 {
         return encode_response(req.seq, EINVAL, &[]);
     }
     let p = req.payload;
-    let caller_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let payload_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let caller_pid = match super::super::caller::resolve_caller(payload_pid, sender_pid) {
+        Some(pid) => pid,
+        None => return encode_response(req.seq, EACCES, &[]),
+    };
     let id = u32::from_le_bytes([p[4], p[5], p[6], p[7]]);
     match store.metadata(id, caller_pid) {
         Ok(m) => encode_response(req.seq, 0, &serialize(&m)),

--- a/userland/capsule_keyring/src/server/handlers/retrieve.rs
+++ b/userland/capsule_keyring/src/server/handlers/retrieve.rs
@@ -19,12 +19,16 @@ use alloc::vec::Vec;
 use crate::protocol::{encode_response, Request, EACCES, EBUSY, EINVAL, ENOENT};
 use crate::store::{Store, StoreError};
 
-pub fn retrieve(store: &mut Store, req: Request<'_>) -> Vec<u8> {
+pub fn retrieve(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     if req.payload.len() != 8 {
         return encode_response(req.seq, EINVAL, &[]);
     }
     let p = req.payload;
-    let caller_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let payload_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let caller_pid = match super::super::caller::resolve_caller(payload_pid, sender_pid) {
+        Some(pid) => pid,
+        None => return encode_response(req.seq, EACCES, &[]),
+    };
     let id = u32::from_le_bytes([p[4], p[5], p[6], p[7]]);
     match store.retrieve(id, caller_pid) {
         Ok(data) => encode_response(req.seq, 0, &data),

--- a/userland/capsule_keyring/src/server/handlers/sign_approve.rs
+++ b/userland/capsule_keyring/src/server/handlers/sign_approve.rs
@@ -22,13 +22,17 @@ use super::super::zeroize::zeroize32;
 use crate::protocol::{encode_response, Request, EACCES, EINVAL};
 use crate::store::{Store, StoreError};
 
-pub fn sign_approve(store: &mut Store, req: Request<'_>) -> Vec<u8> {
+pub fn sign_approve(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     const HDR: usize = 4 + 4 + 32 * 5;
     if req.payload.len() != HDR {
         return encode_response(req.seq, EINVAL, &[]);
     }
     let p = req.payload;
-    let caller_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let payload_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let caller_pid = match crate::server::caller::resolve_caller(payload_pid, sender_pid) {
+        Some(pid) => pid,
+        None => return encode_response(req.seq, EACCES, &[]),
+    };
     let id = u32::from_le_bytes([p[4], p[5], p[6], p[7]]);
     let mut secret = match store.eth_secret(id, caller_pid) {
         Ok(s) => s,

--- a/userland/capsule_keyring/src/server/handlers/sign_receipt/sign_receipt.rs
+++ b/userland/capsule_keyring/src/server/handlers/sign_receipt/sign_receipt.rs
@@ -23,13 +23,17 @@ use crate::store::{Store, StoreError};
 
 use super::read_fields::read_fields;
 
-pub fn sign_receipt(store: &mut Store, req: Request<'_>) -> Vec<u8> {
+pub fn sign_receipt(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     const HDR: usize = 4 + 4 + 32 + 20 + 32 + 32 + 32 + 32 + 32;
     if req.payload.len() != HDR {
         return encode_response(req.seq, EINVAL, &[]);
     }
     let p = req.payload;
-    let caller_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let payload_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let caller_pid = match crate::server::caller::resolve_caller(payload_pid, sender_pid) {
+        Some(pid) => pid,
+        None => return encode_response(req.seq, EACCES, &[]),
+    };
     let id = u32::from_le_bytes([p[4], p[5], p[6], p[7]]);
     let mut secret = match store.eth_secret(id, caller_pid) {
         Ok(s) => s,

--- a/userland/capsule_keyring/src/server/handlers/store.rs
+++ b/userland/capsule_keyring/src/server/handlers/store.rs
@@ -16,17 +16,21 @@
 
 use alloc::vec::Vec;
 
-use crate::protocol::{encode_response, Request, EINVAL, ENOSPC};
+use crate::protocol::{encode_response, Request, EACCES, EINVAL, ENOSPC};
 use crate::store::{KeyType, Store, StoreError};
 
 const HDR: usize = 4 + 8 + 8 + 1 + 2;
 
-pub fn store(store: &mut Store, req: Request<'_>) -> Vec<u8> {
+pub fn store(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     if req.payload.len() < HDR {
         return encode_response(req.seq, EINVAL, &[]);
     }
     let p = req.payload;
-    let caller_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let payload_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let caller_pid = match super::super::caller::resolve_caller(payload_pid, sender_pid) {
+        Some(pid) => pid,
+        None => return encode_response(req.seq, EACCES, &[]),
+    };
     let now = u64::from_le_bytes([p[4], p[5], p[6], p[7], p[8], p[9], p[10], p[11]]);
     let expires_at = u64::from_le_bytes([p[12], p[13], p[14], p[15], p[16], p[17], p[18], p[19]]);
     let key_type = match KeyType::from_u8(p[20]) {

--- a/userland/capsule_keyring/src/server/handlers/unlock.rs
+++ b/userland/capsule_keyring/src/server/handlers/unlock.rs
@@ -19,12 +19,16 @@ use alloc::vec::Vec;
 use crate::protocol::{encode_response, Request, EACCES, EINVAL, ENOENT};
 use crate::store::{Store, StoreError};
 
-pub fn unlock(store: &mut Store, req: Request<'_>) -> Vec<u8> {
+pub fn unlock(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     if req.payload.len() != 8 {
         return encode_response(req.seq, EINVAL, &[]);
     }
     let p = req.payload;
-    let caller_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let payload_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let caller_pid = match super::super::caller::resolve_caller(payload_pid, sender_pid) {
+        Some(pid) => pid,
+        None => return encode_response(req.seq, EACCES, &[]),
+    };
     let id = u32::from_le_bytes([p[4], p[5], p[6], p[7]]);
     match store.unlock(id, caller_pid) {
         Ok(()) => encode_response(req.seq, 0, &[]),

--- a/userland/capsule_keyring/src/server/handlers/wallet_address.rs
+++ b/userland/capsule_keyring/src/server/handlers/wallet_address.rs
@@ -19,12 +19,16 @@ use alloc::vec::Vec;
 use crate::protocol::{encode_response, Request, EACCES, EINVAL};
 use crate::store::{Store, StoreError};
 
-pub fn wallet_address(store: &mut Store, req: Request<'_>) -> Vec<u8> {
+pub fn wallet_address(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     if req.payload.len() != 8 {
         return encode_response(req.seq, EINVAL, &[]);
     }
     let p = req.payload;
-    let caller_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let payload_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let caller_pid = match super::super::caller::resolve_caller(payload_pid, sender_pid) {
+        Some(pid) => pid,
+        None => return encode_response(req.seq, EACCES, &[]),
+    };
     let id = u32::from_le_bytes([p[4], p[5], p[6], p[7]]);
     let mut secret = match store.eth_secret(id, caller_pid) {
         Ok(s) => s,

--- a/userland/capsule_keyring/src/server/handlers/wallet_generate.rs
+++ b/userland/capsule_keyring/src/server/handlers/wallet_generate.rs
@@ -16,16 +16,20 @@
 
 use alloc::vec::Vec;
 
-use crate::protocol::{encode_response, Request, EINVAL, ENOSPC};
+use crate::protocol::{encode_response, Request, EACCES, EINVAL, ENOSPC};
 use crate::store::{eth_secret_valid, KeyType, Store, StoreError};
 
-pub fn wallet_generate(store: &mut Store, req: Request<'_>) -> Vec<u8> {
+pub fn wallet_generate(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     const HDR: usize = 4 + 8 + 8;
     if req.payload.len() != HDR {
         return encode_response(req.seq, EINVAL, &[]);
     }
     let p = req.payload;
-    let caller_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let payload_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let caller_pid = match super::super::caller::resolve_caller(payload_pid, sender_pid) {
+        Some(pid) => pid,
+        None => return encode_response(req.seq, EACCES, &[]),
+    };
     let now = u64::from_le_bytes([p[4], p[5], p[6], p[7], p[8], p[9], p[10], p[11]]);
     let expires_at = u64::from_le_bytes([p[12], p[13], p[14], p[15], p[16], p[17], p[18], p[19]]);
     let mut secret = [0u8; 32];

--- a/userland/capsule_keyring/src/server/handlers/wallet_import.rs
+++ b/userland/capsule_keyring/src/server/handlers/wallet_import.rs
@@ -16,16 +16,20 @@
 
 use alloc::vec::Vec;
 
-use crate::protocol::{encode_response, Request, EINVAL, ENOSPC};
+use crate::protocol::{encode_response, Request, EACCES, EINVAL, ENOSPC};
 use crate::store::{eth_secret_valid, KeyType, Store, StoreError};
 
-pub fn wallet_import(store: &mut Store, req: Request<'_>) -> Vec<u8> {
+pub fn wallet_import(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     const HDR: usize = 4 + 8 + 8;
     if req.payload.len() != HDR + 32 {
         return encode_response(req.seq, EINVAL, &[]);
     }
     let p = req.payload;
-    let caller_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let payload_pid = u32::from_le_bytes([p[0], p[1], p[2], p[3]]);
+    let caller_pid = match super::super::caller::resolve_caller(payload_pid, sender_pid) {
+        Some(pid) => pid,
+        None => return encode_response(req.seq, EACCES, &[]),
+    };
     let now = u64::from_le_bytes([p[4], p[5], p[6], p[7], p[8], p[9], p[10], p[11]]);
     let expires_at = u64::from_le_bytes([p[12], p[13], p[14], p[15], p[16], p[17], p[18], p[19]]);
     let mut secret = [0u8; 32];

--- a/userland/capsule_keyring/src/server/mod.rs
+++ b/userland/capsule_keyring/src/server/mod.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+mod caller;
 mod dispatch;
 mod eip1559;
 mod eip712;

--- a/userland/capsule_keyring/src/server/runner.rs
+++ b/userland/capsule_keyring/src/server/runner.rs
@@ -16,7 +16,7 @@
 
 use alloc::vec;
 
-use nonos_libc::{mk_ipc_recv, mk_ipc_send};
+use nonos_libc::{mk_ipc_recv_from, mk_ipc_send};
 
 use super::dispatch::dispatch;
 use super::wipe::wipe;
@@ -29,13 +29,14 @@ pub fn run() -> ! {
     let mut buf = vec![0u8; MAX_MSG];
     let mut store = Store::new();
     loop {
-        let n = mk_ipc_recv(0, buf.as_mut_ptr(), MAX_MSG, 0);
+        let mut sender_pid: u32 = 0;
+        let n = mk_ipc_recv_from(0, buf.as_mut_ptr(), MAX_MSG, 0, &mut sender_pid);
         if n <= 0 {
             continue;
         }
         let used = n as usize;
         let resp = match decode_request(&buf[..used]) {
-            Some(req) => dispatch(&mut store, req),
+            Some(req) => dispatch(&mut store, req, sender_pid),
             None => {
                 wipe(&mut buf[..used]);
                 continue;

--- a/userland/capsule_keyring/src/store/types/key_entry.rs
+++ b/userland/capsule_keyring/src/store/types/key_entry.rs
@@ -26,3 +26,9 @@ pub(in crate::store) struct KeyEntry {
     pub(in crate::store) use_count: u64,
     pub(in crate::store) locked: bool,
 }
+
+impl Drop for KeyEntry {
+    fn drop(&mut self) {
+        crate::store::wipe::secure_wipe(&mut self.data);
+    }
+}

--- a/userland/capsule_net_dns/src/server/handlers/flush.rs
+++ b/userland/capsule_net_dns/src/server/handlers/flush.rs
@@ -17,10 +17,9 @@
 use crate::protocol::{E_OK, OP_FLUSH_CACHE};
 use crate::server::parse_req::Request;
 use crate::server::respond::respond;
-use crate::state::{now_ms, CACHE};
+use crate::state::CACHE;
 
 pub fn handle(sender_pid: u32, req: &Request, tx: &mut [u8]) {
     CACHE.lock().tick(u64::MAX);
-    let _ = now_ms();
     let _ = respond(sender_pid, OP_FLUSH_CACHE, E_OK, req.request_id, 0, tx);
 }

--- a/userland/capsule_net_dns/src/state.rs
+++ b/userland/capsule_net_dns/src/state.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use core::sync::atomic::{AtomicU16, AtomicU32, AtomicU64, Ordering};
+use core::sync::atomic::{AtomicU16, AtomicU32, Ordering};
 use spin::Mutex;
 
 use crate::dns::Cache;
@@ -26,7 +26,6 @@ pub static CACHE: Mutex<Cache> = Mutex::new(Cache::new());
 pub static UDP_PORT: AtomicU32 = AtomicU32::new(0);
 static LOCAL_PORT: AtomicU16 = AtomicU16::new(53535);
 static XID: AtomicU16 = AtomicU16::new(0x3011);
-static CLOCK_MS: AtomicU64 = AtomicU64::new(1);
 static UPSTREAM: Mutex<[u8; 4]> = Mutex::new(DEFAULT_UPSTREAM);
 
 pub fn udp_port() -> u32 {
@@ -46,7 +45,11 @@ pub fn next_xid() -> u16 {
 }
 
 pub fn now_ms() -> u64 {
-    CLOCK_MS.fetch_add(1000, Ordering::AcqRel)
+    let raw = nonos_libc::mk_time_millis();
+    if raw < 0 {
+        return 0;
+    }
+    raw as u64
 }
 
 pub fn upstream() -> [u8; 4] {

--- a/userland/capsule_power/src/server/runner.rs
+++ b/userland/capsule_power/src/server/runner.rs
@@ -16,7 +16,7 @@
 
 use alloc::vec;
 
-use nonos_libc::{mk_ipc_recv, mk_ipc_send, mk_yield};
+use nonos_libc::{mk_ipc_recv_from, mk_ipc_reply, mk_yield};
 
 use super::handlers::route;
 use crate::protocol::IPC_PAYLOAD_MAX;
@@ -30,19 +30,21 @@ pub fn run() -> ! {
     let mut out_buf = vec![0u8; IPC_PAYLOAD_MAX];
     let mut state = PowerState::new();
     loop {
-        let received = mk_ipc_recv(
+        let mut sender_pid = 0u32;
+        let received = mk_ipc_recv_from(
             SERVICE_PORT,
             in_buf.as_mut_ptr(),
             in_buf.len(),
             RECV_TIMEOUT_MS,
+            &mut sender_pid,
         );
-        if received <= 0 {
+        if received <= 0 || sender_pid == 0 {
             mk_yield();
             continue;
         }
         let n = route(&mut state, &in_buf[..received as usize], &mut out_buf);
         if n > 0 {
-            let _ = mk_ipc_send(SERVICE_PORT, out_buf.as_ptr(), n);
+            let _ = mk_ipc_reply(sender_pid, out_buf.as_ptr(), n);
         }
     }
 }

--- a/userland/capsule_ramfs/src/handles.rs
+++ b/userland/capsule_ramfs/src/handles.rs
@@ -19,8 +19,9 @@ use alloc::string::String;
 
 pub const MAX_HANDLES: usize = 1024;
 
-pub struct Handle {
-    pub path: String,
+struct Handle {
+    path: String,
+    owner_pid: u32,
 }
 
 pub struct HandleTable {
@@ -33,21 +34,37 @@ impl HandleTable {
         Self { next_id: 1, table: BTreeMap::new() }
     }
 
-    pub fn insert(&mut self, path: String) -> Option<u64> {
+    pub fn insert(&mut self, path: String, owner_pid: u32) -> Option<u64> {
         if self.table.len() >= MAX_HANDLES {
             return None;
         }
         let id = self.next_id;
         self.next_id = self.next_id.wrapping_add(1);
-        self.table.insert(id, Handle { path });
+        self.table.insert(id, Handle { path, owner_pid });
         Some(id)
     }
 
-    pub fn path_of(&self, id: u64) -> Option<&str> {
-        self.table.get(&id).map(|h| h.path.as_str())
+    pub fn path_for(&self, id: u64, sender_pid: u32) -> Result<&str, HandleError> {
+        let h = self.table.get(&id).ok_or(HandleError::NotFound)?;
+        if sender_pid != 0 && h.owner_pid != sender_pid {
+            return Err(HandleError::Denied);
+        }
+        Ok(h.path.as_str())
     }
 
-    pub fn remove(&mut self, id: u64) -> bool {
-        self.table.remove(&id).is_some()
+    pub fn remove(&mut self, id: u64, sender_pid: u32) -> Result<(), HandleError> {
+        match self.table.get(&id) {
+            None => Err(HandleError::NotFound),
+            Some(h) if sender_pid != 0 && h.owner_pid != sender_pid => Err(HandleError::Denied),
+            Some(_) => {
+                self.table.remove(&id);
+                Ok(())
+            }
+        }
     }
+}
+
+pub enum HandleError {
+    NotFound,
+    Denied,
 }

--- a/userland/capsule_ramfs/src/protocol/decode.rs
+++ b/userland/capsule_ramfs/src/protocol/decode.rs
@@ -20,6 +20,10 @@ pub fn decode_request(buf: &[u8]) -> Option<Request<'_>> {
     if buf.len() < HDR_LEN {
         return None;
     }
+    let reserved = u16::from_le_bytes([buf[6], buf[7]]);
+    if reserved != 0 {
+        return None;
+    }
     let seq = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]);
     let op = u16::from_le_bytes([buf[4], buf[5]]);
     Some(Request { seq, op, payload: &buf[HDR_LEN..] })

--- a/userland/capsule_ramfs/src/protocol/errno.rs
+++ b/userland/capsule_ramfs/src/protocol/errno.rs
@@ -16,5 +16,6 @@
 
 pub const ENOENT: i32 = -2;
 pub const EIO: i32 = -5;
+pub const EACCES: i32 = -13;
 pub const EINVAL: i32 = -22;
 pub const EMFILE: i32 = -24;

--- a/userland/capsule_ramfs/src/protocol/mod.rs
+++ b/userland/capsule_ramfs/src/protocol/mod.rs
@@ -21,7 +21,7 @@ mod types;
 
 pub use decode::{decode_request, read_u16_le, read_u32_le, read_u64_le};
 pub use encode::encode_response;
-pub use errno::{EINVAL, EIO, EMFILE, ENOENT};
+pub use errno::{EACCES, EINVAL, EIO, EMFILE, ENOENT};
 pub use types::{
     Request, KERNEL_REPLY_ENDPOINT, OPEN_FLAG_CREATE, OPEN_FLAG_TRUNCATE, OP_CLOSE, OP_OPEN,
     OP_READ, OP_TRUNCATE, OP_WRITE,

--- a/userland/capsule_ramfs/src/server/dispatch.rs
+++ b/userland/capsule_ramfs/src/server/dispatch.rs
@@ -23,13 +23,18 @@ use crate::protocol::{
 };
 use crate::store::Store;
 
-pub fn dispatch(store: &mut Store, handles: &mut HandleTable, req: Request<'_>) -> Vec<u8> {
+pub fn dispatch(
+    store: &mut Store,
+    handles: &mut HandleTable,
+    req: Request<'_>,
+    sender_pid: u32,
+) -> Vec<u8> {
     match req.op {
-        OP_OPEN => handlers::open(store, handles, req),
-        OP_READ => handlers::read(store, handles, req),
-        OP_WRITE => handlers::write(store, handles, req),
-        OP_TRUNCATE => handlers::truncate(store, handles, req),
-        OP_CLOSE => handlers::close(handles, req),
+        OP_OPEN => handlers::open(store, handles, req, sender_pid),
+        OP_READ => handlers::read(store, handles, req, sender_pid),
+        OP_WRITE => handlers::write(store, handles, req, sender_pid),
+        OP_TRUNCATE => handlers::truncate(store, handles, req, sender_pid),
+        OP_CLOSE => handlers::close(handles, req, sender_pid),
         _ => encode_response(req.seq, EINVAL, &[]),
     }
 }

--- a/userland/capsule_ramfs/src/server/handlers/close.rs
+++ b/userland/capsule_ramfs/src/server/handlers/close.rs
@@ -16,10 +16,10 @@
 
 use alloc::vec::Vec;
 
-use crate::handles::HandleTable;
-use crate::protocol::{encode_response, read_u64_le, Request, EINVAL, ENOENT};
+use crate::handles::{HandleError, HandleTable};
+use crate::protocol::{encode_response, read_u64_le, Request, EACCES, EINVAL, ENOENT};
 
-pub fn close(handles: &mut HandleTable, req: Request<'_>) -> Vec<u8> {
+pub fn close(handles: &mut HandleTable, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     if req.payload.len() < 8 {
         return encode_response(req.seq, EINVAL, &[]);
     }
@@ -27,9 +27,9 @@ pub fn close(handles: &mut HandleTable, req: Request<'_>) -> Vec<u8> {
         Some(v) => v,
         None => return encode_response(req.seq, EINVAL, &[]),
     };
-    if handles.remove(h) {
-        encode_response(req.seq, 0, &[])
-    } else {
-        encode_response(req.seq, ENOENT, &[])
+    match handles.remove(h, sender_pid) {
+        Ok(()) => encode_response(req.seq, 0, &[]),
+        Err(HandleError::Denied) => encode_response(req.seq, EACCES, &[]),
+        Err(HandleError::NotFound) => encode_response(req.seq, ENOENT, &[]),
     }
 }

--- a/userland/capsule_ramfs/src/server/handlers/open.rs
+++ b/userland/capsule_ramfs/src/server/handlers/open.rs
@@ -24,7 +24,12 @@ use crate::protocol::{
 };
 use crate::store::Store;
 
-pub fn open(store: &mut Store, handles: &mut HandleTable, req: Request<'_>) -> Vec<u8> {
+pub fn open(
+    store: &mut Store,
+    handles: &mut HandleTable,
+    req: Request<'_>,
+    sender_pid: u32,
+) -> Vec<u8> {
     if req.payload.len() < 6 {
         return encode_response(req.seq, EINVAL, &[]);
     }
@@ -54,7 +59,7 @@ pub fn open(store: &mut Store, handles: &mut HandleTable, req: Request<'_>) -> V
     if flags & OPEN_FLAG_TRUNCATE != 0 && store.truncate(&path, 0).is_err() {
         return encode_response(req.seq, EIO, &[]);
     }
-    match handles.insert(path) {
+    match handles.insert(path, sender_pid) {
         Some(id) => encode_response(req.seq, 0, &id.to_le_bytes()),
         None => encode_response(req.seq, EMFILE, &[]),
     }

--- a/userland/capsule_ramfs/src/server/handlers/read.rs
+++ b/userland/capsule_ramfs/src/server/handlers/read.rs
@@ -16,11 +16,13 @@
 
 use alloc::vec::Vec;
 
-use crate::handles::HandleTable;
-use crate::protocol::{encode_response, read_u32_le, read_u64_le, Request, EINVAL, EIO, ENOENT};
+use crate::handles::{HandleError, HandleTable};
+use crate::protocol::{
+    encode_response, read_u32_le, read_u64_le, Request, EACCES, EINVAL, EIO, ENOENT,
+};
 use crate::store::{Store, StoreError};
 
-pub fn read(store: &Store, handles: &HandleTable, req: Request<'_>) -> Vec<u8> {
+pub fn read(store: &Store, handles: &HandleTable, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     if req.payload.len() < 20 {
         return encode_response(req.seq, EINVAL, &[]);
     }
@@ -36,9 +38,10 @@ pub fn read(store: &Store, handles: &HandleTable, req: Request<'_>) -> Vec<u8> {
         Some(v) => v as usize,
         None => return encode_response(req.seq, EINVAL, &[]),
     };
-    let path = match handles.path_of(h) {
-        Some(p) => p,
-        None => return encode_response(req.seq, ENOENT, &[]),
+    let path = match handles.path_for(h, sender_pid) {
+        Ok(p) => p,
+        Err(HandleError::Denied) => return encode_response(req.seq, EACCES, &[]),
+        Err(HandleError::NotFound) => return encode_response(req.seq, ENOENT, &[]),
     };
     match store.read_at(path, offset, count) {
         Ok(bytes) => encode_response(req.seq, bytes.len() as i32, &bytes),

--- a/userland/capsule_ramfs/src/server/handlers/truncate.rs
+++ b/userland/capsule_ramfs/src/server/handlers/truncate.rs
@@ -17,11 +17,16 @@
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use crate::handles::HandleTable;
-use crate::protocol::{encode_response, read_u64_le, Request, EINVAL, EIO, ENOENT};
+use crate::handles::{HandleError, HandleTable};
+use crate::protocol::{encode_response, read_u64_le, Request, EACCES, EINVAL, EIO, ENOENT};
 use crate::store::{Store, StoreError};
 
-pub fn truncate(store: &mut Store, handles: &HandleTable, req: Request<'_>) -> Vec<u8> {
+pub fn truncate(
+    store: &mut Store,
+    handles: &HandleTable,
+    req: Request<'_>,
+    sender_pid: u32,
+) -> Vec<u8> {
     if req.payload.len() < 16 {
         return encode_response(req.seq, EINVAL, &[]);
     }
@@ -33,9 +38,10 @@ pub fn truncate(store: &mut Store, handles: &HandleTable, req: Request<'_>) -> V
         Some(v) => v as usize,
         None => return encode_response(req.seq, EINVAL, &[]),
     };
-    let path = match handles.path_of(h) {
-        Some(p) => String::from(p),
-        None => return encode_response(req.seq, ENOENT, &[]),
+    let path = match handles.path_for(h, sender_pid) {
+        Ok(p) => String::from(p),
+        Err(HandleError::Denied) => return encode_response(req.seq, EACCES, &[]),
+        Err(HandleError::NotFound) => return encode_response(req.seq, ENOENT, &[]),
     };
     match store.truncate(&path, length) {
         Ok(()) => encode_response(req.seq, 0, &[]),

--- a/userland/capsule_ramfs/src/server/handlers/write.rs
+++ b/userland/capsule_ramfs/src/server/handlers/write.rs
@@ -17,11 +17,16 @@
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use crate::handles::HandleTable;
-use crate::protocol::{encode_response, read_u64_le, Request, EINVAL, EIO, ENOENT};
+use crate::handles::{HandleError, HandleTable};
+use crate::protocol::{encode_response, read_u64_le, Request, EACCES, EINVAL, EIO, ENOENT};
 use crate::store::{Store, StoreError};
 
-pub fn write(store: &mut Store, handles: &HandleTable, req: Request<'_>) -> Vec<u8> {
+pub fn write(
+    store: &mut Store,
+    handles: &HandleTable,
+    req: Request<'_>,
+    sender_pid: u32,
+) -> Vec<u8> {
     if req.payload.len() < 16 {
         return encode_response(req.seq, EINVAL, &[]);
     }
@@ -34,9 +39,10 @@ pub fn write(store: &mut Store, handles: &HandleTable, req: Request<'_>) -> Vec<
         None => return encode_response(req.seq, EINVAL, &[]),
     };
     let data = &req.payload[16..];
-    let path = match handles.path_of(h) {
-        Some(p) => String::from(p),
-        None => return encode_response(req.seq, ENOENT, &[]),
+    let path = match handles.path_for(h, sender_pid) {
+        Ok(p) => String::from(p),
+        Err(HandleError::Denied) => return encode_response(req.seq, EACCES, &[]),
+        Err(HandleError::NotFound) => return encode_response(req.seq, ENOENT, &[]),
     };
     match store.write_at(&path, offset, data) {
         Ok(n) => encode_response(req.seq, n as i32, &[]),

--- a/userland/capsule_ramfs/src/server/runner.rs
+++ b/userland/capsule_ramfs/src/server/runner.rs
@@ -16,7 +16,7 @@
 
 use alloc::vec;
 
-use nonos_libc::{mk_ipc_recv, mk_ipc_send};
+use nonos_libc::{mk_ipc_recv_from, mk_ipc_send};
 
 use super::dispatch::dispatch;
 use crate::handles::HandleTable;
@@ -30,7 +30,8 @@ pub fn run() -> ! {
     let mut store = Store::new();
     let mut handles = HandleTable::new();
     loop {
-        let n = mk_ipc_recv(0, buf.as_mut_ptr(), MAX_MSG, 0);
+        let mut sender_pid: u32 = 0;
+        let n = mk_ipc_recv_from(0, buf.as_mut_ptr(), MAX_MSG, 0, &mut sender_pid);
         if n <= 0 {
             continue;
         }
@@ -38,7 +39,7 @@ pub fn run() -> ! {
             Some(r) => r,
             None => continue,
         };
-        let resp = dispatch(&mut store, &mut handles, req);
+        let resp = dispatch(&mut store, &mut handles, req, sender_pid);
         let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, resp.as_ptr(), resp.len());
     }
 }

--- a/userland/capsule_setup_wizard/src/render/screens/review.rs
+++ b/userland/capsule_setup_wizard/src/render/screens/review.rs
@@ -35,7 +35,6 @@ fn commit(ctx: &Context) {
     if ctx.host_len > 0 {
         let _ = policy::set_str(p, Field::Hostname as u32, &ctx.host_buf[..ctx.host_len]);
     }
-    let _ = policy::set_bool(p, Field::SystemKeysGenerated as u32, true);
 }
 
 pub fn on_key(ctx: &mut Context, code: u32) -> Outcome {

--- a/userland/capsule_vfs/src/server/dispatch.rs
+++ b/userland/capsule_vfs/src/server/dispatch.rs
@@ -23,17 +23,17 @@ use crate::protocol::{
 };
 use crate::store::Store;
 
-pub fn dispatch(store: &mut Store, req: Request<'_>) -> Vec<u8> {
+pub fn dispatch(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
     match req.op {
-        OP_OPEN => handlers::open(store, req),
-        OP_CLOSE => handlers::close(store, req),
-        OP_READ => handlers::read(store, req),
-        OP_WRITE => handlers::write(store, req),
-        OP_STAT => handlers::stat(store, req),
-        OP_LIST => handlers::list(store, req),
-        OP_MKDIR => handlers::mkdir(store, req),
-        OP_UNLINK => handlers::unlink(store, req),
-        OP_RENAME => handlers::rename(store, req),
+        OP_OPEN => handlers::open(store, req, sender_pid),
+        OP_CLOSE => handlers::close(store, req, sender_pid),
+        OP_READ => handlers::read(store, req, sender_pid),
+        OP_WRITE => handlers::write(store, req, sender_pid),
+        OP_STAT => handlers::stat(store, req, sender_pid),
+        OP_LIST => handlers::list(store, req, sender_pid),
+        OP_MKDIR => handlers::mkdir(store, req, sender_pid),
+        OP_UNLINK => handlers::unlink(store, req, sender_pid),
+        OP_RENAME => handlers::rename(store, req, sender_pid),
         OP_HEALTHCHECK => handlers::healthcheck(req),
         _ => encode_response(req.op, req.flags, req.request_id, EINVAL, &[]),
     }

--- a/userland/capsule_vfs/src/server/handlers/close.rs
+++ b/userland/capsule_vfs/src/server/handlers/close.rs
@@ -21,8 +21,8 @@ use crate::protocol::{encode_response, Request, EINVAL, OP_CLOSE};
 use crate::store::Store;
 
 // Payload: u32 caller_pid, u32 fd.
-pub fn close(store: &mut Store, req: Request<'_>) -> Vec<u8> {
-    let (pid, rest) = match split_caller(req.payload) {
+pub fn close(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
+    let (pid, rest) = match split_caller(req.payload, sender_pid) {
         Ok(v) => v,
         Err(s) => return encode_response(OP_CLOSE, req.flags, req.request_id, s, &[]),
     };

--- a/userland/capsule_vfs/src/server/handlers/list.rs
+++ b/userland/capsule_vfs/src/server/handlers/list.rs
@@ -26,8 +26,8 @@ use crate::store::Store;
 // Payload: u32 caller_pid, u8 prefix_len, prefix bytes.
 // Reply body: concatenated `<u8 name_len><name bytes>` entries, capped
 // at MAX_LIST_BYTES.
-pub fn list(store: &mut Store, req: Request<'_>) -> Vec<u8> {
-    let (_pid, rest) = match split_caller(req.payload) {
+pub fn list(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
+    let (_pid, rest) = match split_caller(req.payload, sender_pid) {
         Ok(v) => v,
         Err(s) => return encode_response(OP_LIST, req.flags, req.request_id, s, &[]),
     };

--- a/userland/capsule_vfs/src/server/handlers/mkdir.rs
+++ b/userland/capsule_vfs/src/server/handlers/mkdir.rs
@@ -21,8 +21,8 @@ use super::util::{map_store_err, split_caller};
 use crate::protocol::{encode_response, Request, EINVAL, MAX_PATH_BYTES, OP_MKDIR};
 use crate::store::Store;
 
-pub fn mkdir(store: &mut Store, req: Request<'_>) -> Vec<u8> {
-    let (_pid, rest) = match split_caller(req.payload) {
+pub fn mkdir(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
+    let (_pid, rest) = match split_caller(req.payload, sender_pid) {
         Ok(v) => v,
         Err(s) => return encode_response(OP_MKDIR, req.flags, req.request_id, s, &[]),
     };

--- a/userland/capsule_vfs/src/server/handlers/open.rs
+++ b/userland/capsule_vfs/src/server/handlers/open.rs
@@ -24,8 +24,8 @@ use crate::protocol::{
 use crate::store::Store;
 
 // Payload: u32 caller_pid, u8 path_len, path bytes, u32 flags.
-pub fn open(store: &mut Store, req: Request<'_>) -> Vec<u8> {
-    let (pid, rest) = match split_caller(req.payload) {
+pub fn open(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
+    let (pid, rest) = match split_caller(req.payload, sender_pid) {
         Ok(v) => v,
         Err(s) => return encode_response(OP_OPEN, req.flags, req.request_id, s, &[]),
     };

--- a/userland/capsule_vfs/src/server/handlers/read.rs
+++ b/userland/capsule_vfs/src/server/handlers/read.rs
@@ -21,8 +21,8 @@ use crate::protocol::{encode_response, Request, EINVAL, EMSGSIZE, MAX_DATA_BYTES
 use crate::store::Store;
 
 // Payload: u32 caller_pid, u32 fd, u32 max_bytes.
-pub fn read(store: &mut Store, req: Request<'_>) -> Vec<u8> {
-    let (pid, rest) = match split_caller(req.payload) {
+pub fn read(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
+    let (pid, rest) = match split_caller(req.payload, sender_pid) {
         Ok(v) => v,
         Err(s) => return encode_response(OP_READ, req.flags, req.request_id, s, &[]),
     };

--- a/userland/capsule_vfs/src/server/handlers/rename.rs
+++ b/userland/capsule_vfs/src/server/handlers/rename.rs
@@ -21,8 +21,8 @@ use super::util::{map_store_err, split_caller};
 use crate::protocol::{encode_response, Request, EINVAL, MAX_PATH_BYTES, OP_RENAME};
 use crate::store::Store;
 
-pub fn rename(store: &mut Store, req: Request<'_>) -> Vec<u8> {
-    let (_pid, rest) = match split_caller(req.payload) {
+pub fn rename(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
+    let (_pid, rest) = match split_caller(req.payload, sender_pid) {
         Ok(v) => v,
         Err(s) => return encode_response(OP_RENAME, req.flags, req.request_id, s, &[]),
     };

--- a/userland/capsule_vfs/src/server/handlers/stat.rs
+++ b/userland/capsule_vfs/src/server/handlers/stat.rs
@@ -23,8 +23,8 @@ use crate::store::Store;
 
 // Payload: u32 caller_pid, u8 path_len, path bytes.
 // Reply body: u64 size, u32 flags (flags reserved for M3-2 routing).
-pub fn stat(store: &mut Store, req: Request<'_>) -> Vec<u8> {
-    let (_pid, rest) = match split_caller(req.payload) {
+pub fn stat(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
+    let (_pid, rest) = match split_caller(req.payload, sender_pid) {
         Ok(v) => v,
         Err(s) => return encode_response(OP_STAT, req.flags, req.request_id, s, &[]),
     };

--- a/userland/capsule_vfs/src/server/handlers/unlink.rs
+++ b/userland/capsule_vfs/src/server/handlers/unlink.rs
@@ -21,8 +21,8 @@ use super::util::{map_store_err, split_caller};
 use crate::protocol::{encode_response, Request, EINVAL, MAX_PATH_BYTES, OP_UNLINK};
 use crate::store::Store;
 
-pub fn unlink(store: &mut Store, req: Request<'_>) -> Vec<u8> {
-    let (_pid, rest) = match split_caller(req.payload) {
+pub fn unlink(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
+    let (_pid, rest) = match split_caller(req.payload, sender_pid) {
         Ok(v) => v,
         Err(s) => return encode_response(OP_UNLINK, req.flags, req.request_id, s, &[]),
     };

--- a/userland/capsule_vfs/src/server/handlers/util.rs
+++ b/userland/capsule_vfs/src/server/handlers/util.rs
@@ -31,13 +31,28 @@ pub(super) fn map_store_err(e: StoreError) -> i32 {
     }
 }
 
-// Caller pid is delivered as the first 4 bytes of every payload
-// (kernel-side client embeds `state::pid()`-trusted caller pid).
-// Returns `(pid, rest)` or EINVAL on a too-short payload.
-pub(super) fn split_caller(payload: &[u8]) -> Result<(u32, &[u8]), i32> {
+fn resolve_caller(payload_pid: u32, sender_pid: u32) -> Option<u32> {
+    if sender_pid == 0 {
+        return Some(payload_pid);
+    }
+    if payload_pid == sender_pid {
+        return Some(sender_pid);
+    }
+    None
+}
+
+// Caller pid is the first 4 bytes of every payload. For a CPL=3 sender
+// (`sender_pid != 0`) the payload pid must match the kernel-attested
+// sender pid; the kernel-side mirror (`sender_pid == 0`) is the TCB and
+// keeps the payload pid. Returns `(attested_pid, rest)`, EINVAL on a
+// too-short payload, or EACCES on an impersonation attempt.
+pub(super) fn split_caller(payload: &[u8], sender_pid: u32) -> Result<(u32, &[u8]), i32> {
     if payload.len() < 4 {
         return Err(EINVAL);
     }
-    let pid = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
-    Ok((pid, &payload[4..]))
+    let payload_pid = u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+    match resolve_caller(payload_pid, sender_pid) {
+        Some(pid) => Ok((pid, &payload[4..])),
+        None => Err(EACCES),
+    }
 }

--- a/userland/capsule_vfs/src/server/handlers/write.rs
+++ b/userland/capsule_vfs/src/server/handlers/write.rs
@@ -21,8 +21,8 @@ use crate::protocol::{encode_response, Request, EINVAL, EMSGSIZE, MAX_DATA_BYTES
 use crate::store::Store;
 
 // Payload: u32 caller_pid, u32 fd, data bytes.
-pub fn write(store: &mut Store, req: Request<'_>) -> Vec<u8> {
-    let (pid, rest) = match split_caller(req.payload) {
+pub fn write(store: &mut Store, req: Request<'_>, sender_pid: u32) -> Vec<u8> {
+    let (pid, rest) = match split_caller(req.payload, sender_pid) {
         Ok(v) => v,
         Err(s) => return encode_response(OP_WRITE, req.flags, req.request_id, s, &[]),
     };

--- a/userland/capsule_vfs/src/server/runner.rs
+++ b/userland/capsule_vfs/src/server/runner.rs
@@ -16,7 +16,7 @@
 
 use alloc::vec;
 
-use nonos_libc::{mk_ipc_recv, mk_ipc_send};
+use nonos_libc::{mk_ipc_recv_from, mk_ipc_send};
 
 use super::dispatch::dispatch;
 use crate::protocol::{decode_request, encode_response, EINVAL, KERNEL_REPLY_ENDPOINT};
@@ -28,13 +28,14 @@ pub fn run() -> ! {
     let mut buf = vec![0u8; MAX_MSG];
     let mut store = Store::new();
     loop {
-        let n = mk_ipc_recv(0, buf.as_mut_ptr(), MAX_MSG, 0);
+        let mut sender_pid: u32 = 0;
+        let n = mk_ipc_recv_from(0, buf.as_mut_ptr(), MAX_MSG, 0, &mut sender_pid);
         if n <= 0 {
             continue;
         }
         let n = n as usize;
         let resp = match decode_request(&buf[..n]) {
-            Ok(req) => dispatch(&mut store, req),
+            Ok(req) => dispatch(&mut store, req, sender_pid),
             Err(_) => encode_response(0, 0, 0, EINVAL, &[]),
         };
         let _ = mk_ipc_send(KERNEL_REPLY_ENDPOINT, resp.as_ptr(), resp.len());

--- a/userland/capsule_vfs/src/store/fdtable/unlink.rs
+++ b/userland/capsule_vfs/src/store/fdtable/unlink.rs
@@ -28,6 +28,13 @@ impl Store {
                 return Err(StoreError::NotEmpty);
             }
         }
+        for slot in self.fds.iter_mut() {
+            match slot {
+                Some(fd) if fd.file_idx == idx => *slot = None,
+                Some(fd) if fd.file_idx > idx => fd.file_idx -= 1,
+                _ => {}
+            }
+        }
         self.files.remove(idx);
         Ok(())
     }

--- a/userland/capsule_wallpaper/src/protocol/errno.rs
+++ b/userland/capsule_wallpaper/src/protocol/errno.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+pub const E_ACCES: i32 = -13;
 pub const E_INVAL: i32 = -22;
 pub const E_BAD_OP: i32 = -38;
 pub const E_BAD_MAGIC: i32 = -71;

--- a/userland/capsule_wallpaper/src/protocol/mod.rs
+++ b/userland/capsule_wallpaper/src/protocol/mod.rs
@@ -25,7 +25,7 @@ mod read_u32;
 
 pub use decode::parse;
 pub use encode::{response_header, write_status};
-pub use errno::{E_BAD_LEN, E_BAD_MAGIC, E_BAD_OP, E_BAD_VERSION, E_INVAL};
+pub use errno::{E_ACCES, E_BAD_LEN, E_BAD_MAGIC, E_BAD_OP, E_BAD_VERSION, E_INVAL};
 pub use header::{Request, HDR_LEN, MAGIC, VERSION};
 pub use limits::{
     FADE_REQ_LEN, GET_WALLPAPER_RESP_LEN, IPC_PAYLOAD_MAX, SET_POLICY_REQ_LEN,

--- a/userland/capsule_wallpaper/src/server/handlers/set_wallpaper.rs
+++ b/userland/capsule_wallpaper/src/server/handlers/set_wallpaper.rs
@@ -14,14 +14,37 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use nonos_libc::mk_service_lookup;
+
 use crate::compositor_client::push_damage_commit;
 use crate::decode_client::decode_and_paint;
 use crate::paint::fill_argb;
-use crate::protocol::{read_u32, Request, E_INVAL, SET_WALLPAPER_REQ_LEN};
+use crate::protocol::{read_u32, Request, E_ACCES, E_INVAL, SET_WALLPAPER_REQ_LEN};
 use crate::server::respond;
 use crate::state::Context;
 
+const SETTERS: [&[u8]; 2] = [b"desktop_shell", b"policy"];
+
+fn lookup_pid(name: &[u8]) -> Option<u32> {
+    let mut pid = 0u32;
+    let mut port = 0u32;
+    let rc = mk_service_lookup(name.as_ptr(), name.len(), &mut port, &mut pid);
+    if rc < 0 || pid == 0 {
+        None
+    } else {
+        Some(pid)
+    }
+}
+
+fn is_trusted_setter(sender_pid: u32) -> bool {
+    SETTERS.iter().any(|name| lookup_pid(name) == Some(sender_pid))
+}
+
 pub fn handle(ctx: &mut Context, sender_pid: u32, req: &Request, body: &[u8], tx: &mut [u8]) {
+    if !is_trusted_setter(sender_pid) {
+        let _ = respond::status(sender_pid, req, E_ACCES, tx);
+        return;
+    }
     if body.len() == SET_WALLPAPER_REQ_LEN {
         let Some(argb) = read_u32(body, 0) else {
             let _ = respond::status(sender_pid, req, E_INVAL, tx);


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across the kernel and userland, focusing on security, correctness, and code quality. The most significant changes are enhanced memory wiping for cryptographic secrets, stricter parameter validation in cryptographic operations, improved IPC reply handling in userland services, and better validation of GPU buffer ownership.

**Security and Cryptography Improvements:**

* Added a secure `wipe` utility in `userland/capsule_crypto/src/server/wipe.rs` to zero sensitive memory after use; integrated wiping of private keys and buffers in cryptographic operations to minimize secret leakage risk. [[1]](diffhunk://#diff-83cef6bf5ea317f51f20456457e79ac59d243d22c52b8fa4ca9f215f0851d77fR1-R24) [[2]](diffhunk://#diff-b81e02eb9367ca6adc3ca1412ec5178605c3fd00f13e45845255cce231dac240R21) [[3]](diffhunk://#diff-b81e02eb9367ca6adc3ca1412ec5178605c3fd00f13e45845255cce231dac240L33-R36) [[4]](diffhunk://#diff-0693e2f38efd13ce2cd6efe0f2ab08299dcfa6205052fd8704f3808775a41a46R20) [[5]](diffhunk://#diff-d00504724745b64111cf074acc0f522190e64b57838ba2a500639632e3400a9aR22) [[6]](diffhunk://#diff-d00504724745b64111cf074acc0f522190e64b57838ba2a500639632e3400a9aR42)
* Enforced degenerate nonce checks in AEAD seal handlers, rejecting requests with all-zero nonces for `aes256-gcm` and `chacha20-poly1305` to prevent nonce reuse vulnerabilities. [[1]](diffhunk://#diff-febf8031d7607194313fc5ed3faeebab9e27faf32b8617b516b176de25c3e0ebL22-R22) [[2]](diffhunk://#diff-97919ad834aa847acc8d089df16c3ebe772cb7f3a71b9dd64e92e6028bbc767aR29-R36) [[3]](diffhunk://#diff-255bff7d8336b1a0842d23d2dfb482b811288ca6bc729d5107c4deff4e4fe83cL22-R22) [[4]](diffhunk://#diff-255bff7d8336b1a0842d23d2dfb482b811288ca6bc729d5107c4deff4e4fe83cR41-R43) [[5]](diffhunk://#diff-195cccc8c26c9aacbec944d40460ee3bf8d9e64532cf0e36fc651de77ad0fcd1L22-R22) [[6]](diffhunk://#diff-195cccc8c26c9aacbec944d40460ee3bf8d9e64532cf0e36fc651de77ad0fcd1R47-R55)
* Updated `x25519-dalek` dependency to enable the `zeroize` feature, ensuring ephemeral secrets are securely erased.

**IPC and Service Handling:**

* Migrated clipboard and attest capsule servers to use `mk_ipc_recv_from` and `mk_ipc_reply` for explicit sender tracking and proper reply semantics, replacing the previous `mk_ipc_recv`/`mk_ipc_send` pattern. [[1]](diffhunk://#diff-39f53ad945c903adfbd3c875802e592117f77849f4ba7ed17c59b2928cfb51fdL19-R19) [[2]](diffhunk://#diff-39f53ad945c903adfbd3c875802e592117f77849f4ba7ed17c59b2928cfb51fdL31-R45) [[3]](diffhunk://#diff-55fbb6df8f1475ec99fb6852ccc8ed1a312029c90612adf2851f000b16f9286aL18-R18) [[4]](diffhunk://#diff-55fbb6df8f1475ec99fb6852ccc8ed1a312029c90612adf2851f000b16f9286aL34-R50)
* Improved error handling in IPC receive loops by checking for valid sender PIDs. [[1]](diffhunk://#diff-39f53ad945c903adfbd3c875802e592117f77849f4ba7ed17c59b2928cfb51fdL31-R45) [[2]](diffhunk://#diff-55fbb6df8f1475ec99fb6852ccc8ed1a312029c90612adf2851f000b16f9286aL34-R50)

**GPU Driver Robustness:**

* Added strict validation in the GPU driver's `attach_backing` handler to ensure the requested buffer is within the bounds of the surface's owned memory, preventing out-of-bounds DMA. [[1]](diffhunk://#diff-42df30ca4170d9011944a90f7acd9ec2960d493da237c2058b29af54f21729feR49-R52) [[2]](diffhunk://#diff-42df30ca4170d9011944a90f7acd9ec2960d493da237c2058b29af54f21729feR72-R83) [[3]](diffhunk://#diff-54c2051bc24fb3f811dc1f5be157bcd9fd139b36376b8d2a2acf84ce42ddb6fdR70-R71) [[4]](diffhunk://#diff-a3cd1cd89d08f06133f36aaf1e3c11a81947e2f83e09f18caf0a442d878c0720R23-R24)

**Kernel and Init Process Improvements:**

* Refined process scheduler to maintain separate last-scheduled PID tracking per priority band, improving fairness and predictability in process selection. [[1]](diffhunk://#diff-1dececfcc677ef94c7e40f32cd85cc17761b1e432a5743aab48091f07539dcb6R23-R25) [[2]](diffhunk://#diff-1dececfcc677ef94c7e40f32cd85cc17761b1e432a5743aab48091f07539dcb6L68-R78)
* Adjusted init process startup order to ensure the RAMFS smoketest runs after spawning the RAMFS, preventing race conditions.

**Other Notable Changes:**

* Updated dependencies and test harnesses to reflect new capsule requirements in the RAMFS smoketest. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L175-R175) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R583)
* Minor documentation and code organization improvements, including clarifying comments and reordering logic for clarity. [[1]](diffhunk://#diff-4e6eacf711e7f85e874093a7853179a784ed9f427996304183e08fab5bc09d97L17-L27) [[2]](diffhunk://#diff-97fdc7120cbc6ee0cb5a04bc5868cf31eee7471064a816ff87b711ef4c01af35L54-R70)

These changes collectively improve the security, reliability, and maintainability of the system.