### PR TITLE
feat(desktop-shell): hover-to-reveal the auto-hidden bottom dock

### DIFF
--- a/userland/capsule_desktop_shell/src/server/input.rs
+++ b/userland/capsule_desktop_shell/src/server/input.rs
@@ -14,7 +14,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use nonos_libc::{mk_time_millis, INPUT_KIND_BUTTON_DOWN, INPUT_KIND_TOUCH};
+use nonos_libc::{
+    mk_time_millis, INPUT_KIND_BUTTON_DOWN, INPUT_KIND_POINTER_ABS, INPUT_KIND_TOUCH,
+};
+
+const HOVER_REVEAL_BAND: u32 = 4;
 
 use crate::protocol::{read_i32, read_u16, read_u32};
 use crate::render::layout::bottom_dock_rect;
@@ -38,7 +42,14 @@ pub fn handle(ctx: &mut Context, buf: &[u8]) -> bool {
     let Some(y) = read_i32(buf, 20) else {
         return true;
     };
-    if x < 0 || y < 0 || !matches!(kind, INPUT_KIND_TOUCH | INPUT_KIND_BUTTON_DOWN) {
+    if x < 0 || y < 0 {
+        return true;
+    }
+    if kind == INPUT_KIND_POINTER_ABS {
+        hover_reveal(ctx, x as u32, y as u32);
+        return true;
+    }
+    if !matches!(kind, INPUT_KIND_TOUCH | INPUT_KIND_BUTTON_DOWN) {
         return true;
     }
     if !ctx.taskbar.visible {
@@ -51,4 +62,22 @@ pub fn handle(ctx: &mut Context, buf: &[u8]) -> bool {
     }
     launcher_focus::handle(ctx, x as u32, y as u32);
     true
+}
+
+fn hover_reveal(ctx: &mut Context, x: u32, y: u32) {
+    if !ctx.taskbar.visible {
+        if y >= ctx.height.saturating_sub(HOVER_REVEAL_BAND) {
+            reveal_taskbar(&mut ctx.taskbar, mk_time_millis());
+            refresh_taskbar(ctx);
+        }
+        return;
+    }
+    let dock = bottom_dock_rect(ctx.width, ctx.height);
+    let inside = x >= dock.x
+        && x < dock.x + dock.width
+        && y >= dock.y
+        && y < dock.y + dock.height;
+    if inside {
+        reveal_taskbar(&mut ctx.taskbar, mk_time_millis());
+    }
 }

--- a/userland/capsule_desktop_shell/src/server/input.rs
+++ b/userland/capsule_desktop_shell/src/server/input.rs
@@ -17,14 +17,13 @@
 use nonos_libc::{
     mk_time_millis, INPUT_KIND_BUTTON_DOWN, INPUT_KIND_POINTER_ABS, INPUT_KIND_TOUCH,
 };
-
-const HOVER_REVEAL_BAND: u32 = 4;
-
 use crate::protocol::{read_i32, read_u16, read_u32};
 use crate::render::layout::bottom_dock_rect;
 use crate::server::handlers::launcher_focus;
 use crate::server::refresh_taskbar::refresh_taskbar;
 use crate::state::{reveal_taskbar, Context};
+
+const HOVER_REVEAL_BAND: u32 = 4;
 
 pub fn handle(ctx: &mut Context, buf: &[u8]) -> bool {
     if buf.len() < 40 || read_u32(buf, 0) != Some(0x4E49_4E50) {
@@ -65,6 +64,9 @@ pub fn handle(ctx: &mut Context, buf: &[u8]) -> bool {
 }
 
 fn hover_reveal(ctx: &mut Context, x: u32, y: u32) {
+    if ctx.height == 0 {
+        return;
+    }
     if !ctx.taskbar.visible {
         if y >= ctx.height.saturating_sub(HOVER_REVEAL_BAND) {
             reveal_taskbar(&mut ctx.taskbar, mk_time_millis());

--- a/userland/capsule_desktop_shell/src/server/input.rs
+++ b/userland/capsule_desktop_shell/src/server/input.rs
@@ -21,7 +21,7 @@ use crate::protocol::{read_i32, read_u16, read_u32};
 use crate::render::layout::bottom_dock_rect;
 use crate::server::handlers::launcher_focus;
 use crate::server::refresh_taskbar::refresh_taskbar;
-use crate::state::{reveal_taskbar, Context};
+use crate::state::{collapse_taskbar, reveal_taskbar, Context};
 
 const HOVER_REVEAL_BAND: u32 = 4;
 
@@ -45,7 +45,7 @@ pub fn handle(ctx: &mut Context, buf: &[u8]) -> bool {
         return true;
     }
     if kind == INPUT_KIND_POINTER_ABS {
-        hover_reveal(ctx, x as u32, y as u32);
+        hover_reveal(ctx, y as u32);
         return true;
     }
     if !matches!(kind, INPUT_KIND_TOUCH | INPUT_KIND_BUTTON_DOWN) {
@@ -63,7 +63,7 @@ pub fn handle(ctx: &mut Context, buf: &[u8]) -> bool {
     true
 }
 
-fn hover_reveal(ctx: &mut Context, x: u32, y: u32) {
+fn hover_reveal(ctx: &mut Context, y: u32) {
     if ctx.height == 0 {
         return;
     }
@@ -74,12 +74,12 @@ fn hover_reveal(ctx: &mut Context, x: u32, y: u32) {
         }
         return;
     }
-    let dock = bottom_dock_rect(ctx.width, ctx.height);
-    let inside = x >= dock.x
-        && x < dock.x + dock.width
-        && y >= dock.y
-        && y < dock.y + dock.height;
-    if inside {
+    if y >= bottom_dock_rect(ctx.width, ctx.height).y {
         reveal_taskbar(&mut ctx.taskbar, mk_time_millis());
+        return;
+    }
+    if ctx.taskbar.open.iter().any(|open| *open) {
+        collapse_taskbar(&mut ctx.taskbar);
+        refresh_taskbar(ctx);
     }
 }

--- a/userland/capsule_desktop_shell/src/state/mod.rs
+++ b/userland/capsule_desktop_shell/src/state/mod.rs
@@ -30,8 +30,8 @@ pub use context::Context;
 pub use notify::NotifyLevel;
 pub use spotlight::SpotlightState;
 pub use taskbar::{
-    expire_taskbar_pulses, expire_taskbar_visibility, mark_taskbar_launch, new_taskbar_state,
-    reveal_taskbar, set_taskbar_open, TaskbarState, TASKBAR_NO_ACTIVE,
+    collapse_taskbar, expire_taskbar_pulses, expire_taskbar_visibility, mark_taskbar_launch,
+    new_taskbar_state, reveal_taskbar, set_taskbar_open, TaskbarState, TASKBAR_NO_ACTIVE,
 };
 pub use toasts::ToastQueue;
 pub use tray::{TrayEntry, TrayTable};

--- a/userland/capsule_desktop_shell/src/state/taskbar/collapse.rs
+++ b/userland/capsule_desktop_shell/src/state/taskbar/collapse.rs
@@ -14,20 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-mod collapse;
-mod expire_pulses;
-mod expire_visibility;
-mod mark_launch;
-mod new;
-mod reveal;
-mod set_open;
-mod types;
+use super::types::TaskbarState;
 
-pub use collapse::collapse_taskbar;
-pub use expire_pulses::expire_taskbar_pulses;
-pub use expire_visibility::expire_taskbar_visibility;
-pub use mark_launch::mark_taskbar_launch;
-pub use new::new_taskbar_state;
-pub use reveal::reveal_taskbar;
-pub use set_open::set_taskbar_open;
-pub use types::{TaskbarState, TASKBAR_NO_ACTIVE};
+pub fn collapse_taskbar(state: &mut TaskbarState) {
+    state.visible = false;
+    state.reveal_until_ms = 0;
+}


### PR DESCRIPTION
## Problem
When an app window covers the bottom of the screen, the auto-hidden dock could not be brought back: clicks hit-test to the topmost window (the app), so the shell never saw them. You were stuck with a single app.

## Fix
Shell-side only (`capsule_desktop_shell`). `input_router::mirror_shell_pointer` already delivers every pointer-motion event to the shell as `POINTER_ABS` with global screen coords, regardless of window stacking — so hover is the one input the shell reliably receives over another app's window. Act on it:

- **Reveal** when the cursor reaches a thin 4px bottom-edge band.
- **Keep open** while the cursor stays in the bottom zone (`y >= dock.y`, dock rect plus the gap down to the screen edge, kept contiguous so moving band→dock never collapses it).
- **Collapse** immediately when the cursor moves above the dock while an app is open.

Empty-desktop dock never auto-hides (gated on `taskbar.open.any()`).

## Commits
- `a437601a6` reveal the auto-hidden dock on bottom-edge hover
- `a6449bb49` guard against zero display dims + const placement
- `316193d35` collapse the dock when the pointer leaves

## Verification
- Host typecheck clean (pre-existing `nonos_kernel` panic_handler error only).
- `make nonos-mk-desktop-shell` links clean.
- On-target (QEMU) verified by maintainer: open app → dock hides → hover bottom edge → dock reveals → move away → dock collapses; band→dock reach does not mis-collapse; second app launches from the revealed dock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)