### PR TITLE
driver/virtio-gpu: clamp tiny host scanout modes up to 1080p

### DIFF
--- a/userland/capsule_driver_virtio_gpu/src/setup/scanouts.rs
+++ b/userland/capsule_driver_virtio_gpu/src/setup/scanouts.rs
@@ -17,8 +17,10 @@ use crate::constants::VG_MAX_SCANOUTS;
 use crate::device::cmd;
 use crate::device::virtqueue::ControlQueue;
 use crate::state::{FenceCounter, Scanout, ScanoutTable};
-const DEFAULT_SCANOUT_WIDTH: u32 = 1024;
-const DEFAULT_SCANOUT_HEIGHT: u32 = 768;
+const DEFAULT_SCANOUT_WIDTH: u32 = 1920;
+const DEFAULT_SCANOUT_HEIGHT: u32 = 1080;
+const MIN_SCANOUT_WIDTH: u32 = 1280;
+const MIN_SCANOUT_HEIGHT: u32 = 720;
 pub fn seed(
     q: &ControlQueue,
     table: &ScanoutTable,
@@ -31,13 +33,18 @@ pub fn seed(
         if s.enabled == 0 || s.width == 0 || s.height == 0 {
             continue;
         }
+        let (width, height) = if s.width < MIN_SCANOUT_WIDTH || s.height < MIN_SCANOUT_HEIGHT {
+            (DEFAULT_SCANOUT_WIDTH, DEFAULT_SCANOUT_HEIGHT)
+        } else {
+            (s.width, s.height)
+        };
         if !table.record(
             i as u32,
             Scanout {
                 x: s.x,
                 y: s.y,
-                width: s.width,
-                height: s.height,
+                width,
+                height,
                 current_resource_id: 0,
                 enabled: true,
             },


### PR DESCRIPTION
QEMU reports the primary scanout in its display-info rectangle, and on this
setup that comes back as small as 640x360. The driver seeded the compositor
with exactly that rectangle, so the desktop rendered into a fraction of the
screen regardless of the window size.

Treat any host-reported mode below 1280x720 as a bad hint and seed 1920x1080
instead. Larger host-reported modes are kept unchanged, so a real display that
advertises a sane size still wins.

This is the runtime display path; the desktop renders through virtio-gpu. It
complements the boot-time GOP resolution already set in the Makefile.

Built and clippy-checked, no new warnings.