### PR TITLE
nonos/runtime install

### DIFF
--- a/userland/capsule_installer/README.md
+++ b/userland/capsule_installer/README.md
@@ -3,48 +3,50 @@
 ## Role
 
 `capsule_installer` is the userland install authority. It runs as a CPL=3
-capsule and gates every capsule install on a verified payment receipt:
-a caller asks it to install a marketplace entry, the installer settles the
-charge through the payment capsule, checks the returned receipt, and only
-then admits the install. It owns no storage device; it is the policy point
-that binds payment to admission.
+capsule and gates paid install admission on a keyring-signed payment receipt.
+It can also ask the kernel to load a signed, attested capsule artifact set from
+the VFS store through the same verified spawn path used by baked capsules. It
+owns no storage device; it is the policy point that binds payment to admission
+and load.
 
 ```text
 marketplace client
         |
-        | OP_INSTALL (entry id)
+        | OP_INSTALL / OP_LOAD_FROM_STORE
         v
 capsule_installer -- OP_PAY --> capsule_payment -- sign --> keyring
         |
-        `-- admit install only on a verified receipt
+        `-- MkCapsuleLoad --> verified spawn from VFS artifacts
 ```
 
 ## Microkernel contract
 
 ```text
-CAPSULE_REQUIRED_CAPS = 0x18
+CAPSULE_REQUIRED_CAPS = 0x10019
 ```
 
 The capsule resolves the payment capsule with `MkServiceLookup`, drives
 settlement with `MkIpcCall`, serves callers with `MkIpcRecvFrom` plus
-`MkIpcSendToPid`, and terminates only through `MkExit`. It requests no
-hardware grants.
+`MkIpcSendToPid`, invokes `MkCapsuleLoad` for VFS-backed capsule artifacts, and
+terminates only through `MkExit`. It carries the `Driver` bit only because the
+current syscall contract gates `MkCapsuleLoad` as a driver-class authority.
 
 ## Interface contract
 
 | Operation | Input | Output |
 |---|---|---|
 | `OP_HEALTHCHECK` | none | liveness |
-| `OP_PAY` | entry id, publisher address | settlement result, receipt id |
-| `OP_INSTALL` | entry id, receipt id | install admitted or rejected |
+| `OP_INSTALL` | owner pid, wallet id, price kind, capsule id, publisher, amount, receipt type | free admission hash or signed payment receipt hash |
+| `OP_LOAD_FROM_STORE` | requested caps, artifact lengths, ELF/cert/manifest/ZK trailer bytes | spawned pid |
 
 Unknown operations reply `E_BAD_OP`. Malformed bodies reply `E_INVAL`.
 An install request without a verified receipt is refused.
 
 ## Authority
 
-The capsule may talk to the payment capsule over IPC. It has no PCI, MMIO,
-IRQ, DMA, PIO, network, display, or focus-routing authority.
+The capsule may talk to the payment capsule over IPC and may invoke
+`MkCapsuleLoad`. It has no PCI, MMIO, IRQ, DMA, PIO, network, display, or
+focus-routing authority.
 
 ## Privacy and persistence
 

--- a/userland/capsule_installer/src/protocol/mod.rs
+++ b/userland/capsule_installer/src/protocol/mod.rs
@@ -20,4 +20,6 @@ mod types;
 
 pub use decode::decode_request;
 pub use encode::encode_response;
-pub use types::{Request, EAGAIN, EINVAL, KERNEL_REPLY_ENDPOINT, OP_HEALTHCHECK, OP_INSTALL};
+pub use types::{
+    Request, EAGAIN, EINVAL, KERNEL_REPLY_ENDPOINT, OP_HEALTHCHECK, OP_INSTALL, OP_LOAD_FROM_STORE,
+};

--- a/userland/capsule_installer/src/protocol/types.rs
+++ b/userland/capsule_installer/src/protocol/types.rs
@@ -16,6 +16,7 @@
 
 pub const OP_HEALTHCHECK: u16 = 1;
 pub const OP_INSTALL: u16 = 2;
+pub const OP_LOAD_FROM_STORE: u16 = 3;
 
 pub const KERNEL_REPLY_ENDPOINT: u64 = 0x1_0000_0011;
 

--- a/userland/capsule_installer/src/server/dispatch.rs
+++ b/userland/capsule_installer/src/server/dispatch.rs
@@ -17,12 +17,15 @@
 use alloc::vec::Vec;
 
 use super::handlers;
-use crate::protocol::{encode_response, Request, EINVAL, OP_HEALTHCHECK, OP_INSTALL};
+use crate::protocol::{
+    encode_response, Request, EINVAL, OP_HEALTHCHECK, OP_INSTALL, OP_LOAD_FROM_STORE,
+};
 
 pub fn dispatch(req: Request<'_>) -> Vec<u8> {
     match req.op {
         OP_HEALTHCHECK => handlers::health(req),
         OP_INSTALL => handlers::install(req),
+        OP_LOAD_FROM_STORE => handlers::load_store(req),
         _ => encode_response(req.seq, EINVAL, &[]),
     }
 }

--- a/userland/capsule_installer/src/server/handlers/load_store.rs
+++ b/userland/capsule_installer/src/server/handlers/load_store.rs
@@ -1,0 +1,63 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use alloc::vec::Vec;
+
+use crate::protocol::{encode_response, Request, EINVAL};
+use nonos_libc::{mk_capsule_load, CapsuleLoadRequest};
+
+pub fn load_store(req: Request<'_>) -> Vec<u8> {
+    const HEAD_LEN: usize = 24;
+    if req.payload.len() < HEAD_LEN {
+        return encode_response(req.seq, EINVAL, &[]);
+    }
+    let p = req.payload;
+    let elf_len = u32::from_le_bytes([p[8], p[9], p[10], p[11]]) as usize;
+    let cert_len = u32::from_le_bytes([p[12], p[13], p[14], p[15]]) as usize;
+    let manifest_len = u32::from_le_bytes([p[16], p[17], p[18], p[19]]) as usize;
+    let trailer_len = u32::from_le_bytes([p[20], p[21], p[22], p[23]]) as usize;
+    let Some(after_elf) = HEAD_LEN.checked_add(elf_len) else {
+        return encode_response(req.seq, EINVAL, &[]);
+    };
+    let Some(after_cert) = after_elf.checked_add(cert_len) else {
+        return encode_response(req.seq, EINVAL, &[]);
+    };
+    let Some(after_manifest) = after_cert.checked_add(manifest_len) else {
+        return encode_response(req.seq, EINVAL, &[]);
+    };
+    let Some(total) = after_manifest.checked_add(trailer_len) else {
+        return encode_response(req.seq, EINVAL, &[]);
+    };
+    if p.len() != total {
+        return encode_response(req.seq, EINVAL, &[]);
+    }
+    let load = CapsuleLoadRequest {
+        elf_ptr: p[HEAD_LEN..after_elf].as_ptr() as u64,
+        cert_ptr: p[after_elf..after_cert].as_ptr() as u64,
+        manifest_ptr: p[after_cert..after_manifest].as_ptr() as u64,
+        trailer_ptr: p[after_manifest..total].as_ptr() as u64,
+        requested_caps: u64::from_le_bytes([p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]]),
+        elf_len: elf_len as u32,
+        cert_len: cert_len as u32,
+        manifest_len: manifest_len as u32,
+        trailer_len: trailer_len as u32,
+    };
+    let rc = mk_capsule_load(&load as *const CapsuleLoadRequest);
+    if rc < 0 {
+        return encode_response(req.seq, rc as i32, &[]);
+    }
+    encode_response(req.seq, 0, &(rc as u32).to_le_bytes())
+}

--- a/userland/capsule_installer/src/server/runner.rs
+++ b/userland/capsule_installer/src/server/runner.rs
@@ -21,7 +21,10 @@ use nonos_libc::{mk_ipc_recv, mk_ipc_send};
 use super::dispatch::dispatch;
 use crate::protocol::{decode_request, KERNEL_REPLY_ENDPOINT};
 
-const MAX_MSG: usize = 4096;
+// Large enough to receive an OP_LOAD_FROM_STORE request that inlines a
+// capsule's four artifacts (each bounded by the VFS read limit) plus the small
+// fixed header. Well under the 1 MiB kernel IPC message ceiling.
+const MAX_MSG: usize = 512 * 1024;
 
 pub fn run() -> ! {
     let mut buf = vec![0u8; MAX_MSG];

--- a/userland/capsule_terminal/src/command/builtin/nox/dispatch.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/dispatch.rs
@@ -15,8 +15,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::{
-    alias, apps, caps, clear, copy, display, echo, enter, help, history, id, ls, mk, motd, mv,
-    ping, read, rm, run, set, stat, svc, sysinfo, unalias, unknown, unset, whereis, write,
+    alias, apps, caps, clear, copy, display, echo, enter, help, history, id, install, ls, mk, motd,
+    mv, ping, read, rm, run, set, stat, svc, sysinfo, unalias, unknown, unset, whereis, write,
 };
 use crate::command::output::Output;
 use crate::command::Outcome;
@@ -73,6 +73,7 @@ pub fn dispatch(state: &mut State, args: &[&[u8]]) -> Outcome {
             true
         }
         b"run" | b"open" => run::run(state, rest),
+        b"install" => install::run(state, rest),
         b"set" => {
             set::run(state, rest);
             true

--- a/userland/capsule_terminal/src/command/builtin/nox/help.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/help.rs
@@ -34,6 +34,7 @@ pub fn run(out: &mut Output<'_>) {
     out.writeln(b"  sys              version and identity");
     out.writeln(b"  apps             marketplace catalog");
     out.writeln(b"  run (open) <app> launch an app: files editor settings calc about procs");
+    out.writeln(b"  install <name>   verify and load a capsule from /capsules/<name>.*");
     out.writeln(b"  set [name val]   list or define a variable (use as $name)");
     out.writeln(b"  unset <name>     remove a variable");
     out.writeln(b"  alias [n exp]    list or define a command alias");

--- a/userland/capsule_terminal/src/command/builtin/nox/install/artifacts.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/install/artifacts.rs
@@ -1,0 +1,47 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use alloc::vec::Vec;
+use nonos_app_skeleton::clients::vfs::read_file;
+
+const MAX: u32 = 65536;
+
+// The four artifact blobs of a capsule, read from the VFS store.
+pub(super) struct Artifacts {
+    pub elf: Vec<u8>,
+    pub cert: Vec<u8>,
+    pub manifest: Vec<u8>,
+    pub trailer: Vec<u8>,
+}
+
+// Read /capsules/<stem>.{elf,nonos_id_cert.bin,manifest.bin,zk_trailer.bin}
+// from the VFS using the caller's pid.
+pub(super) fn read_artifacts(pid: u32, stem: &[u8]) -> Result<Artifacts, &'static str> {
+    Ok(Artifacts {
+        elf: read_one(pid, stem, b".elf")?,
+        cert: read_one(pid, stem, b".nonos_id_cert.bin")?,
+        manifest: read_one(pid, stem, b".manifest.bin")?,
+        trailer: read_one(pid, stem, b".zk_trailer.bin")?,
+    })
+}
+
+fn read_one(pid: u32, stem: &[u8], ext: &[u8]) -> Result<Vec<u8>, &'static str> {
+    let mut path = Vec::with_capacity(10 + stem.len() + ext.len());
+    path.extend_from_slice(b"/capsules/");
+    path.extend_from_slice(stem);
+    path.extend_from_slice(ext);
+    read_file(pid, &path, MAX)
+}

--- a/userland/capsule_terminal/src/command/builtin/nox/install/call.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/install/call.rs
@@ -1,0 +1,60 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use alloc::vec::Vec;
+use nonos_app_skeleton::discover::lookup_service;
+use nonos_libc::mk_ipc_call;
+
+use super::artifacts::Artifacts;
+
+// Grant the loaded capsule its full declared optional caps. The verified
+// manifest and the identity certificate ceiling are the real bounds; this only
+// avoids restricting a capsule below what it legitimately declares.
+const REQUESTED_CAPS: u64 = u64::MAX;
+const EAGAIN: i32 = -11;
+
+// Ask the installer to load a capsule from the store. The four artifacts are
+// inlined behind a fixed header the installer forwards to the load syscall.
+// Returns the new pid, or a negative status.
+pub(super) fn call_installer(a: &Artifacts) -> Result<u32, i32> {
+    let port = lookup_service(b"installer").map(|p| p.port).ok_or(EAGAIN)?;
+    let payload = pack(a);
+    let mut rx = [0u8; 32];
+    let rc =
+        mk_ipc_call(port as u64, payload.as_ptr(), payload.len(), rx.as_mut_ptr(), rx.len());
+    if rc < 12 {
+        return Err(EAGAIN);
+    }
+    let status = i32::from_le_bytes([rx[4], rx[5], rx[6], rx[7]]);
+    if status != 0 {
+        return Err(status);
+    }
+    Ok(u32::from_le_bytes([rx[8], rx[9], rx[10], rx[11]]))
+}
+
+fn pack(a: &Artifacts) -> Vec<u8> {
+    let mut p = Vec::with_capacity(24 + a.elf.len() + a.cert.len() + a.manifest.len() + a.trailer.len());
+    p.extend_from_slice(&REQUESTED_CAPS.to_le_bytes());
+    p.extend_from_slice(&(a.elf.len() as u32).to_le_bytes());
+    p.extend_from_slice(&(a.cert.len() as u32).to_le_bytes());
+    p.extend_from_slice(&(a.manifest.len() as u32).to_le_bytes());
+    p.extend_from_slice(&(a.trailer.len() as u32).to_le_bytes());
+    p.extend_from_slice(&a.elf);
+    p.extend_from_slice(&a.cert);
+    p.extend_from_slice(&a.manifest);
+    p.extend_from_slice(&a.trailer);
+    p
+}

--- a/userland/capsule_terminal/src/command/builtin/nox/install/emit.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/install/emit.rs
@@ -1,0 +1,42 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use alloc::vec::Vec;
+
+use crate::term::state::State;
+use crate::term::util::format_u64;
+
+// Operator-grade success line: "loaded <name> as pid <n>".
+pub(super) fn emit_ok(state: &mut State, stem: &[u8], pid: u32) {
+    let mut num = [0u8; 24];
+    let k = format_u64(pid as u64, &mut num);
+    let mut line = Vec::with_capacity(18 + stem.len() + k);
+    line.extend_from_slice(b"loaded ");
+    line.extend_from_slice(stem);
+    line.extend_from_slice(b" as pid ");
+    line.extend_from_slice(&num[..k]);
+    state.scrollback.push_line(&line);
+}
+
+// Failure line: "install failed: <reason>" with the negative status.
+pub(super) fn emit_err(state: &mut State, status: i32) {
+    let mut num = [0u8; 24];
+    let k = format_u64((-status) as u64, &mut num);
+    let mut line = Vec::with_capacity(20 + k);
+    line.extend_from_slice(b"install failed: -");
+    line.extend_from_slice(&num[..k]);
+    state.scrollback.push_error(&line);
+}

--- a/userland/capsule_terminal/src/command/builtin/nox/install/mod.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/install/mod.rs
@@ -14,10 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-mod health;
-mod install;
-mod load_store;
+mod artifacts;
+mod call;
+mod emit;
+mod run;
 
-pub(super) use health::health;
-pub(super) use install::install;
-pub(super) use load_store::load_store;
+pub use run::run;

--- a/userland/capsule_terminal/src/command/builtin/nox/install/run.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/install/run.rs
@@ -1,0 +1,62 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::artifacts::read_artifacts;
+use super::call::call_installer;
+use super::emit::{emit_err, emit_ok};
+use super::super::ensure_pid::ensure_pid;
+use crate::term::state::State;
+
+// install <name>: read a capsule's artifacts from the store and ask the
+// installer to verify, load, and spawn it. The name selects
+// /capsules/<name>.* and must be a plain ascii token with no path separators.
+pub fn run(state: &mut State, args: &[&[u8]]) -> bool {
+    if args.is_empty() {
+        state.scrollback.push_error(b"usage: install <name>");
+        return false;
+    }
+    let stem = args[0];
+    if !valid_name(stem) {
+        state.scrollback.push_error(b"install: name must be ascii letters, digits, _ or -");
+        return false;
+    }
+    let pid = ensure_pid(state);
+    let artifacts = match read_artifacts(pid, stem) {
+        Ok(a) => a,
+        Err(e) => {
+            state.scrollback.push_error(e.as_bytes());
+            return false;
+        }
+    };
+    match call_installer(&artifacts) {
+        Ok(new_pid) => {
+            emit_ok(state, stem, new_pid);
+            true
+        }
+        Err(status) => {
+            emit_err(state, status);
+            false
+        }
+    }
+}
+
+fn valid_name(stem: &[u8]) -> bool {
+    !stem.is_empty()
+        && stem.len() <= 64
+        && stem
+            .iter()
+            .all(|&b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+}

--- a/userland/capsule_terminal/src/command/builtin/nox/mod.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/mod.rs
@@ -28,6 +28,7 @@ mod enter;
 mod help;
 mod history;
 mod id;
+mod install;
 mod ls;
 mod mk;
 mod motd;

--- a/userland/capsule_terminal/src/event/complete.rs
+++ b/userland/capsule_terminal/src/event/complete.rs
@@ -70,6 +70,7 @@ const COMMANDS: &[&[u8]] = &[
     b"sort",
     b"uniq",
     b"nl",
+    b"install",
 ];
 
 pub(super) fn command_candidates(prefix: &[u8]) -> Vec<&'static [u8]> {


### PR DESCRIPTION
The runtime install path on the userland side. The installer gains a load operation that forwards a capsule's artifacts to the load syscall and returns the new pid, and the terminal gains an install command that reads those artifacts from /capsules/<name>.* through the VFS and drives the installer. The name must be a plain ascii token with no path separators.