### PR TITLE
fix(net-tcp): reject ACKs that don't acknowledge our SYN

### DIFF
--- a/userland/capsule_net_tcp/src/server/tcp_rx/existing.rs
+++ b/userland/capsule_net_tcp/src/server/tcp_rx/existing.rs
@@ -48,7 +48,10 @@ pub fn update(local: Endpoint4, remote: Endpoint4, hdr: TcpHeader, payload: &[u8
                 if rst::in_window(e, hdr.seq) { RxAction::Reap(e.handle) } else { RxAction::None }
             } else if e.tcb.state == State::SynSent {
                 handshake::step(e, &hdr)
-            } else if e.tcb.state == State::SynReceived && hdr.has_flag(FLAG_ACK) {
+            } else if e.tcb.state == State::SynReceived
+                && hdr.has_flag(FLAG_ACK)
+                && hdr.ack == e.tcb.send.nxt
+            {
                 e.tcb.state = State::Established;
                 accepted = Some((e.parent, e.handle));
                 if hdr.has_flag(FLAG_FIN) {

--- a/userland/capsule_net_tcp/src/server/tcp_rx/transitions/handshake.rs
+++ b/userland/capsule_net_tcp/src/server/tcp_rx/transitions/handshake.rs
@@ -21,7 +21,9 @@ use crate::state::Entry;
 use crate::tcp::{State, TcpHeader, FLAG_ACK, FLAG_SYN};
 
 pub fn step(e: &mut Entry, hdr: &TcpHeader) -> RxAction {
-    if hdr.flags & (FLAG_SYN | FLAG_ACK) == FLAG_SYN | FLAG_ACK {
+    if hdr.flags & (FLAG_SYN | FLAG_ACK) == FLAG_SYN | FLAG_ACK
+        && hdr.ack == e.tcb.send.nxt
+    {
         e.tcb.recv.nxt = hdr.seq.wrapping_add(1);
         e.tcb.send.una = hdr.ack;
         e.tcb.state = State::Established;


### PR DESCRIPTION
## Problem

`net_tcp` accepted ACKs without validating the acknowledgment field at two transitions:

- `handshake.rs` (SYN-SENT) set `send.una = hdr.ack` on **any** SYN-ACK.
- `existing.rs` promoted SYN-RECEIVED → Established on **any** ACK.

Neither checked `hdr.ack`, so a forged/corrupt ACK could establish a connection or corrupt `send.una`. (The `closing.rs` path already gated on the exact ACK — this brings the handshake paths in line.)

## Fix

Gate both transitions on `hdr.ack == send.nxt`. At these points `send.una = iss` and `send.nxt = iss+1`, so the RFC-793 acceptability test (`SND.UNA < SEG.ACK <= SND.NXT`) reduces to this exact match. An unacceptable ACK now drops with no state change. `established.rs` is out of scope — it never reads `hdr.ack` and there is no retransmit queue to corrupt.

## Verification

Regression-tested under QEMU/hvf with the `tcp_lifecycle` profile (hostfwd-driven so the inbound accepts complete):

```
ISS-OK, PLISTEN, PASSIVE-CLOSE OK, ALISTEN, CONNECT OK, CLOSE OK, RST-REFUSED OK
```

pcap confirms both guarded paths are exercised by legitimate traffic and complete (`SYN-ACK ack = peer_seq + 1`). Forged-ACK rejection isn't directly observable without a packet injector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
