### PR TITLE
desktop: wallet launcher icon, NONOS logo, taskbar refinements

### DIFF
--- a/userland/capsule_desktop_shell/src/render/bottom_taskbar.rs
+++ b/userland/capsule_desktop_shell/src/render/bottom_taskbar.rs
@@ -19,7 +19,7 @@ use super::fill::fill_rect;
 use super::layout::{bottom_dock_rect, TASKBAR_ENTRY_W};
 use crate::state::{Context, LAUNCHER_APPS, TASKBAR_NO_ACTIVE};
 
-const ICON_SIZE: u32 = 20;
+const ICON_SIZE: u32 = 28;
 
 pub fn paint_bottom_taskbar(ctx: &Context) {
     let dock = bottom_dock_rect(ctx.width, ctx.height);

--- a/userland/capsule_desktop_shell/src/render/icons.rs
+++ b/userland/capsule_desktop_shell/src/render/icons.rs
@@ -22,6 +22,8 @@ mod about;
 mod calculator;
 mod constants;
 mod file_manager;
+mod nonos_logo;
+mod nonos_logo_bits;
 mod paint;
 mod process_manager;
 mod settings;

--- a/userland/capsule_desktop_shell/src/render/icons/nonos_logo.rs
+++ b/userland/capsule_desktop_shell/src/render/icons/nonos_logo.rs
@@ -1,0 +1,47 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::state::Context;
+
+use super::super::fill::fill_rect;
+
+pub fn paint(ctx: &Context, x: u32, y: u32, size: u32, color: u32) {
+    for row in 0..super::nonos_logo_bits::H {
+        let (left, right) = super::nonos_logo_bits::ROWS[row as usize];
+        for col in 0..super::nonos_logo_bits::W {
+            let bits = if col < 32 { left } else { right };
+            let bit = if col < 32 { 31 - col } else { 63 - col };
+            if bits & (1 << bit) == 0 {
+                continue;
+            }
+            let px = x + col * size / super::nonos_logo_bits::W;
+            let py = y + row * size / super::nonos_logo_bits::H;
+            let nx = x + (col + 1) * size / super::nonos_logo_bits::W;
+            let ny = y + (row + 1) * size / super::nonos_logo_bits::H;
+            fill_rect(
+                ctx.backing_va,
+                ctx.stride,
+                ctx.width,
+                ctx.height,
+                px,
+                py,
+                nx.saturating_sub(px).max(1),
+                ny.saturating_sub(py).max(1),
+                color,
+            );
+        }
+    }
+}

--- a/userland/capsule_desktop_shell/src/render/icons/nonos_logo_bits.rs
+++ b/userland/capsule_desktop_shell/src/render/icons/nonos_logo_bits.rs
@@ -1,0 +1,56 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+pub const W: u32 = 64;
+pub const H: u32 = 71;
+pub const ROWS: [(u32, u32); 71] = [
+    (0x003FFFFF, 0xFFFFFC00), (0x01FFFFFF, 0xFFFFFF80),
+    (0x07FFFFFF, 0xFFFFFFE0), (0x0FFFFFFF, 0xFFFFFFF0),
+    (0x1FFFFFFF, 0xFFFFFFF8), (0x3FFFFFFF, 0xFFFFFFFC),
+    (0x3FFFFFFF, 0xFFFFFFFC), (0x7FFFFFFF, 0xFFFFFFFE),
+    (0x7FFFFFFF, 0xFFFFFFFE), (0x7FFFFFFF, 0xFFFFFFFE),
+    (0xFFFFFFFF, 0xFFFFFFFF), (0xFFFFFFFF, 0xFFFFFFFF),
+    (0xFFFFFFFF, 0xFFFFFFFF), (0xFFFFFFFF, 0xFFFFFFFF),
+    (0xFFFFFFFF, 0xFFFFFFFF), (0xFFFFFFFF, 0xFFFFFFFF),
+    (0xFFFFFFFF, 0xFFFFFFFF), (0xFFFFFFFF, 0xFFFFFFFF),
+    (0xFFFFFFFF, 0xFFFFFFFF), (0xFFFFFFFF, 0xFFFFFFFF),
+    (0xFFFFFFFF, 0xFFFFFFFF), (0xFFFFFFF8, 0x1FFFFFFF),
+    (0xFFFFFFC0, 0x03CFFFFF), (0xFFFFFF00, 0x0187FFFF),
+    (0xFFFFFE07, 0xC00FFFFF), (0xFFFFFC1F, 0xF81FFFFF),
+    (0xFFFFF87F, 0xFC3FFFFF), (0xFFFFF87F, 0xF81FFFFF),
+    (0xFFFFF0FF, 0xF01FFFFF), (0xFFFFF1FF, 0xE10FFFFF),
+    (0xFFFFF1FF, 0xC30FFFFF), (0xFFFFE1FF, 0xC38FFFFF),
+    (0xFFFFE1FF, 0x878FFFFF), (0xFFFFE3FF, 0x0F8FFFFF),
+    (0xFFFFE3FE, 0x1F8FFFFF), (0xFFFFE3FC, 0x3F87FFFF),
+    (0xFFFFE3F8, 0x7F8FFFFF), (0xFFFFE3F0, 0xFF8FFFFF),
+    (0xFFFFE1E1, 0xFF8FFFFF), (0xFFFFE1C3, 0xFF8FFFFF),
+    (0xFFFFF187, 0xFF0FFFFF), (0xFFFFF00F, 0xFF0FFFFF),
+    (0xFFFFF00F, 0xFE1FFFFF), (0xFFFFF81F, 0xFE1FFFFF),
+    (0xFFFFF83F, 0xFC3FFFFF), (0xFFFFF81F, 0xF87FFFFF),
+    (0xFFFFF003, 0xC0FFFFFF), (0xFFFFE100, 0x01FFFFFF),
+    (0xFFFFF3C0, 0x03FFFFFF), (0xFFFFFFF8, 0x3FFFFFFF),
+    (0xFFFFFFFF, 0xFFFFFFFF), (0xFFFFFFFF, 0xFFFFFFFF),
+    (0xFFFFFFFF, 0xFFFFFFFF), (0xFFFFFFFF, 0xFFFFFFFF),
+    (0xFFFFFFFF, 0xFFFFFFFF), (0xFFFFFFFF, 0xFFFFFFFF),
+    (0xFFFFFFFF, 0xFFFFFFFF), (0xFFFFFFFF, 0xFFFFFFFF),
+    (0xFFFFFFFF, 0xFFFFFFFF), (0xFFFFFFFF, 0xFFFFFFFF),
+    (0xFFFFFFFF, 0xFFFFFFFF), (0x7FFFFFFF, 0xFFFFFFFE),
+    (0x7FFFFFFF, 0xFFFFFFFE), (0x7FFFFFFF, 0xFFFFFFFE),
+    (0x3FFFFFFF, 0xFFFFFFFC), (0x3FFFFFFF, 0xFFFFFFFC),
+    (0x1FFFFFFF, 0xFFFFFFF8), (0x0FFFFFFF, 0xFFFFFFF0),
+    (0x07FFFFFF, 0xFFFFFFE0), (0x01FFFFFF, 0xFFFFFF80),
+    (0x003FFFFF, 0xFFFFFC00),
+];

--- a/userland/capsule_desktop_shell/src/render/icons/wallet.rs
+++ b/userland/capsule_desktop_shell/src/render/icons/wallet.rs
@@ -17,11 +17,5 @@
 use crate::state::Context;
 
 pub fn wallet(ctx: &Context, x: u32, y: u32, size: u32) {
-    let fg = super::constants::ICON_FG;
-    let ac = super::constants::ACCENT;
-    super::paint::paint_u(ctx, x, y, size, 3, 4, 10, 8, fg);
-    super::paint::paint_u(ctx, x, y, size, 4, 5, 8, 6, super::constants::ICON_BG);
-    super::paint::paint_u(ctx, x, y, size, 9, 7, 4, 3, ac);
-    super::paint::paint_u(ctx, x, y, size, 10, 8, 1, 1, fg);
-    super::paint::paint_u(ctx, x, y, size, 5, 3, 6, 2, ac);
+    super::nonos_logo::paint(ctx, x, y, size, 0xFF66_FFFF);
 }

--- a/userland/capsule_desktop_shell/src/setup/prime/register.rs
+++ b/userland/capsule_desktop_shell/src/setup/prime/register.rs
@@ -22,7 +22,7 @@ use nonos_libc::{
 use super::overlay::Overlay;
 use crate::compositor_client::push_scene_submit;
 
-const OVERLAY_Z: u32 = 1_000_000;
+const OVERLAY_Z: u32 = 1;
 
 pub fn register_overlay(
     compositor_port: u32,

--- a/userland/capsule_desktop_shell/src/setup/prime/run/commit_overlay.rs
+++ b/userland/capsule_desktop_shell/src/setup/prime/run/commit_overlay.rs
@@ -16,8 +16,19 @@
 
 use crate::compositor_client::push_damage_commit;
 use crate::state::Context;
+use nonos_libc::mk_yield;
 
-pub fn commit_overlay(ctx: &mut Context) {
-    let rid = ctx.issue_request_id();
-    let _ = push_damage_commit(ctx.compositor_port, rid, 0, 0, ctx.width, ctx.height);
+const COMMIT_RETRIES: usize = 16;
+
+pub fn commit_overlay(ctx: &mut Context) -> Result<(), &'static str> {
+    let mut last = "compositor rejected damage_commit";
+    for _ in 0..COMMIT_RETRIES {
+        let rid = ctx.issue_request_id();
+        match push_damage_commit(ctx.compositor_port, rid, 0, 0, ctx.width, ctx.height) {
+            Ok(()) => return Ok(()),
+            Err(e) => last = e,
+        }
+        mk_yield();
+    }
+    Err(last)
 }

--- a/userland/capsule_desktop_shell/src/setup/prime/run/run.rs
+++ b/userland/capsule_desktop_shell/src/setup/prime/run/run.rs
@@ -25,10 +25,10 @@ pub fn run() -> Result<Context, &'static str> {
     let overlay = overlay::allocate(peers.compositor_port, 1)?;
     let mut ctx = super::build_context::build_context(&peers, &overlay);
     paint_chrome(&ctx);
+    super::register_overlay::register_overlay(&mut ctx, &overlay)?;
+    super::commit_overlay::commit_overlay(&mut ctx)?;
     open_chrome_windows::open_chrome_windows(&mut ctx)?;
     super::subscribe_wm::subscribe_wm(&mut ctx, peers.wm_port);
-    super::register_overlay::register_overlay(&mut ctx, &overlay)?;
-    super::commit_overlay::commit_overlay(&mut ctx);
     super::subscribe_input::subscribe_input(&mut ctx, peers.input_router_port);
     Ok(ctx)
 }


### PR DESCRIPTION
Desktop shell updates alongside the wallet work: a wallet launcher icon and NONOS logo rendering, plus taskbar and prime-setup touch-ups. Builds clean for the nonos target.