### PR TITLE
fix(net-l2): learn leased IP so ARP carries a real sender

### DIFF
--- a/userland/capsule_net_dhcp/src/dora/acquire.rs
+++ b/userland/capsule_net_dhcp/src/dora/acquire.rs
@@ -38,6 +38,7 @@ pub fn acquire() -> Result<(), AcquireError> {
     *STATE.client_state.lock() = ClientState::Requesting;
     let ack = request(l2, &msg, &offer).map_err(|e| reset(map_request(e)))?;
     let prefix = install(ip, &ack).map_err(|_| reset(AcquireError::NoLink))?;
+    let _ = crate::l2_client::set_ip(l2, ack.yiaddr);
     *STATE.lease.lock() = Lease {
         ipv4: ack.yiaddr,
         prefix,

--- a/userland/capsule_net_dhcp/src/l2_client/mod.rs
+++ b/userland/capsule_net_dhcp/src/l2_client/mod.rs
@@ -18,9 +18,11 @@ mod header;
 mod mac;
 mod rx;
 mod seq;
+mod set_ip;
 mod tx;
 mod wire;
 
 pub use mac::{read_mac, MacError};
 pub use rx::{poll_frame, RxError};
+pub use set_ip::set_ip;
 pub use tx::{send_frame, TxError};

--- a/userland/capsule_net_dhcp/src/l2_client/set_ip.rs
+++ b/userland/capsule_net_dhcp/src/l2_client/set_ip.rs
@@ -1,0 +1,55 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use nonos_libc::mk_ipc_call;
+
+use super::header::{parse_response, write_request};
+use super::seq;
+use super::wire::{L2_HDR_LEN, OP_SET_IP};
+
+// Body layout matches `capsule_net_l2`'s set_ip handler: 4-byte IPv4.
+const BODY_LEN: usize = 4;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SetIpError {
+    SendFailed,
+    BadResponse,
+    Refused(u16),
+}
+
+// Hand the leased IPv4 to L2 so it can source ARP from a real
+// address and answer ARP requests for the host. Best-effort: the
+// lease itself is already installed in `net.ip` before this runs.
+pub fn set_ip(l2_port: u32, ipv4: [u8; 4]) -> Result<(), SetIpError> {
+    let total = L2_HDR_LEN + BODY_LEN;
+    let mut req = [0u8; L2_HDR_LEN + BODY_LEN];
+    let rid = seq::next();
+    write_request(&mut req, OP_SET_IP, rid, BODY_LEN as u32);
+    req[L2_HDR_LEN..total].copy_from_slice(&ipv4);
+    let mut resp = [0u8; L2_HDR_LEN];
+    let n = mk_ipc_call(l2_port as u64, req.as_ptr(), total, resp.as_mut_ptr(), resp.len());
+    if n < 0 {
+        return Err(SetIpError::SendFailed);
+    }
+    let (op, errno, _, _) = parse_response(&resp).ok_or(SetIpError::BadResponse)?;
+    if op != OP_SET_IP {
+        return Err(SetIpError::BadResponse);
+    }
+    if errno != 0 {
+        return Err(SetIpError::Refused(errno));
+    }
+    Ok(())
+}

--- a/userland/capsule_net_dhcp/src/l2_client/wire.rs
+++ b/userland/capsule_net_dhcp/src/l2_client/wire.rs
@@ -26,3 +26,4 @@ pub const L2_HDR_LEN: usize = 20;
 pub const OP_GET_MAC: u16 = 2;
 pub const OP_SEND_FRAME: u16 = 4;
 pub const OP_POLL_FRAME: u16 = 5;
+pub const OP_SET_IP: u16 = 7;

--- a/userland/capsule_net_l2/src/protocol/mod.rs
+++ b/userland/capsule_net_l2/src/protocol/mod.rs
@@ -28,4 +28,5 @@ pub use header::{Request, HDR_LEN};
 pub use limits::IPC_PAYLOAD_MAX;
 pub use ops::{
     OP_ARP_RESOLVE, OP_GET_LINK, OP_GET_MAC, OP_HEALTHCHECK, OP_POLL_FRAME, OP_SEND_FRAME,
+    OP_SET_IP,
 };

--- a/userland/capsule_net_l2/src/protocol/ops.rs
+++ b/userland/capsule_net_l2/src/protocol/ops.rs
@@ -24,3 +24,4 @@ pub const OP_GET_LINK: u16 = 3;
 pub const OP_SEND_FRAME: u16 = 4;
 pub const OP_POLL_FRAME: u16 = 5;
 pub const OP_ARP_RESOLVE: u16 = 6;
+pub const OP_SET_IP: u16 = 7;

--- a/userland/capsule_net_l2/src/server/handlers/set_ip.rs
+++ b/userland/capsule_net_l2/src/server/handlers/set_ip.rs
@@ -14,10 +14,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod arp_resolve;
-pub mod get_link;
-pub mod get_mac;
-pub mod health;
-pub mod poll_frame;
-pub mod send_frame;
-pub mod set_ip;
+use crate::protocol::{Request, E_BAD_LEN, E_OK, OP_SET_IP};
+use crate::server::respond::respond;
+use crate::state::STATE;
+
+// Body layout (request): 4 bytes interface IPv4. The DHCP client
+// pushes the leased address here once a lease binds, so L2 can put
+// a real sender IP into outbound ARP and answer ARP-for-host.
+pub fn handle(sender_pid: u32, req: &Request, body: &[u8], tx: &mut [u8]) {
+    if body.len() != 4 {
+        let _ = respond(sender_pid, OP_SET_IP, E_BAD_LEN, req.request_id, 0, tx);
+        return;
+    }
+    let mut ipv4 = [0u8; 4];
+    ipv4.copy_from_slice(body);
+    *STATE.ipv4.lock() = ipv4;
+    let _ = respond(sender_pid, OP_SET_IP, E_OK, req.request_id, 0, tx);
+}

--- a/userland/capsule_net_l2/src/server/runner.rs
+++ b/userland/capsule_net_l2/src/server/runner.rs
@@ -20,7 +20,7 @@ use nonos_libc::mk_ipc_recv_from;
 
 use crate::protocol::{
     parse, E_BAD_OP, HDR_LEN, IPC_PAYLOAD_MAX, OP_ARP_RESOLVE, OP_GET_LINK, OP_GET_MAC,
-    OP_HEALTHCHECK, OP_POLL_FRAME, OP_SEND_FRAME,
+    OP_HEALTHCHECK, OP_POLL_FRAME, OP_SEND_FRAME, OP_SET_IP,
 };
 
 use super::handlers;
@@ -48,6 +48,7 @@ pub fn run() -> ! {
             OP_SEND_FRAME => handlers::send_frame::handle(sender_pid, &req, body, &mut tx),
             OP_POLL_FRAME => handlers::poll_frame::handle(sender_pid, &req, &mut tx),
             OP_ARP_RESOLVE => handlers::arp_resolve::handle(sender_pid, &req, body, &mut tx),
+            OP_SET_IP => handlers::set_ip::handle(sender_pid, &req, body, &mut tx),
             _ => {
                 let _ = respond_status_only(sender_pid, req.op, E_BAD_OP, req.request_id, &mut tx);
             }


### PR DESCRIPTION
net.l2 STATE.ipv4 had no writer and stayed 0.0.0.0, so outbound ARP was sourced from 0.0.0.0 and on_inbound could never match target_ip == iface.ipv4 to answer ARP for the host (inbound/passive blocked at L2).

Add net.l2 OP_SET_IP (op 7) with a handler that writes STATE.ipv4, and have the DHCP client push the leased yiaddr to L2 right after it installs the lease into net.ip via OP_SET_CONFIG. Pure userland capsule IPC; no kernel, ABI, or capability change.

Pcap-proven (hvf, tcp_lifecycle): outbound ARP now reads who-has 10.0.2.2 tell 10.0.2.15 instead of tell 0.0.0.0.