### PR TITLE
fix: repair microkernel syscall wiring after thread-spawn merge

### DIFF
--- a/src/syscall/microkernel/dispatch/process.rs
+++ b/src/syscall/microkernel/dispatch/process.rs
@@ -21,8 +21,7 @@ use crate::syscall::microkernel::capsule_load::sys_capsule_load;
 use crate::syscall::microkernel::memory::{sys_mmap, sys_munmap};
 use crate::syscall::microkernel::numbers::*;
 use crate::syscall::microkernel::process::{
-    sys_args, sys_exit, sys_getpid, sys_pid_alive, sys_spawn, sys_yield,
-    sys_exit, sys_getpid, sys_pid_alive, sys_spawn, sys_thread_spawn, sys_yield,
+    sys_args, sys_exit, sys_getpid, sys_pid_alive, sys_spawn, sys_thread_spawn, sys_yield,
 };
 use crate::syscall::microkernel::procstat::sys_proc_stat;
 use crate::syscall::microkernel::time::{sys_time_millis, sys_time_rtc};

--- a/src/syscall/microkernel/mod.rs
+++ b/src/syscall/microkernel/mod.rs
@@ -52,7 +52,6 @@ pub use mmio::{sys_mmio_map, sys_mmio_unmap};
 pub use numbers::*;
 pub use pci::sys_pci_config_write;
 pub use pio::{sys_pio_grant, sys_pio_read, sys_pio_release, sys_pio_write};
-pub use process::{sys_args, sys_exit, sys_spawn, sys_yield};
-pub use process::{sys_exit, sys_spawn, sys_thread_spawn, sys_yield};
+pub use process::{sys_args, sys_exit, sys_spawn, sys_thread_spawn, sys_yield};
 pub use procstat::sys_proc_stat;
 pub use time::{sys_time_millis, sys_time_rtc};

--- a/src/syscall/microkernel/process.rs
+++ b/src/syscall/microkernel/process.rs
@@ -108,6 +108,8 @@ pub fn sys_args(buf: u64, len: usize) -> i64 {
         return ERRNO_FAULT;
     }
     blob.len() as i64
+}
+
 pub fn sys_thread_spawn(entry: u64, stack: u64) -> i64 {
     if entry == 0 || stack == 0 {
         return ERRNO_INVAL;


### PR DESCRIPTION
The thread-spawn merge (#198) was resolved by keeping both sides of
every conflict. That was right for the additive enum/router/table sites
but wrong for two import lists and one function body:

- `dispatch/process.rs` imported `sys_exit, sys_getpid, sys_pid_alive,
  sys_spawn, sys_yield` twice (E0252).
- `mod.rs` re-exported the same set twice (E0252).
- `process.rs` lost the closing brace of `sys_args`, folding it into
  `sys_thread_spawn` (unclosed delimiter).

`make nonos-mk-capsules` failed to compile on `main` as a result, which
is what turned the build and attestation lanes red.

Fix deduplicates both import lists and restores the brace. Verified the
microkernel-capsules config type-checks (the remaining `include_bytes!`
gaps are just the capsule artifacts CI builds as prerequisites).