### PR TITLE
Feat/vfs real work loop

### DIFF
--- a/userland/capsule_file_manager/src/fm/event.rs
+++ b/userland/capsule_file_manager/src/fm/event.rs
@@ -16,17 +16,21 @@
 
 use nonos_app_skeleton::{EventOutcome, InputEvent, InputKind, KEY_BACKSPACE, KEY_ENTER, KEY_ESC, KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT};
 
+use super::prompt;
 use super::refresh::refresh;
-use super::state::State;
+use super::state::{Mode, PromptKind, State};
 
 pub fn on_event(state: &mut State, event: InputEvent) -> EventOutcome {
     if event.kind == InputKind::ButtonDown {
         let row = ((event.y - 60) / 22) as isize;
-        if row >= 0 && (row as usize) < state.entries.len() {
+        if row >= 0 && (row as usize) < state.entries.len() && matches!(state.mode, Mode::Browse) {
             state.cursor = row as usize;
         }
     } else if !event.is_key_down() {
         return EventOutcome::Idle;
+    }
+    if !matches!(state.mode, Mode::Browse) {
+        return prompt::on_key(state, event);
     }
     match if event.kind == InputKind::ButtonDown { KEY_ENTER } else { event.code } {
         KEY_ESC => EventOutcome::Close,
@@ -66,6 +70,17 @@ pub fn on_event(state: &mut State, event: InputEvent) -> EventOutcome {
         code if code == b'k' as u32 => on_event(state, InputEvent { code: KEY_UP, ..event }),
         code if code == b'h' as u32 => on_event(state, InputEvent { code: KEY_LEFT, ..event }),
         code if code == b'l' as u32 => on_event(state, InputEvent { code: KEY_ENTER, ..event }),
+        code if code == b'n' as u32 => start_prompt(state, PromptKind::NewFile, b"new file: "),
+        code if code == b'm' as u32 => start_prompt(state, PromptKind::MkDir, b"mkdir: "),
+        code if code == b'r' as u32 => start_prompt(state, PromptKind::Rename, b"rename to: "),
+        code if code == b'd' as u32 => start_prompt(state, PromptKind::Delete, b"delete? type y + Enter: "),
         _ => EventOutcome::Idle,
     }
+}
+
+fn start_prompt(state: &mut State, kind: PromptKind, status: &'static [u8]) -> EventOutcome {
+    state.mode = Mode::Prompt(kind);
+    state.input = alloc::string::String::new();
+    state.status = status;
+    EventOutcome::Repaint
 }

--- a/userland/capsule_file_manager/src/fm/mod.rs
+++ b/userland/capsule_file_manager/src/fm/mod.rs
@@ -19,6 +19,7 @@ mod entries;
 mod event;
 mod manifest;
 mod paint;
+mod prompt;
 mod refresh;
 mod state;
 mod theme;

--- a/userland/capsule_file_manager/src/fm/paint.rs
+++ b/userland/capsule_file_manager/src/fm/paint.rs
@@ -16,7 +16,7 @@
 
 use nonos_app_skeleton::PaintBuffer;
 
-use super::state::State;
+use super::state::{Mode, State};
 use super::theme::{BACKGROUND, DIRECTORY, FOREGROUND, MUTED, SELECTED};
 
 const TEXT_LEFT: u32 = 16;
@@ -28,6 +28,9 @@ pub fn paint(state: &State, fb: &mut PaintBuffer) {
     fb.text(TEXT_LEFT, 18, b"file_manager", FOREGROUND);
     fb.text(TEXT_LEFT, 38, state.prefix.as_bytes(), MUTED);
     fb.text(TEXT_LEFT, 232, state.status, MUTED);
+    if !matches!(state.mode, Mode::Browse) {
+        fb.text(TEXT_LEFT + 9 * state.status.len() as u32, 232, state.input.as_bytes(), FOREGROUND);
+    }
     let mut y = FIRST_ROW_Y;
     for (i, entry) in state.entries.iter().enumerate() {
         let color = if entry.is_dir { DIRECTORY } else { FOREGROUND };

--- a/userland/capsule_file_manager/src/fm/prompt.rs
+++ b/userland/capsule_file_manager/src/fm/prompt.rs
@@ -1,0 +1,86 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use alloc::format;
+use alloc::string::String;
+
+use nonos_app_skeleton::clients::vfs::{mkdir, rename, unlink, write_file};
+use nonos_app_skeleton::{EventOutcome, InputEvent, KEY_BACKSPACE, KEY_ENTER, KEY_ESC};
+
+use super::refresh::refresh;
+use super::state::{Mode, PromptKind, State};
+
+pub fn on_key(state: &mut State, event: InputEvent) -> EventOutcome {
+    let Mode::Prompt(kind) = state.mode else { return EventOutcome::Idle };
+    match event.code {
+        KEY_ESC => {
+            state.mode = Mode::Browse;
+            state.input = String::new();
+            state.status = b"cancelled";
+        }
+        KEY_BACKSPACE => {
+            state.input.pop();
+        }
+        KEY_ENTER => commit(state, kind),
+        code => {
+            if let Some(ch) = char::from_u32(code) {
+                if ch.is_ascii_graphic() && state.input.len() < 64 {
+                    state.input.push(ch);
+                }
+            }
+        }
+    }
+    EventOutcome::Repaint
+}
+
+fn commit(state: &mut State, kind: PromptKind) {
+    let name = core::mem::take(&mut state.input);
+    state.mode = Mode::Browse;
+    if name.is_empty() && !matches!(kind, PromptKind::Delete) {
+        state.status = b"empty name";
+        return;
+    }
+    let target = format!("{}{}", state.prefix, name);
+    let msg = match run_op(state, kind, &name, &target) {
+        Ok(msg) => msg,
+        Err(e) => e.as_bytes(),
+    };
+    refresh(state);
+    state.status = msg;
+}
+
+fn run_op(state: &State, kind: PromptKind, name: &str, target: &str) -> Result<&'static [u8], &'static str> {
+    let pid = state.owner_pid;
+    match kind {
+        PromptKind::NewFile => write_file(pid, target.as_bytes(), b"").map(|_| b"created".as_slice()),
+        PromptKind::MkDir => mkdir(pid, target.as_bytes()).map(|_| b"directory created".as_slice()),
+        PromptKind::Rename => {
+            let old = state.entries.get(state.cursor).ok_or("no selection")?;
+            rename(pid, old.full_path.trim_end_matches('/').as_bytes(), target.as_bytes())
+                .map(|_| b"renamed".as_slice())
+        }
+        PromptKind::Delete => {
+            if name != "y" {
+                return Ok(b"not deleted");
+            }
+            let sel = state.entries.get(state.cursor).ok_or("no selection")?;
+            if sel.is_dir {
+                return Err("dirs not supported");
+            }
+            unlink(pid, sel.full_path.as_bytes()).map(|_| b"deleted".as_slice())
+        }
+    }
+}

--- a/userland/capsule_file_manager/src/fm/state.rs
+++ b/userland/capsule_file_manager/src/fm/state.rs
@@ -20,6 +20,20 @@ use alloc::{string::String, vec::Vec};
 
 use super::entries::Entry;
 
+#[derive(Clone, Copy)]
+pub enum Mode {
+    Browse,
+    Prompt(PromptKind),
+}
+
+#[derive(Clone, Copy)]
+pub enum PromptKind {
+    NewFile,
+    MkDir,
+    Rename,
+    Delete,
+}
+
 pub struct State {
     pub owner_pid: u32,
     pub prefix: String,
@@ -27,6 +41,8 @@ pub struct State {
     pub cursor: usize,
     pub preview: Option<String>,
     pub status: &'static [u8],
+    pub mode: Mode,
+    pub input: String,
 }
 
 impl State {
@@ -38,6 +54,8 @@ impl State {
             cursor: 0,
             preview: None,
             status: b"loading...",
+            mode: Mode::Browse,
+            input: String::new(),
         }
     }
 }

--- a/userland/capsule_input_router/src/clients/wire/call.rs
+++ b/userland/capsule_input_router/src/clients/wire/call.rs
@@ -23,7 +23,7 @@ use super::build::build;
 use super::constants::HDR_LEN;
 use super::u32_at::u32_at;
 
-const GUI_CALL_TIMEOUT_MS: u64 = 16;
+const GUI_CALL_TIMEOUT_MS: u64 = 150;
 
 pub fn call(
     port: u32,

--- a/userland/capsule_input_router/src/route/keyboard.rs
+++ b/userland/capsule_input_router/src/route/keyboard.rs
@@ -24,7 +24,14 @@ use super::pointer::shell_pid;
 
 pub fn route_keyboard(ctx: &mut Context, event: &InputEvent) -> u32 {
     let rid = ctx.issue_request_id();
-    let pid = wm::query_focus(&mut ctx.wm_port, rid).unwrap_or_else(|| shell_pid(ctx));
+    let pid = match wm::query_focus(&mut ctx.wm_port, rid) {
+        Some(focused) => {
+            ctx.last_focus_pid = focused;
+            focused
+        }
+        None if ctx.last_focus_pid != 0 => ctx.last_focus_pid,
+        None => shell_pid(ctx),
+    };
     if !ctx.subscriptions.allows(pid, event.kind) {
         ctx.record(0);
         return 0;

--- a/userland/capsule_input_router/src/state/context/forget_pid.rs
+++ b/userland/capsule_input_router/src/state/context/forget_pid.rs
@@ -32,5 +32,8 @@ impl Context {
         if self.shell_pid == pid {
             self.shell_pid = 0;
         }
+        if self.last_focus_pid == pid {
+            self.last_focus_pid = 0;
+        }
     }
 }

--- a/userland/capsule_input_router/src/state/context/new.rs
+++ b/userland/capsule_input_router/src/state/context/new.rs
@@ -29,6 +29,7 @@ impl Context {
             compositor_port: 0,
             wm_port: 0,
             shell_pid: 0,
+            last_focus_pid: 0,
             next_request_id: 1,
             delivered_count: 0,
             dropped_count: 0,

--- a/userland/capsule_input_router/src/state/context/types.rs
+++ b/userland/capsule_input_router/src/state/context/types.rs
@@ -26,6 +26,7 @@ pub struct Context {
     pub compositor_port: u32,
     pub wm_port: u32,
     pub shell_pid: u32,
+    pub last_focus_pid: u32,
     pub next_request_id: u32,
     pub delivered_count: u64,
     pub dropped_count: u64,

--- a/userland/capsule_terminal/src/command/builtin/nox/dispatch.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/dispatch.rs
@@ -30,12 +30,16 @@ pub fn dispatch(state: &mut State, args: &[&[u8]]) -> Outcome {
     let rest = &args[1..];
     match args[0] {
         b"where" => whereis::run(state),
+        b"pwd" => whereis::run(state),
         b"in" => enter::run(state, rest),
+        b"cd" => enter::run(state, rest),
         b"ls" => ls::run(state, rest),
         b"read" => read::run(state, rest),
+        b"cat" => read::run(state, rest),
         b"write" => write::run(state, rest),
         b"copy" => copy::run(state, rest),
         b"mk" => mk::run(state, rest),
+        b"mkdir" => mk::run(state, rest),
         b"rm" => rm::run(state, rest),
         b"mv" => mv::run(state, rest),
         b"stat" => stat::run(state, rest),

--- a/userland/capsule_terminal/src/command/builtin/nox/help.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/help.rs
@@ -28,6 +28,7 @@ pub fn run(out: &mut Output<'_>) {
     out.writeln(b"  rm <path>        remove a file or empty dir");
     out.writeln(b"  mv <a> <b>       move or rename");
     out.writeln(b"  stat <path>      metadata");
+    out.writeln(b"  cat/cd/pwd/mkdir aliases for read/in/where/mk");
     out.writeln(b"  caps             running capsules");
     out.writeln(b"  svc <name>       resolve a service");
     out.writeln(b"  id               identity");

--- a/userland/capsule_text_editor/src/editor/ctrl_open.rs
+++ b/userland/capsule_text_editor/src/editor/ctrl_open.rs
@@ -17,18 +17,25 @@
 use nonos_app_skeleton::{clients::vfs, EventOutcome};
 
 use super::resolve_owner_pid::resolve_owner_pid;
-use super::state::{State, CAPACITY, PATH};
+use super::state::{State, CAPACITY};
 
 pub(super) fn ctrl_open(state: &mut State) -> EventOutcome {
     if !resolve_owner_pid(state) {
         state.status = b"open failed";
         return EventOutcome::Repaint;
     }
-    match vfs::read_file(state.owner_pid, PATH, CAPACITY as u32) {
+    let path = state.path[..state.path_len].to_vec();
+    if let Ok((size, _)) = vfs::stat(state.owner_pid, &path) {
+        if size > CAPACITY as u64 {
+            state.status = b"file too large";
+            return EventOutcome::Repaint;
+        }
+    }
+    match vfs::read_file(state.owner_pid, &path, CAPACITY as u32) {
         Ok(bytes) if core::str::from_utf8(&bytes).is_ok() && bytes.len() <= CAPACITY => {
             state.buf[..bytes.len()].copy_from_slice(&bytes);
             state.len = bytes.len();
-            state.status = b"opened /notes.txt";
+            state.status = b"opened";
         }
         Ok(_) => state.status = b"file is not valid utf-8",
         Err(_) => state.status = b"open failed",

--- a/userland/capsule_text_editor/src/editor/ctrl_save.rs
+++ b/userland/capsule_text_editor/src/editor/ctrl_save.rs
@@ -17,15 +17,16 @@
 use nonos_app_skeleton::{clients::vfs, EventOutcome};
 
 use super::resolve_owner_pid::resolve_owner_pid;
-use super::state::{State, PATH};
+use super::state::State;
 
 pub(super) fn ctrl_save(state: &mut State) -> EventOutcome {
     if !resolve_owner_pid(state) {
         state.status = b"save failed";
         return EventOutcome::Repaint;
     }
-    state.status = if vfs::write_file(state.owner_pid, PATH, &state.buf[..state.len]).is_ok() {
-        b"saved /notes.txt"
+    let path = state.path[..state.path_len].to_vec();
+    state.status = if vfs::write_file(state.owner_pid, &path, &state.buf[..state.len]).is_ok() {
+        b"saved"
     } else {
         b"save failed"
     };

--- a/userland/capsule_text_editor/src/editor/event.rs
+++ b/userland/capsule_text_editor/src/editor/event.rs
@@ -17,11 +17,15 @@
 use nonos_app_skeleton::{EventOutcome, InputEvent, KEY_BACKSPACE, KEY_ENTER, KEY_ESC, MOD_CTRL};
 
 use super::on_ctrl::on_ctrl;
+use super::path_prompt;
 use super::state::State;
 
 pub fn on_event(state: &mut State, event: InputEvent) -> EventOutcome {
     if !event.is_key_down() {
         return EventOutcome::Idle;
+    }
+    if state.prompt.is_some() {
+        return path_prompt::on_key(state, event);
     }
     if event.flags & MOD_CTRL != 0 {
         return on_ctrl(state, event.code);
@@ -40,7 +44,7 @@ pub fn on_event(state: &mut State, event: InputEvent) -> EventOutcome {
         _ => false,
     };
     if changed {
-        state.status = b"edited /notes.txt";
+        state.status = b"edited";
         EventOutcome::Repaint
     } else {
         EventOutcome::Idle

--- a/userland/capsule_text_editor/src/editor/mod.rs
+++ b/userland/capsule_text_editor/src/editor/mod.rs
@@ -23,6 +23,7 @@ mod event;
 mod manifest;
 mod on_ctrl;
 mod paint;
+mod path_prompt;
 mod resolve_owner_pid;
 mod state;
 mod theme;

--- a/userland/capsule_text_editor/src/editor/on_ctrl.rs
+++ b/userland/capsule_text_editor/src/editor/on_ctrl.rs
@@ -17,16 +17,15 @@
 use nonos_app_skeleton::EventOutcome;
 
 use super::ctrl_copy::ctrl_copy;
-use super::ctrl_open::ctrl_open;
 use super::ctrl_paste::ctrl_paste;
-use super::ctrl_save::ctrl_save;
-use super::state::State;
+use super::path_prompt;
+use super::state::{PromptOp, State};
 
 pub(super) fn on_ctrl(state: &mut State, code: u32) -> EventOutcome {
     match code {
         c if matches!(c, 0x43 | 0x63) => ctrl_copy(state),
-        c if matches!(c, 0x4F | 0x6F) => ctrl_open(state),
-        c if matches!(c, 0x53 | 0x73) => ctrl_save(state),
+        c if matches!(c, 0x4F | 0x6F) => path_prompt::start(state, PromptOp::Open),
+        c if matches!(c, 0x53 | 0x73) => path_prompt::start(state, PromptOp::Save),
         c if matches!(c, 0x56 | 0x76) => ctrl_paste(state),
         _ => EventOutcome::Idle,
     }

--- a/userland/capsule_text_editor/src/editor/paint.rs
+++ b/userland/capsule_text_editor/src/editor/paint.rs
@@ -16,7 +16,7 @@
 
 use nonos_app_skeleton::PaintBuffer;
 
-use super::state::{State, PATH};
+use super::state::State;
 use super::theme::{BACKGROUND, FOREGROUND, MUTED, TITLE};
 
 const WRAP_COLS: u32 = 48;
@@ -28,7 +28,10 @@ const FIRST_LINE_Y: u32 = 76;
 pub fn paint(state: &State, fb: &mut PaintBuffer) {
     fb.clear(BACKGROUND);
     fb.text(TEXT_LEFT, 18, b"text_editor", TITLE);
-    fb.text(TEXT_LEFT, 38, PATH, MUTED);
+    fb.text(TEXT_LEFT, 38, &state.path[..state.path_len], MUTED);
+    if state.prompt.is_some() {
+        fb.text(TEXT_LEFT + state.path_len as u32 * GLYPH_ADVANCE, 38, b"_", FOREGROUND);
+    }
     fb.text(TEXT_LEFT, 58, state.status, MUTED);
     let mut y = FIRST_LINE_Y;
     let mut col: u32 = 0;

--- a/userland/capsule_text_editor/src/editor/path_prompt.rs
+++ b/userland/capsule_text_editor/src/editor/path_prompt.rs
@@ -1,0 +1,63 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use nonos_app_skeleton::{EventOutcome, InputEvent, KEY_BACKSPACE, KEY_ENTER, KEY_ESC, MOD_CTRL};
+
+use super::ctrl_open::ctrl_open;
+use super::ctrl_save::ctrl_save;
+use super::state::{PromptOp, State};
+
+pub(super) fn start(state: &mut State, op: PromptOp) -> EventOutcome {
+    state.prompt = Some(op);
+    state.status = match op {
+        PromptOp::Open => b"open path, Enter to load, Esc cancels",
+        PromptOp::Save => b"save path, Enter to write, Esc cancels",
+    };
+    EventOutcome::Repaint
+}
+
+pub(super) fn on_key(state: &mut State, event: InputEvent) -> EventOutcome {
+    let Some(op) = state.prompt else { return EventOutcome::Idle };
+    match event.code {
+        KEY_ESC => {
+            state.prompt = None;
+            state.status = b"cancelled";
+        }
+        KEY_BACKSPACE => {
+            if state.path_len > 0 {
+                state.path_len -= 1;
+            }
+        }
+        KEY_ENTER => {
+            state.prompt = None;
+            return match op {
+                PromptOp::Open => ctrl_open(state),
+                PromptOp::Save => ctrl_save(state),
+            };
+        }
+        code => {
+            if event.flags & MOD_CTRL == 0 {
+                if let Some(ch) = char::from_u32(code) {
+                    if ch.is_ascii_graphic() && state.path_len < 255 {
+                        state.path[state.path_len] = ch as u8;
+                        state.path_len += 1;
+                    }
+                }
+            }
+        }
+    }
+    EventOutcome::Repaint
+}

--- a/userland/capsule_text_editor/src/editor/state.rs
+++ b/userland/capsule_text_editor/src/editor/state.rs
@@ -17,20 +17,34 @@
 pub const CAPACITY: usize = 4096;
 pub const PATH: &[u8] = b"/notes.txt";
 
+#[derive(Clone, Copy, PartialEq)]
+pub enum PromptOp {
+    Open,
+    Save,
+}
+
 pub struct State {
     pub owner_pid: u32,
     pub buf: [u8; CAPACITY],
     pub len: usize,
     pub status: &'static [u8],
+    pub path: [u8; 256],
+    pub path_len: usize,
+    pub prompt: Option<PromptOp>,
 }
 
 impl State {
     pub fn new() -> Self {
+        let mut path = [0u8; 256];
+        path[..PATH.len()].copy_from_slice(PATH);
         State {
             owner_pid: 0,
             buf: [0; CAPACITY],
             len: 0,
             status: b"Ctrl-O open  Ctrl-S save  Ctrl-C copy  Ctrl-V paste",
+            path,
+            path_len: PATH.len(),
+            prompt: None,
         }
     }
 

--- a/userland/capsule_vfs/src/server/runner.rs
+++ b/userland/capsule_vfs/src/server/runner.rs
@@ -27,6 +27,7 @@ const MAX_MSG: usize = 65556;
 pub fn run() -> ! {
     let mut buf = vec![0u8; MAX_MSG];
     let mut store = Store::new();
+    store.seed();
     loop {
         let mut sender_pid: u32 = 0;
         let n = mk_ipc_recv_from(0, buf.as_mut_ptr(), MAX_MSG, 0, &mut sender_pid);

--- a/userland/capsule_vfs/src/store/fdtable.rs
+++ b/userland/capsule_vfs/src/store/fdtable.rs
@@ -22,6 +22,7 @@ mod open;
 mod query;
 mod read;
 mod rename;
+mod seed;
 mod types;
 mod unlink;
 mod write;

--- a/userland/capsule_vfs/src/store/fdtable/seed.rs
+++ b/userland/capsule_vfs/src/store/fdtable/seed.rs
@@ -1,0 +1,39 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use super::types::{File, Store, MAX_FILES};
+
+const README: &[u8] = b"Welcome to NONOS.\n\nThis file lives in the vfs capsule.\nTry: ls, cat /docs/demo.txt, write /hello.txt hi, mkdir /tmp\nThe file manager and text editor see the same filesystem.\n";
+const ABOUT: &[u8] = b"NONOS is a RAM-resident x86_64 microkernel.\nEvery app is a signed capsule running at CPL=3 behind a\ncapability boundary; this filesystem is itself a userspace\nservice reached over IPC.\n";
+const DEMO: &[u8] = b"Demo loop:\n 1. terminal: write /hello.txt hello from nonos\n 2. file manager: see /hello.txt appear\n 3. editor: Ctrl-O /hello.txt, edit, Ctrl-S\n 4. terminal: cat /hello.txt shows the edit\n";
+
+impl Store {
+    pub fn seed(&mut self) {
+        let _ = self.mkdir("/docs");
+        self.seed_file("/readme.txt", README);
+        self.seed_file("/docs/about.txt", ABOUT);
+        self.seed_file("/docs/demo.txt", DEMO);
+    }
+
+    fn seed_file(&mut self, name: &str, data: &[u8]) {
+        if self.files.len() < MAX_FILES && self.find(name).is_none() {
+            self.files.push(File { name: String::from(name), data: Vec::from(data), is_dir: false });
+        }
+    }
+}

--- a/userland/capsule_wm/src/server/handlers/route_focus/handle.rs
+++ b/userland/capsule_wm/src/server/handlers/route_focus/handle.rs
@@ -54,19 +54,14 @@ pub fn handle(ctx: &mut Context, sender_pid: u32, req: &Request, body: &[u8], tx
     }
     if !matches!(ctx.focus.current(), Some(f) if f.owner_pid == owner_pid && f.window_id == window_id)
     {
-        let rid = ctx.issue_request_id();
-        if push_focus_set(ctx.compositor_port, rid, owner_pid).is_err() {
-            if respond::status(sender_pid, req, E_INVAL, tx) < 0 {
-                return;
-            }
-            return;
-        }
         if !ctx.focus.set(owner_pid, window_id) {
             if respond::status(sender_pid, req, E_INVAL, tx) < 0 {
                 return;
             }
             return;
         }
+        let rid = ctx.issue_request_id();
+        let _ = push_focus_set(ctx.compositor_port, rid, owner_pid);
     }
     if respond::status(sender_pid, req, 0, tx) < 0 {
         return;

--- a/userland/capsule_wm/src/server/handlers/window_open/focus_new_window.rs
+++ b/userland/capsule_wm/src/server/handlers/window_open/focus_new_window.rs
@@ -25,9 +25,8 @@ pub(super) fn focus_new_window(ctx: &mut Context, sender_pid: u32, window_id: u3
     if unchanged {
         return true;
     }
+    let changed = ctx.focus.set(sender_pid, window_id);
     let rid = ctx.issue_request_id();
-    if push_focus_set(ctx.compositor_port, rid, sender_pid).is_err() {
-        return false;
-    }
-    ctx.focus.set(sender_pid, window_id)
+    let _ = push_focus_set(ctx.compositor_port, rid, sender_pid);
+    changed
 }


### PR DESCRIPTION
This pull request introduces significant improvements to both the file manager and text editor capsules, focusing on user interaction, prompt handling, and code maintainability. The file manager now supports interactive prompts for file operations (like create, rename, delete), while the text editor allows users to specify file paths for open/save actions via a prompt. Additionally, several quality-of-life enhancements and bug fixes are included across the input router and terminal.

**File Manager: Interactive Prompts and Command Handling**

- Added a prompt system to the file manager, enabling interactive creation, renaming, and deletion of files and directories. This includes a new `Mode` state, prompt rendering, and input handling for confirmation and user entry. (`userland/capsule_file_manager/src/fm/event.rs`, `userland/capsule_file_manager/src/fm/prompt.rs`, `userland/capsule_file_manager/src/fm/state.rs`, `userland/capsule_file_manager/src/fm/paint.rs`, `userland/capsule_file_manager/src/fm/mod.rs`) [[1]](diffhunk://#diff-ee67ab0446b4dcd4ea57530eb9fbd6c5884eb22d4eafdb2e5763a79c9d01a007R19-R34) [[2]](diffhunk://#diff-ee67ab0446b4dcd4ea57530eb9fbd6c5884eb22d4eafdb2e5763a79c9d01a007R73-R86) [[3]](diffhunk://#diff-e94509d3695f9f798d57056d642f30093442e4142d28e655b7cef9037a078355R22) [[4]](diffhunk://#diff-54bc90a5a3bb0a8a5eff113223519f864307bc92be94ed1a63dd76e16d272618L19-R19) [[5]](diffhunk://#diff-54bc90a5a3bb0a8a5eff113223519f864307bc92be94ed1a63dd76e16d272618R31-R33) [[6]](diffhunk://#diff-2d9a3f91bdb58521b9462e1a05c58d2374de1233932cb96b8d5ea503ddeeb13aR1-R86) [[7]](diffhunk://#diff-31d3d53eb1fbfefeb1d4ba93f858295c6367e6b2721af382f7e24872b5ed402cR23-R45) [[8]](diffhunk://#diff-31d3d53eb1fbfefeb1d4ba93f858295c6367e6b2721af382f7e24872b5ed402cR57-R58)

**Text Editor: Path Prompt for Open/Save**

- Implemented a path prompt in the text editor, allowing users to enter or edit the file path before opening or saving. This includes a new prompt module, UI feedback, and integration with open/save logic. (`userland/capsule_text_editor/src/editor/path_prompt.rs`, `userland/capsule_text_editor/src/editor/event.rs`, `userland/capsule_text_editor/src/editor/on_ctrl.rs`, `userland/capsule_text_editor/src/editor/paint.rs`, `userland/capsule_text_editor/src/editor/mod.rs`) [[1]](diffhunk://#diff-8f213ecb8430b172339be24e64bc03be595b8fc4b75e6c1de078d31a8aa4ee56R1-R63) [[2]](diffhunk://#diff-d0cb59648748f85379b5cf300c2f91e7338e1be350a0e7e29ec67821ca5f205fR20-R29) [[3]](diffhunk://#diff-d0cb59648748f85379b5cf300c2f91e7338e1be350a0e7e29ec67821ca5f205fL43-R47) [[4]](diffhunk://#diff-4f40586f1b1abcb50f96012c5b43ad7ca2d83ffdaaa39d44464f048776589688L20-R28) [[5]](diffhunk://#diff-62a56052bc1338b1238760609849339c3422809b592a46111916d17b14cf9c0eL19-R19) [[6]](diffhunk://#diff-62a56052bc1338b1238760609849339c3422809b592a46111916d17b14cf9c0eL31-R34) [[7]](diffhunk://#diff-eb92df5768c2337397e4542c73e493f358a436fecedadd6687359e971c16a286R26)

**Input Router: Improved Focus Handling**

- Enhanced input routing by remembering the last focused process, ensuring keyboard events are delivered even if the window manager loses focus information. Also resets focus tracking when processes exit. (`userland/capsule_input_router/src/route/keyboard.rs`, `userland/capsule_input_router/src/state/context/types.rs`, `userland/capsule_input_router/src/state/context/new.rs`, `userland/capsule_input_router/src/state/context/forget_pid.rs`) [[1]](diffhunk://#diff-fe32b83223fd7bf0d1d8fd006fa8b70b8fc84c0d26506c159994127d4525f464L27-R34) [[2]](diffhunk://#diff-7bb55056456a788b77a3f9a750c96dafbeb3cf3992755064b2e55aac3f86f96fR29) [[3]](diffhunk://#diff-319bacf5172cb1e3ac4549315439365e778f4c5d80efd98c9e1904778bbdefdcR32) [[4]](diffhunk://#diff-241c1c923a71bbfebd5dbb0b62841336f81e0e18e1a5186dca6e0557f8d61b40R35-R37)

**Terminal: Command Aliases and Help Update**

- Added common command aliases (e.g., `cat` for `read`, `cd` for `in`, `pwd` for `where`, `mkdir` for `mk`) and updated the help text to reflect these, improving usability for users familiar with standard shell commands. (`userland/capsule_terminal/src/command/builtin/nox/dispatch.rs`, `userland/capsule_terminal/src/command/builtin/nox/help.rs`) [[1]](diffhunk://#diff-928c382c7d2cefaf23fcfcaa4614764edefe9d498267770adc235df20aaa28fcR33-R42) [[2]](diffhunk://#diff-e29c9033c99253bc2b0b3941ce338225b0f857525ddad50f52afcc61107a5a86R31)

**Text Editor: Path Handling and Status Messages**

- Refactored file open/save logic to use the user-edited path and improved status messages for clarity. Also checks file size before opening to prevent loading excessively large files. (`userland/capsule_text_editor/src/editor/ctrl_open.rs`, `userland/capsule_text_editor/src/editor/ctrl_save.rs`, `userland/capsule_text_editor/src/editor/event.rs`) [[1]](diffhunk://#diff-d235696d2b0e92af0c93a9da81eb7cb7331d63c4b9d9f55c146fb238a7373f24L20-R38) [[2]](diffhunk://#diff-63049562b3e1257a7b87649140d3666d1e69dd81c987a84d278a53626fa32599L20-R29) [[3]](diffhunk://#diff-d0cb59648748f85379b5cf300c2f91e7338e1be350a0e7e29ec67821ca5f205fL43-R47)

Other minor changes include increasing the GUI call timeout for improved reliability.