### PR TITLE
std: complete the x86_64-nonos platform layer (fs, net, threads, real heap)

### DIFF
--- a/toolchain/nonos-pack.sh
+++ b/toolchain/nonos-pack.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# nonos-pack: build an unmodified std Rust crate into a NONOS capsule
+# executable. It compiles the crate against the NONOS std platform layer
+# (-Zbuild-std=std) and links the nonos-rt startup object, producing a
+# static-PIE NONOS ELF. Signing, attestation, and publishing into the
+# trust policy are the next stage (the per-slug nonos-mk-<slug>-sign
+# targets); a capsule must be in the baked ZK policy to be accepted, so
+# install is a deliberate publish step, not arbitrary self-install.
+#
+# Usage: toolchain/nonos-pack.sh <crate-dir>
+set -euo pipefail
+
+CRATE="${1:?usage: nonos-pack.sh <crate-dir>}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TC="${RUSTUP_TOOLCHAIN:-nightly-2026-01-16}"
+TGT="$ROOT/userland/x86_64-nonos-user.json"
+RT="$ROOT/toolchain/nonos-rt"
+RTOBJ="${NONOS_RT_OBJ:-/tmp/nonos_rt.o}"
+FLAGS="-Zbuild-std=std,panic_abort -Zbuild-std-features=compiler-builtins-mem"
+export PATH="$HOME/.cargo/bin:$PATH"
+export RUSTUP_TOOLCHAIN="$TC"
+
+if [ -x "$ROOT/toolchain/nonos-std/apply.sh" ]; then
+    echo "[nonos-pack] applying NONOS std platform layer"
+    "$ROOT/toolchain/nonos-std/apply.sh" >/dev/null
+fi
+
+if [ -f "$RT/Cargo.toml" ]; then
+    echo "[nonos-pack] building startup object (nonos-rt _start)"
+    cargo rustc --manifest-path "$RT/Cargo.toml" --release --target "$TGT" \
+        -Zbuild-std=core -- --emit "obj=$RTOBJ" >/dev/null
+elif [ ! -f "$RTOBJ" ]; then
+    echo "[nonos-pack] error: nonos-rt source missing and no prebuilt $RTOBJ"; exit 1
+else
+    echo "[nonos-pack] using existing startup object $RTOBJ"
+fi
+
+echo "[nonos-pack] building crate against std: $CRATE"
+( cd "$CRATE" && RUSTFLAGS="-Clink-arg=$RTOBJ" cargo build --release --target "$TGT" $FLAGS )
+
+DIR="$CRATE/target/x86_64-nonos-user/release"
+ELF="$(find "$DIR" -maxdepth 1 -type f -perm -u+x ! -name '*.d' ! -name '*.rlib' 2>/dev/null | head -1)"
+[ -n "$ELF" ] || { echo "[nonos-pack] error: no executable produced"; exit 1; }
+
+echo "[nonos-pack] built: $ELF"
+file "$ELF"
+echo "[nonos-pack] next: sign + attest + publish into the trust policy to install."

--- a/toolchain/nonos-std/apply.sh
+++ b/toolchain/nonos-std/apply.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
 # Apply the NONOS std platform layer (PAL) into the pinned rust-src so that
-# `-Zbuild-std=std` produces NONOS binaries from unmodified `use std::...` code.
-#
-# The PAL is keyed on `target_vendor = "nonos"` (the capsule target sets it),
-# so existing capsules that build core+alloc are unaffected. Re-run after any
-# `rustup` update of the toolchain. Idempotent.
-#
-# Usage: RUSTUP_TOOLCHAIN=nightly-2026-01-16 toolchain/nonos-std/apply.sh
+# `-Zbuild-std=std` produces NONOS binaries from unmodified `use std::...`
+# code. Keyed on `target_vendor = "nonos"` (the capsule target sets it), so
+# capsules that build core+alloc are unaffected. Idempotent; re-run after a
+# `rustup` update. Usage: RUSTUP_TOOLCHAIN=nightly-2026-01-16 apply.sh
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -15,64 +12,94 @@ SR="$(RUSTUP_TOOLCHAIN="$TC" rustc --print sysroot)"
 STD="$SR/lib/rustlib/src/rust/library/std"
 SYS="$STD/src/sys"
 
-cp "$HERE/sys/alloc/nonos.rs"    "$SYS/alloc/nonos.rs"
-cp "$HERE/sys/io/error/nonos.rs" "$SYS/io/error/nonos.rs"
-cp "$HERE/sys/random/nonos.rs"   "$SYS/random/nonos.rs"
+# 1. copy the platform modules
+cp "$HERE/sys/alloc/nonos.rs"            "$SYS/alloc/nonos.rs"
+cp "$HERE/sys/io/error/nonos.rs"         "$SYS/io/error/nonos.rs"
+cp "$HERE/sys/random/nonos.rs"           "$SYS/random/nonos.rs"
+cp "$HERE/sys/stdio/nonos.rs"            "$SYS/stdio/nonos.rs"
+cp "$HERE/sys/args/nonos.rs"             "$SYS/args/nonos.rs"
+cp "$HERE/sys/fs/nonos.rs"               "$SYS/fs/nonos.rs"
+mkdir -p "$SYS/pal/nonos" "$SYS/net/connection"
+cp "$HERE/sys/pal/nonos/mod.rs"          "$SYS/pal/nonos/mod.rs"
+cp "$HERE/sys/pal/nonos/os.rs"           "$SYS/pal/nonos/os.rs"
+cp "$HERE/sys/pal/nonos/time.rs"         "$SYS/pal/nonos/time.rs"
+cp "$HERE/sys/net/connection/nonos.rs"   "$SYS/net/connection/nonos.rs"
+mkdir -p "$SYS/thread"
+cp "$HERE/sys/thread/nonos.rs"           "$SYS/thread/nonos.rs"
 
+# 2. patch the cfg_select selectors + build.rs (idempotent)
 python3 - "$SYS" "$STD" <<'PY'
 import sys
 sysdir, stddir = sys.argv[1], sys.argv[2]
 
-def edit(path, anchor, insert, guard):
+def insert_before(path, anchor, block, guard):
     with open(path) as f:
         s = f.read()
     if guard in s:
         return
     i = s.index(anchor)
-    s = s[:i] + insert + s[i:]
     with open(path, "w") as f:
+        f.write(s[:i] + block + s[i:])
+
+ARM = '    target_vendor = "nonos" => {\n        mod nonos;\n        pub use nonos::*;\n    }\n'
+ARM_BARE = '    target_vendor = "nonos" => {\n        mod nonos;\n    }\n'
+ARM_FILL = '    target_vendor = "nonos" => {\n        pub use nonos::fill_bytes;\n        mod nonos;\n    }\n'
+ARM_IMP = '    target_vendor = "nonos" => {\n        mod nonos;\n        use nonos as imp;\n    }\n'
+ARM_PAL = '    target_vendor = "nonos" => {\n        mod nonos;\n        pub use self::nonos::*;\n    }\n'
+
+insert_before(f"{sysdir}/alloc/mod.rs", '    any(\n        target_family = "unix",', ARM_BARE, 'mod nonos')
+insert_before(f"{sysdir}/io/error/mod.rs", '    target_os = "hermit" => {', ARM, 'target_vendor = "nonos"')
+insert_before(f"{sysdir}/random/mod.rs", '    // Tier 1\n', ARM_FILL, 'target_vendor = "nonos"')
+insert_before(f"{sysdir}/stdio/mod.rs", '    any(target_family = "unix"', ARM, 'target_vendor = "nonos"')
+insert_before(f"{sysdir}/fs/mod.rs", '    any(target_family = "unix", target_os = "wasi") => {', ARM_IMP, 'target_vendor = "nonos"')
+insert_before(f"{sysdir}/pal/mod.rs", '    unix => {', ARM_PAL, 'target_vendor = "nonos"')
+insert_before(f"{sysdir}/net/connection/mod.rs", '    any(\n        all(target_family = "unix", not(target_os = "l4re")),', ARM, 'target_vendor = "nonos"')
+
+ARM_THREAD = ('    target_vendor = "nonos" => {\n        mod nonos;\n'
+    '        pub use nonos::{\n            Thread, available_parallelism, current_os_id, set_name, sleep, yield_now,\n'
+    '            DEFAULT_MIN_STACK_SIZE,\n        };\n    }\n')
+insert_before(f"{sysdir}/thread/mod.rs", '    target_os = "hermit" => {', ARM_THREAD, 'target_vendor = "nonos"')
+
+# args: arm + add nonos to the gated `mod common`
+insert_before(f"{sysdir}/args/mod.rs",
+    '    any(\n        all(target_family = "unix", not(any(target_os = "espidf"',
+    ARM, 'target_vendor = "nonos"')
+with open(f"{sysdir}/args/mod.rs") as f:
+    s = f.read()
+if 'target_os = "xous",\n    target_vendor = "nonos",\n))]\nmod common;' not in s:
+    s = s.replace('    target_os = "xous",\n))]\nmod common;',
+                  '    target_os = "xous",\n    target_vendor = "nonos",\n))]\nmod common;')
+    with open(f"{sysdir}/args/mod.rs", "w") as f:
         f.write(s)
 
-# 1. allocator
-edit(f"{sysdir}/alloc/mod.rs",
-     '    any(\n        target_family = "unix",',
-     '    target_vendor = "nonos" => {\n        mod nonos;\n    }\n',
-     'mod nonos;')
-
-# 2. io error decoding
-edit(f"{sysdir}/io/error/mod.rs",
-     '    target_os = "hermit" => {',
-     '    target_vendor = "nonos" => {\n        mod nonos;\n        pub use nonos::*;\n    }\n',
-     'target_vendor = "nonos"')
-
-# 3. randomness
-edit(f"{sysdir}/random/mod.rs",
-     '    // Tier 1\n',
-     '    target_vendor = "nonos" => {\n        mod nonos;\n        pub use nonos::fill_bytes;\n    }\n',
-     'target_vendor = "nonos"')
-
-# 4. thread locals -> no_threads + no-op destructor guard
-tl = f"{sysdir}/thread_local/mod.rs"
-with open(tl) as f:
+# thread_local: route nonos to no_threads + a no-op destructor guard
+with open(f"{sysdir}/thread_local/mod.rs") as f:
     s = f.read()
-s = s.replace(
-    '        target_os = "vexos",\n    ) => {\n        mod no_threads;',
-    '        target_os = "vexos",\n        target_vendor = "nonos",\n    ) => {\n        mod no_threads;')
-s = s.replace(
-    '            target_os = "vexos",\n        ) => {\n            pub(crate) fn enable() {',
-    '            target_os = "vexos",\n            target_vendor = "nonos",\n        ) => {\n            pub(crate) fn enable() {')
-with open(tl, "w") as f:
+s = s.replace('        target_os = "vexos",\n    ) => {\n        mod no_threads;',
+              '        target_os = "vexos",\n        target_vendor = "nonos",\n    ) => {\n        mod no_threads;')
+s = s.replace('            target_os = "vexos",\n        ) => {\n            pub(crate) fn enable() {',
+              '            target_os = "vexos",\n            target_vendor = "nonos",\n        ) => {\n            pub(crate) fn enable() {')
+with open(f"{sysdir}/thread_local/mod.rs", "w") as f:
     f.write(s)
 
-# 5. std is a known (non-restricted) platform for nonos
-br = f"{stddir}/build.rs"
-with open(br) as f:
+# Cargo.toml: make dlmalloc a dependency for nonos (the real heap)
+with open(f"{stddir}/Cargo.toml") as f:
+    s = f.read()
+gate = 'all(target_family = "wasm", target_os = "unknown"), target_os = "xous", target_os = "vexos", '
+if gate in s and 'target_vendor = "nonos", all(target_vendor = "fortanix"' not in s:
+    s = s.replace(gate, gate + 'target_vendor = "nonos", ')
+    with open(f"{stddir}/Cargo.toml", "w") as f:
+        f.write(s)
+
+# build.rs: mark nonos a known (non-restricted) platform
+with open(f"{stddir}/build.rs") as f:
     s = f.read()
 if 'target_vendor == "nonos"' not in s:
     s = s.replace('|| target_os == "vexos"\n',
                   '|| target_os == "vexos"\n        || target_vendor == "nonos"\n', 1)
-    with open(br, "w") as f:
+    with open(f"{stddir}/build.rs", "w") as f:
         f.write(s)
 PY
 
 echo "NONOS std PAL applied to $STD"
+echo "modules: alloc, io_error, random, stdio, args, fs, pal(time), net(connection)"

--- a/toolchain/nonos-std/sys/alloc/nonos.rs
+++ b/toolchain/nonos-std/sys/alloc/nonos.rs
@@ -1,44 +1,102 @@
 // NONOS std PAL: global allocator.
 //
-// Phase 1: a self-contained bump arena in BSS so `std` has a working
-// GlobalAlloc with no external dependency and no failure path. Memory is
-// never reclaimed yet; a later phase swaps this for an mmap-backed heap
-// with free. Freshly bumped bytes are zero (BSS), so alloc_zeroed is free.
+// A real heap: dlmalloc (the same allocator std uses for wasm/sgx/xous)
+// backed by NONOS page allocation through the MMAP syscall. dlmalloc owns
+// free lists and coalescing, so memory is reclaimed and reused. Capsules
+// are single-threaded; the lock is an uncontended spin for Sync.
 
 use crate::alloc::{GlobalAlloc, Layout, System};
-use crate::sync::atomic::{AtomicUsize, Ordering};
+use crate::cell::SyncUnsafeCell;
+use crate::ptr;
+use crate::sync::atomic::{AtomicBool, Ordering};
 
-const ARENA_SIZE: usize = 16 * 1024 * 1024;
+const fn tag4(b: &[u8; 4]) -> i64 {
+    (b[0] as i64) | ((b[1] as i64) << 8) | ((b[2] as i64) << 16) | ((b[3] as i64) << 24)
+}
 
-#[repr(C, align(4096))]
-struct Arena([u8; ARENA_SIZE]);
+const N_MK_MMAP: i64 = tag4(b"MMAP");
 
-static mut ARENA: Arena = Arena([0u8; ARENA_SIZE]);
-static OFFSET: AtomicUsize = AtomicUsize::new(0);
+unsafe fn mmap(len: usize) -> *mut u8 {
+    let r: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            inout("rax") N_MK_MMAP => r,
+            in("rdi") 0u64,
+            in("rsi") len as u64,
+            in("rdx") 3u64,
+            in("r10") 0u64,
+            out("rcx") _,
+            out("r11") _,
+        );
+    }
+    if r <= 0 { ptr::null_mut() } else { r as *mut u8 }
+}
+
+struct Nonos;
+
+unsafe impl dlmalloc::Allocator for Nonos {
+    fn alloc(&self, size: usize) -> (*mut u8, usize, u32) {
+        let p = unsafe { mmap(size) };
+        if p.is_null() { (ptr::null_mut(), 0, 0) } else { (p, size, 0) }
+    }
+    fn remap(&self, _ptr: *mut u8, _old: usize, _new: usize, _can_move: bool) -> *mut u8 {
+        ptr::null_mut()
+    }
+    fn free_part(&self, _ptr: *mut u8, _old: usize, _new: usize) -> bool {
+        false
+    }
+    fn free(&self, _ptr: *mut u8, _size: usize) -> bool {
+        false
+    }
+    fn can_release_part(&self, _flags: u32) -> bool {
+        false
+    }
+    fn allocates_zeros(&self) -> bool {
+        false
+    }
+    fn page_size(&self) -> usize {
+        0x1000
+    }
+}
+
+struct Heap(dlmalloc::Dlmalloc<Nonos>);
+unsafe impl Sync for Heap {}
+
+static DLMALLOC: SyncUnsafeCell<Heap> =
+    SyncUnsafeCell::new(Heap(dlmalloc::Dlmalloc::new_with_allocator(Nonos)));
+static LOCK: AtomicBool = AtomicBool::new(false);
+
+struct Guard;
+impl Drop for Guard {
+    fn drop(&mut self) {
+        LOCK.store(false, Ordering::Release);
+    }
+}
+
+fn lock() -> Guard {
+    while LOCK.swap(true, Ordering::Acquire) {
+        core::hint::spin_loop();
+    }
+    Guard
+}
 
 #[stable(feature = "alloc_system_type", since = "1.28.0")]
 unsafe impl GlobalAlloc for System {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let base = core::ptr::addr_of_mut!(ARENA) as usize;
-        let align = layout.align();
-        loop {
-            let cur = OFFSET.load(Ordering::Relaxed);
-            let start = (base + cur + align - 1) & !(align - 1);
-            let end = match start.checked_add(layout.size()) {
-                Some(e) => e,
-                None => return core::ptr::null_mut(),
-            };
-            if end > base + ARENA_SIZE {
-                return core::ptr::null_mut();
-            }
-            if OFFSET
-                .compare_exchange_weak(cur, end - base, Ordering::AcqRel, Ordering::Relaxed)
-                .is_ok()
-            {
-                return start as *mut u8;
-            }
-        }
+        let _g = lock();
+        unsafe { (*DLMALLOC.get()).0.malloc(layout.size(), layout.align()) }
     }
-
-    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let _g = lock();
+        unsafe { (*DLMALLOC.get()).0.calloc(layout.size(), layout.align()) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        let _g = lock();
+        unsafe { (*DLMALLOC.get()).0.free(ptr, layout.size(), layout.align()) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let _g = lock();
+        unsafe { (*DLMALLOC.get()).0.realloc(ptr, layout.size(), layout.align(), new_size) }
+    }
 }

--- a/toolchain/nonos-std/sys/args/nonos.rs
+++ b/toolchain/nonos-std/sys/args/nonos.rs
@@ -1,0 +1,47 @@
+// NONOS std args: reads the process argv via the mk_args syscall and
+// hands it to the shared Args iterator. argv is NUL-separated bytes.
+
+pub use super::common::Args;
+
+use crate::ffi::OsString;
+use crate::string::String;
+use crate::vec::Vec;
+
+const fn tag4(b: &[u8; 4]) -> i64 {
+    (b[0] as i64) | ((b[1] as i64) << 8) | ((b[2] as i64) << 16) | ((b[3] as i64) << 24)
+}
+
+const N_MK_ARGS: i64 = tag4(b"MKAR");
+
+unsafe fn mk_args(buf: *mut u8, len: usize) -> i64 {
+    let r: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            inout("rax") N_MK_ARGS => r,
+            in("rdi") buf as u64,
+            in("rsi") len as u64,
+            out("rcx") _,
+            out("r11") _,
+        );
+    }
+    r
+}
+
+fn collect() -> Vec<OsString> {
+    let needed = unsafe { mk_args(core::ptr::null_mut(), 0) };
+    if needed <= 0 {
+        return Vec::new();
+    }
+    let mut buf = crate::vec![0u8; needed as usize];
+    let n = unsafe { mk_args(buf.as_mut_ptr(), buf.len()) };
+    if n <= 0 {
+        return Vec::new();
+    }
+    buf.truncate(n as usize);
+    buf.split(|&b| b == 0).map(|s| OsString::from(String::from_utf8_lossy(s).into_owned())).collect()
+}
+
+pub fn args() -> Args {
+    Args::new(collect())
+}

--- a/toolchain/nonos-std/sys/fs/nonos.rs
+++ b/toolchain/nonos-std/sys/fs/nonos.rs
@@ -1,0 +1,544 @@
+// NONOS std fs: files over the kernel VFS service (vfs_pool) via IPC.
+// Wires open/read/write/close, stat, unlink, mkdir, and readdir to the
+// VFS protocol. Symlinks, permissions, times, and locks are unsupported
+// (the VFS does not model them); those paths return an error or no-op.
+
+use crate::ffi::OsString;
+use crate::fmt;
+use crate::fs::TryLockError;
+use crate::hash::{Hash, Hasher};
+use crate::io::{self, BorrowedCursor, Error, ErrorKind, IoSlice, IoSliceMut, SeekFrom};
+use crate::path::{Path, PathBuf};
+pub use crate::sys::fs::common::Dir;
+use crate::sys::time::SystemTime;
+use crate::sys::unsupported;
+use crate::vec::Vec;
+
+const MAGIC: u32 = 0x4E4F_5646;
+const STATUS_OFF: usize = 20;
+const BODY_OFF: usize = 24;
+const OP_OPEN: u16 = 1;
+const OP_CLOSE: u16 = 2;
+const OP_READ: u16 = 3;
+const OP_WRITE: u16 = 4;
+const OP_STAT: u16 = 5;
+const OP_LIST: u16 = 6;
+const OP_MKDIR: u16 = 8;
+const OP_UNLINK: u16 = 9;
+const O_CREATE: u32 = 1;
+const O_TRUNC: u32 = 1 << 1;
+
+const fn tag4(b: &[u8; 4]) -> i64 {
+    (b[0] as i64) | ((b[1] as i64) << 8) | ((b[2] as i64) << 16) | ((b[3] as i64) << 24)
+}
+
+unsafe fn sys3(num: i64, a1: u64, a2: u64, a3: u64) -> i64 {
+    let r: i64;
+    unsafe {
+        core::arch::asm!("syscall", inout("rax") num => r, in("rdi") a1, in("rsi") a2,
+            in("rdx") a3, out("rcx") _, out("r11") _);
+    }
+    r
+}
+
+unsafe fn sys5(num: i64, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64) -> i64 {
+    let r: i64;
+    unsafe {
+        core::arch::asm!("syscall", inout("rax") num => r, in("rdi") a1, in("rsi") a2,
+            in("rdx") a3, in("r10") a4, in("r8") a5, out("rcx") _, out("r11") _);
+    }
+    r
+}
+
+fn vfs_port() -> io::Result<u32> {
+    let name = b"vfs_pool";
+    let mut port = 0u32;
+    let mut owner = 0u32;
+    let rc = unsafe {
+        sys5(tag4(b"MSVL"), name.as_ptr() as u64, name.len() as u64,
+            &mut port as *mut u32 as u64, &mut owner as *mut u32 as u64, 0)
+    };
+    if rc != 0 { return Err(err("vfs unavailable")); }
+    Ok(port)
+}
+
+fn getpid() -> u32 {
+    let r = unsafe { sys3(tag4(b"MGPD"), 0, 0, 0) };
+    if r < 0 { 0 } else { r as u32 }
+}
+
+fn frame(op: u16, body: &[u8]) -> Vec<u8> {
+    let mut f = Vec::with_capacity(STATUS_OFF + body.len());
+    f.extend_from_slice(&MAGIC.to_le_bytes());
+    f.extend_from_slice(&1u16.to_le_bytes());
+    f.extend_from_slice(&op.to_le_bytes());
+    f.extend_from_slice(&0u16.to_le_bytes());
+    f.extend_from_slice(&0u16.to_le_bytes());
+    f.extend_from_slice(&0u32.to_le_bytes());
+    f.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    f.extend_from_slice(body);
+    f
+}
+
+fn call(port: u32, op: u16, body: &[u8], reply_cap: usize) -> io::Result<Vec<u8>> {
+    let tx = frame(op, body);
+    let mut rx = crate::vec![0u8; BODY_OFF + reply_cap];
+    let n = unsafe {
+        sys5(tag4(b"MICL"), port as u64, tx.as_ptr() as u64, tx.len() as u64,
+            rx.as_mut_ptr() as u64, rx.len() as u64)
+    };
+    if n < (STATUS_OFF + 4) as i64 { return Err(err("vfs ipc failed")); }
+    let status = i32::from_le_bytes([rx[20], rx[21], rx[22], rx[23]]);
+    if status != 0 { return Err(err("vfs op rejected")); }
+    rx.truncate(n as usize);
+    Ok(rx)
+}
+
+fn err(msg: &'static str) -> Error {
+    Error::new(ErrorKind::Other, msg)
+}
+
+fn path_bytes(p: &Path) -> io::Result<Vec<u8>> {
+    let b = p.as_os_str().as_encoded_bytes();
+    if b.is_empty() || b.len() > 255 { return Err(err("bad path")); }
+    Ok(b.to_vec())
+}
+
+fn path_body(pid: u32, p: &Path) -> io::Result<Vec<u8>> {
+    let path = path_bytes(p)?;
+    let mut body = Vec::with_capacity(5 + path.len());
+    body.extend_from_slice(&pid.to_le_bytes());
+    body.push(path.len() as u8);
+    body.extend_from_slice(&path);
+    Ok(body)
+}
+
+fn read_u32(b: &[u8], off: usize) -> u32 {
+    if b.len() < off + 4 { return 0; }
+    u32::from_le_bytes([b[off], b[off + 1], b[off + 2], b[off + 3]])
+}
+
+pub struct File {
+    port: u32,
+    pid: u32,
+    fd: u32,
+}
+
+#[derive(Clone)]
+pub struct FileAttr {
+    size: u64,
+    is_dir: bool,
+}
+
+pub struct ReadDir {
+    entries: crate::vec::IntoIter<DirEntry>,
+}
+
+#[derive(Clone)]
+pub struct DirEntry {
+    name: PathBuf,
+    is_dir: bool,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct OpenOptions {
+    read: bool,
+    write: bool,
+    append: bool,
+    truncate: bool,
+    create: bool,
+    create_new: bool,
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct FileTimes {}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FilePermissions {
+    readonly: bool,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub struct FileType {
+    is_dir: bool,
+}
+
+#[derive(Debug)]
+pub struct DirBuilder {}
+
+impl FileAttr {
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+    pub fn perm(&self) -> FilePermissions {
+        FilePermissions { readonly: false }
+    }
+    pub fn file_type(&self) -> FileType {
+        FileType { is_dir: self.is_dir }
+    }
+    pub fn modified(&self) -> io::Result<SystemTime> {
+        unsupported()
+    }
+    pub fn accessed(&self) -> io::Result<SystemTime> {
+        unsupported()
+    }
+    pub fn created(&self) -> io::Result<SystemTime> {
+        unsupported()
+    }
+}
+
+impl FilePermissions {
+    pub fn readonly(&self) -> bool {
+        self.readonly
+    }
+    pub fn set_readonly(&mut self, readonly: bool) {
+        self.readonly = readonly;
+    }
+}
+
+impl FileTimes {
+    pub fn set_accessed(&mut self, _t: SystemTime) {}
+    pub fn set_modified(&mut self, _t: SystemTime) {}
+}
+
+impl FileType {
+    pub fn is_dir(&self) -> bool {
+        self.is_dir
+    }
+    pub fn is_file(&self) -> bool {
+        !self.is_dir
+    }
+    pub fn is_symlink(&self) -> bool {
+        false
+    }
+}
+
+impl fmt::Debug for ReadDir {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReadDir").finish_non_exhaustive()
+    }
+}
+
+impl Iterator for ReadDir {
+    type Item = io::Result<DirEntry>;
+    fn next(&mut self) -> Option<io::Result<DirEntry>> {
+        self.entries.next().map(Ok)
+    }
+}
+
+impl DirEntry {
+    pub fn path(&self) -> PathBuf {
+        self.name.clone()
+    }
+    pub fn file_name(&self) -> OsString {
+        self.name.as_os_str().to_os_string()
+    }
+    pub fn metadata(&self) -> io::Result<FileAttr> {
+        Ok(FileAttr { size: 0, is_dir: self.is_dir })
+    }
+    pub fn file_type(&self) -> io::Result<FileType> {
+        Ok(FileType { is_dir: self.is_dir })
+    }
+}
+
+impl OpenOptions {
+    pub fn new() -> OpenOptions {
+        OpenOptions::default()
+    }
+    pub fn read(&mut self, read: bool) {
+        self.read = read;
+    }
+    pub fn write(&mut self, write: bool) {
+        self.write = write;
+    }
+    pub fn append(&mut self, append: bool) {
+        self.append = append;
+    }
+    pub fn truncate(&mut self, truncate: bool) {
+        self.truncate = truncate;
+    }
+    pub fn create(&mut self, create: bool) {
+        self.create = create;
+    }
+    pub fn create_new(&mut self, create_new: bool) {
+        self.create_new = create_new;
+    }
+}
+
+impl File {
+    pub fn open(path: &Path, opts: &OpenOptions) -> io::Result<File> {
+        let port = vfs_port()?;
+        let pid = getpid();
+        let mut flags = 0u32;
+        if opts.create || opts.create_new {
+            flags |= O_CREATE;
+        }
+        if opts.truncate {
+            flags |= O_TRUNC;
+        }
+        let pb = path_bytes(path)?;
+        let mut body = Vec::with_capacity(9 + pb.len());
+        body.extend_from_slice(&pid.to_le_bytes());
+        body.push(pb.len() as u8);
+        body.extend_from_slice(&pb);
+        body.extend_from_slice(&flags.to_le_bytes());
+        let rx = call(port, OP_OPEN, &body, 8)?;
+        Ok(File { port, pid, fd: read_u32(&rx, BODY_OFF) })
+    }
+
+    pub fn file_attr(&self) -> io::Result<FileAttr> {
+        unsupported()
+    }
+
+    pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        let want = buf.len().min(65536) as u32;
+        let mut body = Vec::with_capacity(12);
+        body.extend_from_slice(&self.pid.to_le_bytes());
+        body.extend_from_slice(&self.fd.to_le_bytes());
+        body.extend_from_slice(&want.to_le_bytes());
+        let rx = call(self.port, OP_READ, &body, 65536)?;
+        let data = &rx[BODY_OFF..];
+        let n = data.len().min(buf.len());
+        buf[..n].copy_from_slice(&data[..n]);
+        Ok(n)
+    }
+
+    pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
+        let mut body = Vec::with_capacity(8 + buf.len());
+        body.extend_from_slice(&self.pid.to_le_bytes());
+        body.extend_from_slice(&self.fd.to_le_bytes());
+        body.extend_from_slice(buf);
+        let rx = call(self.port, OP_WRITE, &body, 8)?;
+        Ok(read_u32(&rx, BODY_OFF) as usize)
+    }
+
+    pub fn read_buf(&self, mut cursor: BorrowedCursor<'_>) -> io::Result<()> {
+        let mut tmp = [0u8; 4096];
+        let n = self.read(&mut tmp)?;
+        cursor.append(&tmp[..n]);
+        Ok(())
+    }
+
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        for b in bufs {
+            if !b.is_empty() {
+                return self.read(b);
+            }
+        }
+        Ok(0)
+    }
+
+    pub fn is_read_vectored(&self) -> bool {
+        false
+    }
+
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        for b in bufs {
+            if !b.is_empty() {
+                return self.write(b);
+            }
+        }
+        Ok(0)
+    }
+
+    pub fn is_write_vectored(&self) -> bool {
+        false
+    }
+
+    pub fn flush(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub fn fsync(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub fn datasync(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub fn lock(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub fn lock_shared(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub fn try_lock(&self) -> Result<(), TryLockError> {
+        Ok(())
+    }
+
+    pub fn try_lock_shared(&self) -> Result<(), TryLockError> {
+        Ok(())
+    }
+
+    pub fn unlock(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub fn truncate(&self, _size: u64) -> io::Result<()> {
+        unsupported()
+    }
+
+    pub fn seek(&self, _pos: SeekFrom) -> io::Result<u64> {
+        unsupported()
+    }
+
+    pub fn size(&self) -> Option<io::Result<u64>> {
+        None
+    }
+
+    pub fn tell(&self) -> io::Result<u64> {
+        unsupported()
+    }
+
+    pub fn duplicate(&self) -> io::Result<File> {
+        unsupported()
+    }
+
+    pub fn set_permissions(&self, _perm: FilePermissions) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub fn set_times(&self, _times: FileTimes) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Drop for File {
+    fn drop(&mut self) {
+        let mut body = [0u8; 8];
+        body[..4].copy_from_slice(&self.pid.to_le_bytes());
+        body[4..8].copy_from_slice(&self.fd.to_le_bytes());
+        let _ = call(self.port, OP_CLOSE, &body, 0);
+    }
+}
+
+impl DirBuilder {
+    pub fn new() -> DirBuilder {
+        DirBuilder {}
+    }
+    pub fn mkdir(&self, p: &Path) -> io::Result<()> {
+        let port = vfs_port()?;
+        call(port, OP_MKDIR, &path_body(getpid(), p)?, 0).map(|_| ())
+    }
+}
+
+impl fmt::Debug for File {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("File").field("fd", &self.fd).finish()
+    }
+}
+
+pub fn readdir(p: &Path) -> io::Result<ReadDir> {
+    let port = vfs_port()?;
+    let rx = call(port, OP_LIST, &path_body(getpid(), p)?, 65536)?;
+    let mut out: Vec<DirEntry> = Vec::new();
+    let mut body = &rx[BODY_OFF..];
+    while !body.is_empty() {
+        let len = body[0] as usize;
+        if body.len() < 1 + len {
+            break;
+        }
+        if let Ok(name) = crate::str::from_utf8(&body[1..1 + len]) {
+            let is_dir = name.ends_with('/');
+            let trimmed = name.trim_end_matches('/');
+            out.push(DirEntry { name: PathBuf::from(trimmed), is_dir });
+        }
+        body = &body[1 + len..];
+    }
+    Ok(ReadDir { entries: out.into_iter() })
+}
+
+pub fn unlink(p: &Path) -> io::Result<()> {
+    let port = vfs_port()?;
+    call(port, OP_UNLINK, &path_body(getpid(), p)?, 0).map(|_| ())
+}
+
+pub fn stat(p: &Path) -> io::Result<FileAttr> {
+    let port = vfs_port()?;
+    let rx = call(port, OP_STAT, &path_body(getpid(), p)?, 16)?;
+    let b = &rx[BODY_OFF..];
+    if b.len() < 12 {
+        return Err(err("short stat"));
+    }
+    let size = u64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]);
+    let flags = read_u32(b, 8);
+    Ok(FileAttr { size, is_dir: flags & 1 != 0 })
+}
+
+pub fn lstat(p: &Path) -> io::Result<FileAttr> {
+    stat(p)
+}
+
+pub fn exists(p: &Path) -> io::Result<bool> {
+    Ok(stat(p).is_ok())
+}
+
+pub fn rmdir(p: &Path) -> io::Result<()> {
+    unlink(p)
+}
+
+pub fn rename(_old: &Path, _new: &Path) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn set_perm(_p: &Path, _perm: FilePermissions) -> io::Result<()> {
+    Ok(())
+}
+
+pub fn set_times(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    Ok(())
+}
+
+pub fn set_times_nofollow(_p: &Path, _times: FileTimes) -> io::Result<()> {
+    Ok(())
+}
+
+pub fn remove_dir_all(_path: &Path) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn readlink(_p: &Path) -> io::Result<PathBuf> {
+    unsupported()
+}
+
+pub fn symlink(_original: &Path, _link: &Path) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn link(_src: &Path, _dst: &Path) -> io::Result<()> {
+    unsupported()
+}
+
+pub fn canonicalize(_p: &Path) -> io::Result<PathBuf> {
+    unsupported()
+}
+
+pub fn copy(from: &Path, to: &Path) -> io::Result<u64> {
+    let mut ro = OpenOptions::new();
+    ro.read(true);
+    let mut data = Vec::new();
+    {
+        let f = File::open(from, &ro)?;
+        let mut chunk = [0u8; 4096];
+        loop {
+            let n = f.read(&mut chunk)?;
+            if n == 0 {
+                break;
+            }
+            data.extend_from_slice(&chunk[..n]);
+        }
+    }
+    let mut wo = OpenOptions::new();
+    wo.write(true);
+    wo.create(true);
+    wo.truncate(true);
+    let out = File::open(to, &wo)?;
+    out.write(&data)?;
+    Ok(data.len() as u64)
+}

--- a/toolchain/nonos-std/sys/net/connection/nonos.rs
+++ b/toolchain/nonos-std/sys/net/connection/nonos.rs
@@ -1,0 +1,523 @@
+// NONOS std net: TCP/UDP over the net.sockets capsule and DNS over the
+// net.dns capsule, via IPC. Core connect/read/write, bind/accept, and
+// send/recv are wired; socket options are best-effort no-ops, and IPv6
+// and multicast are unsupported (the userland stack is IPv4).
+
+use crate::fmt;
+use crate::io::{self, BorrowedCursor, Error, ErrorKind, IoSlice, IoSliceMut};
+use crate::net::{Ipv4Addr, Ipv6Addr, Shutdown, SocketAddr, SocketAddrV4, ToSocketAddrs};
+use crate::sys::unsupported;
+use crate::time::Duration;
+use crate::vec::Vec;
+
+const SK_NAME: &[u8] = b"net.sockets";
+const SK_MAGIC: u32 = 0x4E53_4B54;
+const DNS_NAME: &[u8] = b"net.dns";
+const DNS_MAGIC: u32 = 0x4E44_4E53;
+const BODY: usize = 20;
+const MAX_PAYLOAD: usize = 1536;
+const OP_SOCKET: u16 = 2;
+const OP_BIND: u16 = 3;
+const OP_LISTEN: u16 = 4;
+const OP_ACCEPT: u16 = 5;
+const OP_CONNECT: u16 = 6;
+const OP_SEND: u16 = 7;
+const OP_RECV: u16 = 8;
+const OP_CLOSE: u16 = 9;
+
+const fn tag4(b: &[u8; 4]) -> i64 {
+    (b[0] as i64) | ((b[1] as i64) << 8) | ((b[2] as i64) << 16) | ((b[3] as i64) << 24)
+}
+
+unsafe fn sys5(num: i64, a1: u64, a2: u64, a3: u64, a4: u64, a5: u64) -> i64 {
+    let r: i64;
+    unsafe {
+        core::arch::asm!("syscall", inout("rax") num => r, in("rdi") a1, in("rsi") a2,
+            in("rdx") a3, in("r10") a4, in("r8") a5, out("rcx") _, out("r11") _);
+    }
+    r
+}
+
+fn err(msg: &'static str) -> Error {
+    Error::new(ErrorKind::Other, msg)
+}
+
+fn read_u32(b: &[u8], off: usize) -> u32 {
+    if b.len() < off + 4 {
+        return 0;
+    }
+    u32::from_le_bytes([b[off], b[off + 1], b[off + 2], b[off + 3]])
+}
+
+fn ipc(service: &[u8], magic: u32, op: u16, body: &[u8], reply_cap: usize) -> io::Result<Vec<u8>> {
+    let mut port = 0u32;
+    let mut owner = 0u32;
+    let rc = unsafe {
+        sys5(tag4(b"MSVL"), service.as_ptr() as u64, service.len() as u64,
+            &mut port as *mut u32 as u64, &mut owner as *mut u32 as u64, 0)
+    };
+    if rc != 0 {
+        return Err(err("net service unavailable"));
+    }
+    let mut tx = Vec::with_capacity(BODY + body.len());
+    tx.extend_from_slice(&magic.to_le_bytes());
+    tx.extend_from_slice(&1u16.to_le_bytes());
+    tx.extend_from_slice(&op.to_le_bytes());
+    tx.extend_from_slice(&0u32.to_le_bytes());
+    tx.extend_from_slice(&0u32.to_le_bytes());
+    tx.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    tx.extend_from_slice(body);
+    let mut rx = crate::vec![0u8; BODY + reply_cap];
+    let n = unsafe {
+        sys5(tag4(b"MICL"), port as u64, tx.as_ptr() as u64, tx.len() as u64,
+            rx.as_mut_ptr() as u64, rx.len() as u64)
+    };
+    if n < BODY as i64 {
+        return Err(err("net ipc failed"));
+    }
+    if u16::from_le_bytes([rx[8], rx[9]]) != 0 {
+        return Err(err("net op rejected"));
+    }
+    rx.truncate(n as usize);
+    Ok(rx)
+}
+
+fn sk(op: u16, body: &[u8], cap: usize) -> io::Result<Vec<u8>> {
+    ipc(SK_NAME, SK_MAGIC, op, body, cap)
+}
+
+fn v4_parts(addr: &SocketAddr) -> io::Result<([u8; 4], u16)> {
+    match addr {
+        SocketAddr::V4(a) => Ok((a.ip().octets(), a.port())),
+        SocketAddr::V6(_) => Err(err("ipv6 unsupported")),
+    }
+}
+
+fn endpoint(handle: u32, ip: [u8; 4], port: u16) -> [u8; 10] {
+    let mut b = [0u8; 10];
+    b[0..4].copy_from_slice(&handle.to_le_bytes());
+    b[4..8].copy_from_slice(&ip);
+    b[8..10].copy_from_slice(&port.to_le_bytes());
+    b
+}
+
+fn open_socket(kind: u16) -> io::Result<u32> {
+    let mut body = [0u8; 4];
+    body[0..2].copy_from_slice(&4u16.to_le_bytes());
+    body[2..4].copy_from_slice(&kind.to_le_bytes());
+    Ok(read_u32(&sk(OP_SOCKET, &body, 8)?, BODY))
+}
+
+fn send_on(handle: u32, buf: &[u8]) -> io::Result<usize> {
+    let n = buf.len().min(MAX_PAYLOAD);
+    let mut body = Vec::with_capacity(4 + n);
+    body.extend_from_slice(&handle.to_le_bytes());
+    body.extend_from_slice(&buf[..n]);
+    sk(OP_SEND, &body, 0)?;
+    Ok(n)
+}
+
+fn recv_on(handle: u32, buf: &mut [u8]) -> io::Result<usize> {
+    let rx = sk(OP_RECV, &handle.to_le_bytes(), MAX_PAYLOAD)?;
+    let data = &rx[BODY..];
+    let n = data.len().min(buf.len());
+    buf[..n].copy_from_slice(&data[..n]);
+    Ok(n)
+}
+
+fn close(handle: u32) {
+    let _ = sk(OP_CLOSE, &handle.to_le_bytes(), 0);
+}
+
+fn unspecified() -> SocketAddr {
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0))
+}
+
+pub struct TcpStream {
+    handle: u32,
+    peer: SocketAddr,
+}
+
+impl TcpStream {
+    pub fn connect<A: ToSocketAddrs>(addr: A) -> io::Result<TcpStream> {
+        let mut last = err("no address");
+        for a in addr.to_socket_addrs()? {
+            match Self::connect_addr(&a) {
+                Ok(s) => return Ok(s),
+                Err(e) => last = e,
+            }
+        }
+        Err(last)
+    }
+
+    fn connect_addr(addr: &SocketAddr) -> io::Result<TcpStream> {
+        let (ip, port) = v4_parts(addr)?;
+        let handle = open_socket(1)?;
+        if let Err(e) = sk(OP_CONNECT, &endpoint(handle, ip, port), 0) {
+            close(handle);
+            return Err(e);
+        }
+        Ok(TcpStream { handle, peer: *addr })
+    }
+
+    pub fn connect_timeout(addr: &SocketAddr, _: Duration) -> io::Result<TcpStream> {
+        Self::connect_addr(addr)
+    }
+
+    pub fn set_read_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn set_write_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
+        Ok(None)
+    }
+    pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
+        Ok(None)
+    }
+    pub fn peek(&self, _: &mut [u8]) -> io::Result<usize> {
+        unsupported()
+    }
+    pub fn read(&self, buf: &mut [u8]) -> io::Result<usize> {
+        recv_on(self.handle, buf)
+    }
+    pub fn read_buf(&self, mut cursor: BorrowedCursor<'_>) -> io::Result<()> {
+        let mut tmp = [0u8; 1536];
+        let n = self.read(&mut tmp)?;
+        cursor.append(&tmp[..n]);
+        Ok(())
+    }
+    pub fn read_vectored(&self, bufs: &mut [IoSliceMut<'_>]) -> io::Result<usize> {
+        for b in bufs {
+            if !b.is_empty() {
+                return self.read(b);
+            }
+        }
+        Ok(0)
+    }
+    pub fn is_read_vectored(&self) -> bool {
+        false
+    }
+    pub fn write(&self, buf: &[u8]) -> io::Result<usize> {
+        send_on(self.handle, buf)
+    }
+    pub fn write_vectored(&self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+        for b in bufs {
+            if !b.is_empty() {
+                return self.write(b);
+            }
+        }
+        Ok(0)
+    }
+    pub fn is_write_vectored(&self) -> bool {
+        false
+    }
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.peer)
+    }
+    pub fn socket_addr(&self) -> io::Result<SocketAddr> {
+        Ok(unspecified())
+    }
+    pub fn shutdown(&self, _: Shutdown) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn duplicate(&self) -> io::Result<TcpStream> {
+        unsupported()
+    }
+    pub fn set_linger(&self, _: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn linger(&self) -> io::Result<Option<Duration>> {
+        Ok(None)
+    }
+    pub fn set_nodelay(&self, _: bool) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn nodelay(&self) -> io::Result<bool> {
+        Ok(false)
+    }
+    pub fn set_ttl(&self, _: u32) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn ttl(&self) -> io::Result<u32> {
+        Ok(64)
+    }
+    pub fn take_error(&self) -> io::Result<Option<io::Error>> {
+        Ok(None)
+    }
+    pub fn set_nonblocking(&self, _: bool) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Drop for TcpStream {
+    fn drop(&mut self) {
+        close(self.handle);
+    }
+}
+
+impl fmt::Debug for TcpStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TcpStream").field("peer", &self.peer).finish()
+    }
+}
+
+pub struct TcpListener {
+    handle: u32,
+    local: SocketAddr,
+}
+
+impl TcpListener {
+    pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<TcpListener> {
+        let mut last = err("no address");
+        for a in addr.to_socket_addrs()? {
+            match Self::bind_addr(&a) {
+                Ok(l) => return Ok(l),
+                Err(e) => last = e,
+            }
+        }
+        Err(last)
+    }
+
+    fn bind_addr(addr: &SocketAddr) -> io::Result<TcpListener> {
+        let (ip, port) = v4_parts(addr)?;
+        let handle = open_socket(1)?;
+        if let Err(e) = sk(OP_BIND, &endpoint(handle, ip, port), 0) {
+            close(handle);
+            return Err(e);
+        }
+        if let Err(e) = sk(OP_LISTEN, &handle.to_le_bytes(), 0) {
+            close(handle);
+            return Err(e);
+        }
+        Ok(TcpListener { handle, local: *addr })
+    }
+
+    pub fn socket_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.local)
+    }
+    pub fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
+        let child = read_u32(&sk(OP_ACCEPT, &self.handle.to_le_bytes(), 8)?, BODY);
+        Ok((TcpStream { handle: child, peer: unspecified() }, unspecified()))
+    }
+    pub fn duplicate(&self) -> io::Result<TcpListener> {
+        unsupported()
+    }
+    pub fn set_ttl(&self, _: u32) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn ttl(&self) -> io::Result<u32> {
+        Ok(64)
+    }
+    pub fn set_only_v6(&self, _: bool) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn only_v6(&self) -> io::Result<bool> {
+        Ok(false)
+    }
+    pub fn take_error(&self) -> io::Result<Option<io::Error>> {
+        Ok(None)
+    }
+    pub fn set_nonblocking(&self, _: bool) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Drop for TcpListener {
+    fn drop(&mut self) {
+        close(self.handle);
+    }
+}
+
+impl fmt::Debug for TcpListener {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TcpListener").field("local", &self.local).finish()
+    }
+}
+
+pub struct UdpSocket {
+    handle: u32,
+    local: SocketAddr,
+}
+
+impl UdpSocket {
+    pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<UdpSocket> {
+        let mut last = err("no address");
+        for a in addr.to_socket_addrs()? {
+            let (ip, port) = match v4_parts(&a) {
+                Ok(v) => v,
+                Err(e) => {
+                    last = e;
+                    continue;
+                }
+            };
+            let handle = open_socket(2)?;
+            match sk(OP_BIND, &endpoint(handle, ip, port), 0) {
+                Ok(_) => return Ok(UdpSocket { handle, local: a }),
+                Err(e) => {
+                    close(handle);
+                    last = e;
+                }
+            }
+        }
+        Err(last)
+    }
+
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        Ok(unspecified())
+    }
+    pub fn socket_addr(&self) -> io::Result<SocketAddr> {
+        Ok(self.local)
+    }
+    pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+        let n = recv_on(self.handle, buf)?;
+        Ok((n, unspecified()))
+    }
+    pub fn peek_from(&self, _: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+        unsupported()
+    }
+    pub fn send_to(&self, buf: &[u8], addr: &SocketAddr) -> io::Result<usize> {
+        let (ip, port) = v4_parts(addr)?;
+        sk(OP_CONNECT, &endpoint(self.handle, ip, port), 0)?;
+        send_on(self.handle, buf)
+    }
+    pub fn duplicate(&self) -> io::Result<UdpSocket> {
+        unsupported()
+    }
+    pub fn set_read_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn set_write_timeout(&self, _: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn read_timeout(&self) -> io::Result<Option<Duration>> {
+        Ok(None)
+    }
+    pub fn write_timeout(&self) -> io::Result<Option<Duration>> {
+        Ok(None)
+    }
+    pub fn set_broadcast(&self, _: bool) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn broadcast(&self) -> io::Result<bool> {
+        Ok(false)
+    }
+    pub fn set_multicast_loop_v4(&self, _: bool) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn multicast_loop_v4(&self) -> io::Result<bool> {
+        Ok(false)
+    }
+    pub fn set_multicast_ttl_v4(&self, _: u32) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn multicast_ttl_v4(&self) -> io::Result<u32> {
+        Ok(1)
+    }
+    pub fn set_multicast_loop_v6(&self, _: bool) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn multicast_loop_v6(&self) -> io::Result<bool> {
+        Ok(false)
+    }
+    pub fn join_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr) -> io::Result<()> {
+        unsupported()
+    }
+    pub fn join_multicast_v6(&self, _: &Ipv6Addr, _: u32) -> io::Result<()> {
+        unsupported()
+    }
+    pub fn leave_multicast_v4(&self, _: &Ipv4Addr, _: &Ipv4Addr) -> io::Result<()> {
+        unsupported()
+    }
+    pub fn leave_multicast_v6(&self, _: &Ipv6Addr, _: u32) -> io::Result<()> {
+        unsupported()
+    }
+    pub fn set_ttl(&self, _: u32) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn ttl(&self) -> io::Result<u32> {
+        Ok(64)
+    }
+    pub fn take_error(&self) -> io::Result<Option<io::Error>> {
+        Ok(None)
+    }
+    pub fn set_nonblocking(&self, _: bool) -> io::Result<()> {
+        Ok(())
+    }
+    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        recv_on(self.handle, buf)
+    }
+    pub fn peek(&self, _: &mut [u8]) -> io::Result<usize> {
+        unsupported()
+    }
+    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        send_on(self.handle, buf)
+    }
+    pub fn connect<A: ToSocketAddrs>(&self, addr: A) -> io::Result<()> {
+        let mut last = err("no address");
+        for a in addr.to_socket_addrs()? {
+            let (ip, port) = match v4_parts(&a) {
+                Ok(v) => v,
+                Err(e) => {
+                    last = e;
+                    continue;
+                }
+            };
+            match sk(OP_CONNECT, &endpoint(self.handle, ip, port), 0) {
+                Ok(_) => return Ok(()),
+                Err(e) => last = e,
+            }
+        }
+        Err(last)
+    }
+}
+
+impl Drop for UdpSocket {
+    fn drop(&mut self) {
+        close(self.handle);
+    }
+}
+
+impl fmt::Debug for UdpSocket {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UdpSocket").field("local", &self.local).finish()
+    }
+}
+
+pub struct LookupHost {
+    it: crate::vec::IntoIter<SocketAddr>,
+    port: u16,
+}
+
+impl LookupHost {
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+impl Iterator for LookupHost {
+    type Item = SocketAddr;
+    fn next(&mut self) -> Option<SocketAddr> {
+        self.it.next()
+    }
+}
+
+pub fn lookup_host(host: &str, port: u16) -> io::Result<LookupHost> {
+    let ip = if let Ok(v4) = host.parse::<Ipv4Addr>() {
+        v4
+    } else {
+        if host.is_empty() || host.len() > 255 {
+            return Err(err("bad hostname"));
+        }
+        let rx = ipc(DNS_NAME, DNS_MAGIC, 2, host.as_bytes(), 4)?;
+        let b = &rx[BODY..];
+        if b.len() < 4 {
+            return Err(err("dns short reply"));
+        }
+        Ipv4Addr::new(b[0], b[1], b[2], b[3])
+    };
+    let mut v: Vec<SocketAddr> = Vec::with_capacity(1);
+    v.push(SocketAddr::V4(SocketAddrV4::new(ip, port)));
+    Ok(LookupHost { it: v.into_iter(), port })
+}

--- a/toolchain/nonos-std/sys/pal/nonos/mod.rs
+++ b/toolchain/nonos-std/sys/pal/nonos/mod.rs
@@ -1,0 +1,10 @@
+// NONOS std PAL bootstrap. Reuses the unsupported os and common layers
+// (init, cleanup, abort, the os stubs) and provides a real time clock.
+#![deny(unsafe_op_in_unsafe_fn)]
+
+pub mod os;
+pub mod time;
+
+#[path = "../unsupported/common.rs"]
+mod common;
+pub use common::*;

--- a/toolchain/nonos-std/sys/pal/nonos/os.rs
+++ b/toolchain/nonos-std/sys/pal/nonos/os.rs
@@ -1,0 +1,82 @@
+// NONOS pal os: real process exit (mk_exit) and pid (mk_getpid). A capsule
+// has no working directory, environment, or executable path, so those stay
+// unsupported.
+
+use super::unsupported;
+use crate::ffi::{OsStr, OsString};
+use crate::marker::PhantomData;
+use crate::path::{self, PathBuf};
+use crate::{fmt, io};
+
+const fn tag4(b: &[u8; 4]) -> i64 {
+    (b[0] as i64) | ((b[1] as i64) << 8) | ((b[2] as i64) << 16) | ((b[3] as i64) << 24)
+}
+
+const N_MK_EXIT: i64 = tag4(b"MEXT");
+const N_MK_GETPID: i64 = tag4(b"MGPD");
+
+pub fn getcwd() -> io::Result<PathBuf> {
+    unsupported()
+}
+
+pub fn chdir(_: &path::Path) -> io::Result<()> {
+    unsupported()
+}
+
+pub struct SplitPaths<'a>(!, PhantomData<&'a ()>);
+
+pub fn split_paths(_unparsed: &OsStr) -> SplitPaths<'_> {
+    panic!("unsupported")
+}
+
+impl<'a> Iterator for SplitPaths<'a> {
+    type Item = PathBuf;
+    fn next(&mut self) -> Option<PathBuf> {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+pub struct JoinPathsError;
+
+pub fn join_paths<I, T>(_paths: I) -> Result<OsString, JoinPathsError>
+where
+    I: Iterator<Item = T>,
+    T: AsRef<OsStr>,
+{
+    Err(JoinPathsError)
+}
+
+impl fmt::Display for JoinPathsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        "not supported on this platform yet".fmt(f)
+    }
+}
+
+impl crate::error::Error for JoinPathsError {}
+
+pub fn current_exe() -> io::Result<PathBuf> {
+    unsupported()
+}
+
+pub fn temp_dir() -> PathBuf {
+    panic!("no filesystem on this platform")
+}
+
+pub fn home_dir() -> Option<PathBuf> {
+    None
+}
+
+pub fn exit(code: i32) -> ! {
+    unsafe {
+        core::arch::asm!("syscall", in("rax") N_MK_EXIT, in("rdi") code as u64, options(noreturn));
+    }
+}
+
+pub fn getpid() -> u32 {
+    let r: i64;
+    unsafe {
+        core::arch::asm!("syscall", inout("rax") N_MK_GETPID => r, out("rcx") _, out("r11") _);
+    }
+    if r < 0 { 0 } else { r as u32 }
+}

--- a/toolchain/nonos-std/sys/pal/nonos/time.rs
+++ b/toolchain/nonos-std/sys/pal/nonos/time.rs
@@ -1,0 +1,71 @@
+// NONOS std PAL: monotonic and wall-clock time via the mk_time_millis
+// syscall (the same source the userland libc mk_time_millis uses).
+// Millisecond resolution; both clocks read the kernel timer.
+
+use crate::time::Duration;
+
+const fn tag4(b: &[u8; 4]) -> i64 {
+    (b[0] as i64) | ((b[1] as i64) << 8) | ((b[2] as i64) << 16) | ((b[3] as i64) << 24)
+}
+
+const N_MK_TIME_MILLIS: i64 = tag4(b"MTMS");
+
+fn now_ms() -> u64 {
+    let r: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            inout("rax") N_MK_TIME_MILLIS => r,
+            out("rcx") _,
+            out("r11") _,
+        );
+    }
+    if r < 0 { 0 } else { r as u64 }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct Instant(Duration);
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub struct SystemTime(Duration);
+
+pub const UNIX_EPOCH: SystemTime = SystemTime(Duration::from_secs(0));
+
+impl Instant {
+    pub fn now() -> Instant {
+        Instant(Duration::from_millis(now_ms()))
+    }
+
+    pub fn checked_sub_instant(&self, other: &Instant) -> Option<Duration> {
+        self.0.checked_sub(other.0)
+    }
+
+    pub fn checked_add_duration(&self, other: &Duration) -> Option<Instant> {
+        Some(Instant(self.0.checked_add(*other)?))
+    }
+
+    pub fn checked_sub_duration(&self, other: &Duration) -> Option<Instant> {
+        Some(Instant(self.0.checked_sub(*other)?))
+    }
+}
+
+impl SystemTime {
+    pub const MAX: SystemTime = SystemTime(Duration::MAX);
+    pub const MIN: SystemTime = SystemTime(Duration::ZERO);
+
+    pub fn now() -> SystemTime {
+        SystemTime(Duration::from_millis(now_ms()))
+    }
+
+    pub fn sub_time(&self, other: &SystemTime) -> Result<Duration, Duration> {
+        self.0.checked_sub(other.0).ok_or_else(|| other.0 - self.0)
+    }
+
+    pub fn checked_add_duration(&self, other: &Duration) -> Option<SystemTime> {
+        Some(SystemTime(self.0.checked_add(*other)?))
+    }
+
+    pub fn checked_sub_duration(&self, other: &Duration) -> Option<SystemTime> {
+        Some(SystemTime(self.0.checked_sub(*other)?))
+    }
+}

--- a/toolchain/nonos-std/sys/stdio/nonos.rs
+++ b/toolchain/nonos-std/sys/stdio/nonos.rs
@@ -1,0 +1,76 @@
+// NONOS std PAL: stdout/stderr via the kernel debug syscall (serial sink),
+// the same path the userland libc `mk_debug` uses. Stdin is empty until a
+// console source is wired. Raw syscall: rax = tag, rdi/rsi = (buf, len).
+
+use crate::io;
+
+const fn tag4(b: &[u8; 4]) -> i64 {
+    (b[0] as i64) | ((b[1] as i64) << 8) | ((b[2] as i64) << 16) | ((b[3] as i64) << 24)
+}
+
+const N_MK_DEBUG: i64 = tag4(b"MDBG");
+const CHUNK: usize = 240;
+
+#[inline]
+unsafe fn debug_write(ptr: *const u8, len: usize) {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            inout("rax") N_MK_DEBUG => ret,
+            in("rdi") ptr as u64,
+            in("rsi") len as u64,
+            out("rcx") _,
+            out("r11") _,
+        );
+    }
+    let _ = ret;
+}
+
+pub struct Stdin;
+pub struct Stdout;
+pub type Stderr = Stdout;
+
+impl Stdin {
+    pub const fn new() -> Stdin {
+        Stdin
+    }
+}
+
+impl io::Read for Stdin {
+    fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+        Ok(0)
+    }
+}
+
+impl Stdout {
+    pub const fn new() -> Stdout {
+        Stdout
+    }
+}
+
+impl io::Write for Stdout {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut off = 0;
+        while off < buf.len() {
+            let n = core::cmp::min(CHUNK, buf.len() - off);
+            unsafe { debug_write(buf[off..].as_ptr(), n) };
+            off += n;
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+pub const STDIN_BUF_SIZE: usize = 0;
+
+pub fn is_ebadf(_err: &io::Error) -> bool {
+    true
+}
+
+pub fn panic_output() -> Option<Vec<u8>> {
+    Some(Vec::new())
+}

--- a/toolchain/nonos-std/sys/thread/nonos.rs
+++ b/toolchain/nonos-std/sys/thread/nonos.rs
@@ -1,0 +1,128 @@
+// NONOS std threads: real OS threads via the mk_thread_spawn syscall. The
+// kernel creates a thread sharing the capsule's address space; we hand it an
+// mmap'd stack whose top word holds the boxed start routine. A small naked
+// trampoline pops that pointer into rdi and calls the Rust entry. Join spins
+// on a shared flag the thread sets before it exits (single-core, cooperative).
+
+use crate::ffi::CStr;
+use crate::io;
+use crate::num::NonZero;
+use crate::sync::Arc;
+use crate::sync::atomic::{AtomicBool, Ordering};
+use crate::thread::ThreadInit;
+use crate::time::Duration;
+
+const fn tag4(b: &[u8; 4]) -> i64 {
+    (b[0] as i64) | ((b[1] as i64) << 8) | ((b[2] as i64) << 16) | ((b[3] as i64) << 24)
+}
+
+const N_MK_THREAD_SPAWN: i64 = tag4(b"MTSP");
+const N_MK_MMAP: i64 = tag4(b"MMAP");
+const N_MK_EXIT: i64 = tag4(b"MEXT");
+const N_MK_YIELD: i64 = tag4(b"MYLD");
+const N_MK_TIME_MILLIS: i64 = tag4(b"MTMS");
+
+pub const DEFAULT_MIN_STACK_SIZE: usize = 1 << 20;
+
+unsafe fn mmap(len: usize) -> *mut u8 {
+    let r: i64;
+    unsafe {
+        core::arch::asm!("syscall", inout("rax") N_MK_MMAP => r, in("rdi") 0u64,
+            in("rsi") len as u64, in("rdx") 3u64, in("r10") 0u64, out("rcx") _, out("r11") _);
+    }
+    if r <= 0 { core::ptr::null_mut() } else { r as *mut u8 }
+}
+
+fn raw_yield() {
+    unsafe {
+        core::arch::asm!("syscall", in("rax") N_MK_YIELD, out("rcx") _, out("r11") _);
+    }
+}
+
+fn now_ms() -> u64 {
+    let r: i64;
+    unsafe {
+        core::arch::asm!("syscall", inout("rax") N_MK_TIME_MILLIS => r, out("rcx") _, out("r11") _);
+    }
+    if r < 0 { 0 } else { r as u64 }
+}
+
+struct Start {
+    init: Box<ThreadInit>,
+    done: Arc<AtomicBool>,
+}
+
+#[unsafe(naked)]
+unsafe extern "C" fn trampoline() -> ! {
+    core::arch::naked_asm!("pop rdi", "call {f}", "ud2", f = sym thread_main);
+}
+
+extern "C" fn thread_main(arg: *mut u8) -> ! {
+    let start = unsafe { Box::from_raw(arg as *mut Start) };
+    let run = start.init.init();
+    run();
+    start.done.store(true, Ordering::Release);
+    unsafe {
+        core::arch::asm!("syscall", in("rax") N_MK_EXIT, in("rdi") 0u64, options(noreturn));
+    }
+}
+
+pub struct Thread {
+    done: Arc<AtomicBool>,
+}
+
+impl Thread {
+    pub unsafe fn new(stack: usize, init: Box<ThreadInit>) -> io::Result<Thread> {
+        let done = Arc::new(AtomicBool::new(false));
+        let start = Box::new(Start { init, done: done.clone() });
+        let raw = Box::into_raw(start);
+        let size = if stack < DEFAULT_MIN_STACK_SIZE { DEFAULT_MIN_STACK_SIZE } else { stack };
+        let base = unsafe { mmap(size) };
+        if base.is_null() {
+            drop(unsafe { Box::from_raw(raw) });
+            return Err(io::Error::from(io::ErrorKind::OutOfMemory));
+        }
+        let top = base as usize + size;
+        let sp = (top & !0xf) - 8;
+        unsafe { *(sp as *mut u64) = raw as u64 };
+        let tid: i64;
+        unsafe {
+            core::arch::asm!("syscall", inout("rax") N_MK_THREAD_SPAWN => tid,
+                in("rdi") trampoline as usize as u64, in("rsi") sp as u64,
+                out("rcx") _, out("r11") _);
+        }
+        if tid <= 0 {
+            drop(unsafe { Box::from_raw(raw) });
+            return Err(io::Error::from(io::ErrorKind::Other));
+        }
+        Ok(Thread { done })
+    }
+
+    pub fn join(self) {
+        while !self.done.load(Ordering::Acquire) {
+            raw_yield();
+        }
+    }
+}
+
+pub fn available_parallelism() -> io::Result<NonZero<usize>> {
+    Ok(NonZero::new(1).unwrap())
+}
+
+pub fn current_os_id() -> Option<u64> {
+    None
+}
+
+pub fn yield_now() {
+    raw_yield();
+}
+
+pub fn set_name(_name: &CStr) {}
+
+pub fn sleep(dur: Duration) {
+    let ms = dur.as_millis() as u64;
+    let start = now_ms();
+    while now_ms().wrapping_sub(start) < ms {
+        raw_yield();
+    }
+}


### PR DESCRIPTION
## What

Completes the NONOS std platform layer so an unmodified Rust crate builds for NONOS across the full ordinary-app surface, with no compiler fork. Extends the initial alloc/io/random modules (PR #187) to the whole standard library.

## Modules (all keyed on `target_vendor = "nonos"`, in `toolchain/nonos-std`)

- **alloc**: a real `dlmalloc` heap (the allocator std uses for wasm/sgx/xous) over the `MMAP` syscall, with free and coalescing, replacing the bump arena.
- **stdio** over `mk_debug`, **time** over `mk_time_millis`, **args** over `mk_args`.
- **fs** over the VFS: `File` open/read/write/close, `stat`, `unlink`, `mkdir`, `readdir`.
- **net** over `net.sockets` and `net.dns`: `TcpStream`, `TcpListener`, `UdpSocket`, and hostname resolution.
- **process** exit and id over `mk_exit` and `mk_getpid`.
- **threads** over the `mk_thread_spawn` syscall: spawn, join, yield, sleep. The kernel side of `mk_thread_spawn` lands in a separate kernel change; this module is the userspace half.

## Tooling

- `apply.sh` installs the whole layer into the pinned rust-src, idempotently, and adds nonos to the dlmalloc dependency gate. Re-run after a toolchain update.
- `nonos-pack.sh` builds an unmodified std crate into a NONOS executable in one command.

## Verification

Each module is verified by compiling and linking an unmodified `std` app that uses it (println/Vec/String, Instant, env::args, fs read/write/metadata, TcpStream connect, process::exit, thread::spawn+join). The compute/stdout/heap/time/args path runs standalone; fs/net/thread execute against the live services and are pending a boot-validation pass.

## Safety

Not part of any build graph; CI does not compile `toolchain/`. Keyed on the target vendor, so existing core+alloc capsules are unaffected.