### PR TITLE
build: boot QEMU at 1920x1080 so fullscreen fills the screen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ QEMU_SERIAL_LOG ?= $(TARGET_DIR)/qemu-serial.log
 QEMU_BLK_IMG := $(TARGET_DIR)/qemu-virtio-blk.img
 QEMU_OVMF_VARS_RW := $(TARGET_DIR)/qemu-OVMF_VARS.fd
 QEMU_BLK := -drive "file=$(QEMU_BLK_IMG),if=none,id=vd0,format=raw" -device virtio-blk-pci,drive=vd0
-QEMU_GPU := -device virtio-vga,disable-modern=on,vectors=0,xres=1024,yres=768
+QEMU_GPU := -device virtio-vga,disable-modern=on,vectors=0,xres=1920,yres=1080
 # Keyboard/mouse via the q35 i8042 (PS/2). USB HID interrupt-IN transfers
 # are not serviced under macOS hvf, so usb-kbd/usb-mouse never deliver input
 # there; the xHCI controller stays for the USB stack/storage paths.


### PR DESCRIPTION
The virtio-vga device advertised 1024x768, a 4:3 mode. Under the cocoa
zoom-to-fit display, the guest scaled to fit by height and pillarboxed the
sides, roughly three quarters of the width on a widescreen panel (the "3/4x
after fullscreen" report).

Advertise 1920x1080, which is 16:9 and within the bootloader GOP mode ceiling
(<= 1920x1080), so the compositor renders widescreen and the fullscreen image
fills. On a 16:10 panel a thin top and bottom bar remains; 1680x1050 would fill
it edge to edge if that is preferred later.

Dev/VM config only, no kernel or capsule code touched.