### PR TITLE
capsules: std_proof and gui_proof on nonos_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ sched = []
 # named capsule binary and arms the kernel-side spawner. Every name
 # below maps 1:1 to a capsule directory under `userland/`.
 nonos-capsule-proof-io          = []
+nonos-capsule-std-proof         = []
 nonos-capsule-ramfs             = []
 nonos-capsule-wallpaper         = []
 nonos-capsule-compositor        = []

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@
 .PHONY: nonos-mk-libc nonos-mk-proof-io nonos-mk-proof-io-sign nonos-mk-check-trust-keys nonos-mk-check-trust-manifest nonos-mk-trust-policy nonos-mk-host-trust-test nonos-mk-verify-trust nonos-mk-ramfs nonos-mk-ramfs-sign nonos-mk-keyring nonos-mk-entropy nonos-mk-crypto nonos-mk-vfs nonos-mk-virtio-rng nonos-mk-virtio-rng-sign nonos-mk-check-virtio-rng-keys nonos-mk-virtio-blk nonos-mk-virtio-blk-sign nonos-mk-check-virtio-blk-keys nonos-mk-driver-virtio-gpu nonos-mk-driver-virtio-gpu-sign nonos-mk-check-driver-virtio-gpu-keys nonos-mk-virtio-net nonos-mk-virtio-net-sign nonos-mk-check-virtio-net-keys nonos-mk-driver-iwlwifi nonos-mk-driver-iwlwifi-sign nonos-mk-check-driver-iwlwifi-keys nonos-mk-driver-i2c-pci nonos-mk-driver-i2c-pci-sign nonos-mk-check-driver-i2c-pci-keys nonos-mk-driver-i2c-hid nonos-mk-driver-i2c-hid-sign nonos-mk-check-driver-i2c-hid-keys nonos-mk-ps2-input nonos-mk-ps2-input-sign nonos-mk-check-ps2-input-keys nonos-mk-xhci nonos-mk-xhci-sign nonos-mk-check-xhci-keys nonos-mk-driver-usb-msc nonos-mk-driver-usb-msc-sign nonos-mk-check-driver-usb-msc-keys nonos-mk-driver-e1000 nonos-mk-driver-e1000-sign nonos-mk-check-driver-e1000-keys nonos-mk-driver-rtl8139 nonos-mk-driver-rtl8139-sign nonos-mk-check-driver-rtl8139-keys nonos-mk-driver-rtl8169 nonos-mk-driver-rtl8169-sign nonos-mk-check-driver-rtl8169-keys nonos-mk-driver-ahci nonos-mk-driver-ahci-sign nonos-mk-check-driver-ahci-keys nonos-mk-driver-hda nonos-mk-driver-hda-sign nonos-mk-check-driver-hda-keys nonos-mk-driver-nvme nonos-mk-driver-nvme-sign nonos-mk-check-driver-nvme-keys nonos-mk-wallpaper nonos-mk-marketplace-abi nonos-mk-market nonos-mk-marketplace-index-tool
 .PHONY: nonos-mk-userland-clean
 .PHONY: nonos-mk-bootloader nonos-mk-sign nonos-mk-attest nonos-mk-esp
-.PHONY: nonos-mk-run nonos-mk-run-net nonos-mk-run-serial nonos-mk-run-serial-net nonos-mk-run-serial-log nonos-mk-debug nonos-mk-plan-a-runtime
+.PHONY: nonos-mk-run nonos-mk-run-nat nonos-mk-run-net nonos-mk-run-serial nonos-mk-run-serial-nat nonos-mk-run-serial-net nonos-mk-run-serial-log nonos-mk-debug nonos-mk-plan-a-runtime
 .PHONY: nonos-mk-boot-ramfs nonos-mk-boot-keyring nonos-mk-boot-entropy nonos-mk-boot-crypto-hash nonos-mk-boot-vfs nonos-mk-boot-ps2-input nonos-mk-boot-xhci nonos-mk-boot-usb-hid nonos-mk-boot-desktop-gui
 .PHONY: nonos-mk-input-e2e-ps2-test nonos-mk-input-e2e-ps2-esp nonos-mk-input-e2e-xhci-test nonos-mk-input-e2e-xhci-esp nonos-mk-boot-input-e2e-ps2 nonos-mk-boot-input-e2e-xhci nonos-mk-input-probe-test nonos-mk-input-probe-esp nonos-mk-input-probe-run nonos-mk-input-probe-run-serial nonos-mk-input-probe-inject-test nonos-mk-input-probe-inject-esp nonos-mk-input-probe-inject-run-serial
 .PHONY: nonos-mk-static nonos-mk-scan
@@ -202,6 +202,13 @@ QEMU_RNG := -device virtio-rng-pci
 ifeq ($(QEMU_NET_MODE),off)
     QEMU_NET :=
     QEMU_NET_DESC := disabled
+else ifeq ($(QEMU_NET_MODE),nat)
+    QEMU_NET := -device virtio-net-pci,netdev=net0 -netdev user,id=net0
+    QEMU_NET_DESC := nat outbound virtio-net
+    ifneq ($(QEMU_NET_CAPTURE),)
+        QEMU_NET += -object filter-dump,id=net0dump,netdev=net0,file=$(QEMU_NET_CAPTURE)
+        QEMU_NET_DESC := $(QEMU_NET_DESC) capture=$(QEMU_NET_CAPTURE)
+    endif
 else ifeq ($(QEMU_NET_MODE),hostfwd)
     QEMU_NET := -device virtio-net-pci,netdev=net0 -netdev user,id=net0,hostfwd=tcp::$(QEMU_HOST_SSH_PORT)-:22,hostfwd=tcp::$(QEMU_HOST_HTTP_PORT)-:80
     QEMU_NET_DESC := hostfwd ssh=$(QEMU_HOST_SSH_PORT) http=$(QEMU_HOST_HTTP_PORT)
@@ -210,7 +217,7 @@ else ifeq ($(QEMU_NET_MODE),hostfwd)
         QEMU_NET_DESC := $(QEMU_NET_DESC) capture=$(QEMU_NET_CAPTURE)
     endif
 else
-    $(error Unsupported QEMU_NET_MODE=$(QEMU_NET_MODE). Use off or hostfwd)
+    $(error Unsupported QEMU_NET_MODE=$(QEMU_NET_MODE). Use off, nat, or hostfwd)
 endif
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -722,6 +729,7 @@ nonos-mk-trust-policy: $(NONOS_TRUST_ANCHOR_POLICY_BIN)
 #   nonos-mk-<slug>-sign      sign cert + manifest
 #   nonos-mk-check-<slug>-keys assert publisher seeds + pubs exist
 include userland/capsule_proof_io/Capsule.mk
+include userland/capsule_std_proof/Capsule.mk
 include userland/capsule_ramfs/Capsule.mk
 include userland/capsule_keyring/Capsule.mk
 include userland/capsule_entropy/Capsule.mk
@@ -1231,6 +1239,13 @@ nonos-mk-proof-io-prod: $(proof-io_ARTIFACTS) nonos-mk-check-deps nonos-mk-ensur
 		$(CARGO) build $(KERNEL_BUILD_FLAGS) \
 		--no-default-features --features microkernel-proof-io
 
+nonos-mk-std-proof-prod: $(proof-io_ARTIFACTS) $(std-proof_ARTIFACTS) nonos-mk-check-deps nonos-mk-ensure-signing-key
+	@echo "Building kernel (microkernel-proof-io + std_proof)..."
+	@$(SDK_FLAGS) NONOS_SIGNING_KEY=$(KERNEL_SIGNING_KEY) \
+		RUSTUP_TOOLCHAIN=$(TOOLCHAIN) \
+		$(CARGO) build $(KERNEL_BUILD_FLAGS) \
+		--no-default-features --features microkernel-proof-io,nonos-capsule-std-proof
+
 nonos-mk-ramfs-prod: $(proof-io_ARTIFACTS) $(ramfs_ARTIFACTS) \
 		nonos-mk-check-deps nonos-mk-ensure-signing-key
 	@echo "Building kernel (microkernel-ramfs)..."
@@ -1646,6 +1661,9 @@ nonos-mk-run: nonos-mk-live-production-proof nonos-mk-desktop-gui-prod nonos-mk-
 nonos-mk-run-net:
 	@$(MAKE) --no-print-directory QEMU_NET_MODE=hostfwd nonos-mk-run
 
+nonos-mk-run-nat:
+	@$(MAKE) --no-print-directory QEMU_NET_MODE=nat nonos-mk-run
+
 nonos-mk-run-wizard: nonos-mk-setup-wizard-esp $(QEMU_BLK_IMG) $(QEMU_OVMF_VARS_RW)
 	@echo "Booting NONOS (first-boot setup wizard) in QEMU..."
 	@echo "  Network: $(QEMU_NET_DESC)"
@@ -1678,6 +1696,9 @@ nonos-mk-run-serial: nonos-mk-desktop-gui-prod nonos-mk-esp
 
 nonos-mk-run-serial-net:
 	@$(MAKE) --no-print-directory QEMU_NET_MODE=hostfwd nonos-mk-run-serial
+
+nonos-mk-run-serial-nat:
+	@$(MAKE) --no-print-directory QEMU_NET_MODE=nat nonos-mk-run-serial
 
 nonos-mk-run-serial-log: nonos-mk-desktop-gui-prod nonos-mk-esp
 	@mkdir -p $(dir $(QEMU_SERIAL_LOG))
@@ -1914,9 +1935,11 @@ help:
 	@echo
 	@echo "Run:"
 	@echo "  make nonos-mk-run             QEMU + OVMF, network disabled by default"
+	@echo "  make nonos-mk-run-nat         QEMU + OVMF with outbound NAT network"
 	@echo "  make nonos-mk-run-net         QEMU + OVMF with explicit hostfwd network"
 	@echo "  make nonos-mk-run-wizard      QEMU + OVMF, first-boot setup wizard"
 	@echo "  make nonos-mk-run-serial      headless serial-only"
+	@echo "  make nonos-mk-run-serial-nat  headless serial with outbound NAT network"
 	@echo "  make nonos-mk-run-serial-net  headless serial with explicit hostfwd network"
 	@echo "  make nonos-mk-run-serial-log  headless serial with file log"
 	@echo "  make nonos-mk-debug           QEMU + GDB on :1234"
@@ -1989,7 +2012,7 @@ nonos-mk-cargo-to-capsule-test:
 # with wallpaper, shell, and the SDK/App Kit apps. The capture variant boots
 # headless and saves a framebuffer screenshot + a bounded serial log.
 .PHONY: nonos-mk-run-gui-demo nonos-mk-gui-demo-capture
-nonos-mk-run-gui-demo: nonos-mk-run
+nonos-mk-run-gui-demo: nonos-mk-run-nat
 
 nonos-mk-gui-demo-capture: nonos-mk-desktop-gui-prod nonos-mk-esp $(QEMU_BLK_IMG) $(QEMU_OVMF_VARS_RW)
 	@bash tests/boot/gui_demo_capture.sh

--- a/src/userspace/capsule_std_proof/embed.rs
+++ b/src/userspace/capsule_std_proof/embed.rs
@@ -1,0 +1,43 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#[cfg(feature = "nonos-capsule-std-proof")]
+pub(crate) const STD_PROOF_ELF: &[u8] =
+    include_bytes!("../../../userland/capsule_std_proof/target/x86_64-nonos-user/release/std_proof");
+
+#[cfg(feature = "nonos-capsule-std-proof")]
+pub(crate) const STD_PROOF_NONOS_ID_CERT_BYTES: &[u8] =
+    include_bytes!("../../../nonos-data/trust/capsules/std_proof.nonos_id_cert.bin");
+
+#[cfg(feature = "nonos-capsule-std-proof")]
+pub(crate) const STD_PROOF_MANIFEST_BYTES: &[u8] =
+    include_bytes!("../../../nonos-data/trust/capsules/std_proof.manifest.bin");
+
+#[cfg(feature = "nonos-capsule-std-proof")]
+pub(crate) const STD_PROOF_ATTESTATION_BYTES: &[u8] =
+    include_bytes!("../../../nonos-data/trust/capsules/std_proof.zk_trailer.bin");
+
+#[cfg(not(feature = "nonos-capsule-std-proof"))]
+pub(crate) const STD_PROOF_ELF: &[u8] = &[];
+
+#[cfg(not(feature = "nonos-capsule-std-proof"))]
+pub(crate) const STD_PROOF_NONOS_ID_CERT_BYTES: &[u8] = &[];
+
+#[cfg(not(feature = "nonos-capsule-std-proof"))]
+pub(crate) const STD_PROOF_MANIFEST_BYTES: &[u8] = &[];
+
+#[cfg(not(feature = "nonos-capsule-std-proof"))]
+pub(crate) const STD_PROOF_ATTESTATION_BYTES: &[u8] = &[];

--- a/src/userspace/capsule_std_proof/mod.rs
+++ b/src/userspace/capsule_std_proof/mod.rs
@@ -1,0 +1,20 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+mod embed;
+mod spawn;
+
+pub use spawn::spawn_std_proof_capsule;

--- a/src/userspace/capsule_std_proof/spawn.rs
+++ b/src/userspace/capsule_std_proof/spawn.rs
@@ -1,0 +1,53 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::embed::{
+    STD_PROOF_ATTESTATION_BYTES, STD_PROOF_ELF, STD_PROOF_MANIFEST_BYTES,
+    STD_PROOF_NONOS_ID_CERT_BYTES,
+};
+use crate::capabilities::Capability;
+use crate::kernel_core::process_spawn::capsule_spawn::{self, CapsuleSpecVerified, SpawnError};
+use crate::security::nonos_id_cert::IdCertVerifyError;
+use crate::security::nonos_trust_anchor::{decode as decode_trust_anchor, BAKED_TRUST_ANCHOR_POLICY};
+
+const SERVICE_NAME: &str = "std_proof";
+const SERVICE_PORT: u32 = 4502;
+const REPLY_INBOX: &str = "endpoint.std_proof.reply";
+const REPLY_PORT: u32 = 4503;
+const TARGET_TRIPLE: &str = "x86_64-nonos-user";
+
+pub fn spawn_std_proof_capsule() -> Result<(), SpawnError> {
+    let trust_anchor = decode_trust_anchor(BAKED_TRUST_ANCHOR_POLICY)
+        .map_err(|_| SpawnError::NonosIdCertRejected(IdCertVerifyError::TrustAnchorPolicy))?;
+
+    let spec = CapsuleSpecVerified {
+        name: SERVICE_NAME,
+        service_port: SERVICE_PORT,
+        reply_inbox: REPLY_INBOX,
+        reply_port: REPLY_PORT,
+        elf: STD_PROOF_ELF,
+        nonos_id_cert_bytes: STD_PROOF_NONOS_ID_CERT_BYTES,
+        manifest_bytes: STD_PROOF_MANIFEST_BYTES,
+        attestation_trailer: STD_PROOF_ATTESTATION_BYTES,
+        target_triple: TARGET_TRIPLE,
+        requested_caps: Capability::CoreExec.bit()
+            | Capability::IPC.bit()
+            | Capability::Memory.bit(),
+        debug_tag: b"",
+    };
+    capsule_spawn::spawn_verified(&spec, &trust_anchor, None)?;
+    Ok(())
+}

--- a/src/userspace/init/entry.rs
+++ b/src/userspace/init/entry.rs
@@ -20,6 +20,7 @@ use crate::sys::boot_log;
 pub fn run_init() -> ! {
     boot_log::ok("INIT", "Starting");
     run_user_entry_proof();
+    run_std_proof();
     spawn_plan::spawn_ramfs();
     spawn_plan::spawn_core_after_ramfs();
     spawn_plan::run_ramfs_smoketest();
@@ -45,6 +46,14 @@ fn run_user_entry_proof() {
 
 #[cfg(not(feature = "nonos-user-entry-proof"))]
 fn run_user_entry_proof() {}
+
+#[cfg(feature = "nonos-capsule-std-proof")]
+fn run_std_proof() {
+    let _ = crate::userspace::capsule_std_proof::spawn_std_proof_capsule();
+}
+
+#[cfg(not(feature = "nonos-capsule-std-proof"))]
+fn run_std_proof() {}
 
 fn lower_init_priority() {
     use crate::process::core::{Priority, CURRENT_PID, PROCESS_TABLE};

--- a/src/userspace/mod.rs
+++ b/src/userspace/mod.rs
@@ -59,6 +59,7 @@ pub mod capsule_settings;
 #[cfg(feature = "nonos-capsule-setup-wizard")]
 pub mod capsule_setup_wizard;
 pub mod capsule_snake;
+pub mod capsule_std_proof;
 pub mod capsule_terminal;
 pub mod capsule_text_editor;
 pub mod capsule_toolkit;

--- a/userland/capsule_gui_proof/Cargo.lock
+++ b/userland/capsule_gui_proof/Cargo.lock
@@ -35,11 +35,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "nonos_capsule_std_proof"
+name = "nonos_app_skeleton"
+version = "0.1.0"
+dependencies = [
+ "nonos_toolkit",
+ "nonos_userland_libc",
+]
+
+[[package]]
+name = "nonos_capsule_gui_proof"
 version = "0.1.0"
 dependencies = [
  "nonos-std",
+ "nonos_app_skeleton",
  "nonos_userland_libc",
+]
+
+[[package]]
+name = "nonos_toolkit"
+version = "0.1.0"
+dependencies = [
+ "nonos_userland_libc",
+ "spin",
 ]
 
 [[package]]
@@ -54,6 +71,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spinning_top"

--- a/userland/capsule_gui_proof/Cargo.toml
+++ b/userland/capsule_gui_proof/Cargo.toml
@@ -1,0 +1,36 @@
+# NONOS userland: capsule_gui_proof
+# eK@nonos.systems
+#
+# A GUI capsule built on nonos_app_skeleton whose window state lives in
+# nonos_std (HashMap, format!). Proves a GUI Rust app compiles and runs
+# against the sovereign standard library, not just CLI-shaped capsules.
+
+[package]
+name = "nonos_capsule_gui_proof"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "AGPL-3.0"
+authors = ["eK@nonos.systems"]
+description = "NONOS GUI proof capsule on nonos_std"
+
+[[bin]]
+name = "gui_proof"
+path = "src/main.rs"
+
+[dependencies]
+nonos_libc = { package = "nonos_userland_libc", path = "../libc" }
+nonos_app_skeleton = { path = "../app_skeleton" }
+nonos_std = { package = "nonos-std", path = "../sdk/nonos_std" }
+
+[profile.release]
+panic = "abort"
+opt-level = 2
+lto = false
+debug = false
+strip = true
+
+[profile.dev]
+panic = "abort"
+opt-level = 0
+debug = true

--- a/userland/capsule_gui_proof/src/app.rs
+++ b/userland/capsule_gui_proof/src/app.rs
@@ -1,0 +1,69 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use nonos_app_skeleton::{
+    App, AppManifest, EventOutcome, InputEvent, InputKind, PaintBuffer, WindowKind, KEY_ESC,
+};
+use nonos_std::collections::HashMap;
+use nonos_std::format;
+
+pub struct GuiProof {
+    clicks: u32,
+    labels: HashMap<u32, &'static str>,
+}
+
+impl GuiProof {
+    pub fn new() -> Self {
+        let mut labels = HashMap::default();
+        labels.insert(0, "nonos_std drives this GUI");
+        Self { clicks: 0, labels }
+    }
+}
+
+impl App for GuiProof {
+    fn manifest(&self) -> AppManifest {
+        AppManifest {
+            title: b"std GUI proof",
+            window_id: 0x5354_4447,
+            kind: WindowKind::Normal,
+            initial_x: 160,
+            initial_y: 140,
+            width: 360,
+            height: 200,
+            input_kind_mask: (1 << 0) | (1 << 5),
+        }
+    }
+
+    fn on_event(&mut self, event: InputEvent) -> EventOutcome {
+        match event.kind {
+            InputKind::ButtonDown => {
+                self.clicks += 1;
+                EventOutcome::Repaint
+            }
+            InputKind::KeyDown if event.code == KEY_ESC => EventOutcome::Close,
+            _ => EventOutcome::Idle,
+        }
+    }
+
+    fn paint(&mut self, fb: &mut PaintBuffer) {
+        fb.clear(0xFF10_1820);
+        fb.fill_rect(20, 20, 320, 60, 0xFF2A_7FFF);
+        let label = self.labels.get(&0).copied().unwrap_or("");
+        fb.text(34, 44, label.as_bytes(), 0xFFFF_FFFF);
+        let line = format!("clicks: {}", self.clicks);
+        fb.text(34, 120, line.as_bytes(), 0xFFCF_E8FF);
+    }
+}

--- a/userland/capsule_gui_proof/src/main.rs
+++ b/userland/capsule_gui_proof/src/main.rs
@@ -1,0 +1,29 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+mod app;
+
+use nonos_app_skeleton::run;
+
+#[no_mangle]
+pub unsafe extern "C" fn _start() -> ! {
+    run(app::GuiProof::new)
+}

--- a/userland/capsule_std_proof/Capsule.mk
+++ b/userland/capsule_std_proof/Capsule.mk
@@ -1,0 +1,20 @@
+# std_proof — userland capsule built against nonos_std, the sovereign
+# standard library. Its `_start` exercises a seeded HashMap, Arc<Mutex>,
+# time, and process on the verified spawn path, then prints one serial
+# line. Booting it proves a nonos_std capsule runs end to end. IPC and
+# Memory only; no drivers, no broker resources.
+
+CAPSULE_SLUG               := std-proof
+CAPSULE_HANDLE             := std_proof
+CAPSULE_DOMAIN             := systems.nonos
+CAPSULE_DIR                := userland/capsule_std_proof
+CAPSULE_BIN_NAME           := std_proof
+CAPSULE_FEATURE            := nonos-capsule-std-proof
+CAPSULE_NAMESPACE          := systems.nonos.std_proof
+CAPSULE_SERVICE_ENDPOINT   := service:4502:std_proof
+CAPSULE_REPLY_ENDPOINT     := reply:4503:endpoint.std_proof.reply
+# CoreExec | IPC | Memory = 0x01 | 0x08 | 0x10 = 0x19
+CAPSULE_REQUIRED_CAPS      := 0x19
+CAPSULE_KERNEL_MIRROR      := src/userspace/capsule_std_proof
+
+include nonos-mk/capsule.mk

--- a/userland/capsule_std_proof/src/main.rs
+++ b/userland/capsule_std_proof/src/main.rs
@@ -20,8 +20,9 @@
 extern crate alloc;
 
 use nonos_libc::{heap_init, mk_exit};
-use nonos_std::collections::BTreeMap;
+use nonos_std::collections::{BTreeMap, HashMap};
 use nonos_std::fs;
+use nonos_std::sync::{Arc, Mutex};
 use nonos_std::time::Instant;
 use nonos_std::vec::Vec;
 
@@ -37,9 +38,23 @@ pub unsafe extern "C" fn _start() -> ! {
     let mut counts: BTreeMap<&str, u32> = BTreeMap::new();
     counts.insert("nonos", items.iter().copied().sum());
     let total = counts.get("nonos").copied().unwrap_or(0);
+    let mut seen: HashMap<&str, u32> = HashMap::default();
+    for word in ["nonos", "std", "nonos"] {
+        *seen.entry(word).or_insert(0) += 1;
+    }
+    let hits = seen.get("nonos").copied().unwrap_or(0);
+    let shared = Arc::new(Mutex::new(0u32));
+    {
+        let mut guard = shared.lock().unwrap();
+        *guard = total + hits;
+    }
+    let locked = *shared.lock().unwrap();
     let _ = fs::write(b"/std_proof.txt", b"nonos_std fs works\n");
     let stored = fs::read(b"/std_proof.txt").map(|d| d.len()).unwrap_or(0);
     let elapsed = start.elapsed().as_millis();
-    nonos_std::println!("nonos_std live: total {total}, file {stored} bytes, {elapsed} ms");
+    let pid = nonos_std::process::id();
+    nonos_std::println!(
+        "nonos_std live: total {total}, hits {hits}, locked {locked}, pid {pid}, file {stored} bytes, {elapsed} ms"
+    );
     mk_exit(0)
 }


### PR DESCRIPTION
## What

Two capsules that demonstrate `nonos_std` running on real paths, plus the boot wiring for the first. Rebased onto current main.

- **capsule_std_proof** exercises the seeded `HashMap`, `Arc<Mutex>`, `time`, and `process`, then prints one serial line. A `Capsule.mk`, a kernel mirror, an entry spawn, and a `nonos-mk-std-proof-prod` target build, sign, attest, and embed it under the `nonos-capsule-std-proof` feature.
- **capsule_gui_proof** is a GUI app on `nonos_app_skeleton` whose window state lives in `nonos_std`, proving GUI Rust apps compile against the std library.

## Safety

The std_proof embed is behind `nonos-capsule-std-proof`, off by default, so default kernel builds neither require the signed artifacts nor change behaviour.