### PR TITLE
fix(virtio-net): defer RX refill until the frame is consumed

### DIFF
--- a/userland/capsule_driver_virtio_net/src/queue/rx_queue.rs
+++ b/userland/capsule_driver_virtio_net/src/queue/rx_queue.rs
@@ -25,6 +25,7 @@ pub struct RxQueue {
     pub buf_len: u32,
     pub buf_count: u16,
     pub last_used: u16,
+    pub pending_refill: Option<u16>,
 }
 
 impl RxQueue {
@@ -37,6 +38,7 @@ impl RxQueue {
             buf_len: RX_BUFFER_LEN,
             buf_count: RX_DESC_COUNT,
             last_used: 0,
+            pending_refill: None,
         }
     }
 

--- a/userland/capsule_driver_virtio_net/src/rx.rs
+++ b/userland/capsule_driver_virtio_net/src/rx.rs
@@ -35,6 +35,9 @@ pub struct Frame<'a> {
 
 
 pub unsafe fn take_one(rx: &mut RxQueue) -> Option<Frame<'static>> {
+    if let Some(prev) = rx.pending_refill.take() {
+        rx.refill(prev);
+    }
     let used = rx.used_idx();
     if used == rx.last_used {
         return None;
@@ -58,7 +61,7 @@ pub unsafe fn take_one(rx: &mut RxQueue) -> Option<Frame<'static>> {
     };
 
     rx.last_used = rx.last_used.wrapping_add(1);
-    rx.refill(desc_id as u16);
+    rx.pending_refill = Some(desc_id as u16);
 
     if payload_len == 0 {
         return Some(Frame { bytes: &[] });


### PR DESCRIPTION
## Problem

`take_one` called `refill(desc_id)` — returning the RX buffer to the device's avail ring — **before** the caller copied the returned `&'static` payload slice out of that same DMA buffer (`rx_packet::handle` copies at the end). A device polling the avail ring could DMA a new frame over the buffer mid-copy, so the `'static` lifetime aliased device-writable memory. Latent (QEMU only consumes avail on notify, so it was never observed) but unsound.

Note: the length was already clamped to `buf_len` and the slot index taken `% buf_count`, so the out-of-bounds read the 2026-06-08 audit suspected was **not** present. The real issue is the refill ordering.

## Fix

Deferred refill: hold the consumed descriptor in `RxQueue.pending_refill` and recycle it on the **next** `take_one`, by which point the synchronous IPC handler has finished copying the frame. At most one buffer is held back at a time (7 of 8 stay posted).

## Verification

Regression-tested under QEMU/hvf with the `tcp_lifecycle` profile. RX delivery is intact:

- DHCP DORA completes (guest **receives** OFFER + ACK).
- `CONNECT OK / ECHO OK / CLOSE OK / RST-REFUSED OK / PASSIVE-CLOSE OK` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
