### PR TITLE
fix(net-ip): reject fragmented IPv4 datagrams

### DIFF
--- a/userland/capsule_net_ip/src/ipv4/parse.rs
+++ b/userland/capsule_net_ip/src/ipv4/parse.rs
@@ -24,6 +24,7 @@ pub enum ParseError {
     BadIhl,
     TotalLengthMismatch,
     BadChecksum,
+    Fragmented,
 }
 
 // Validate and parse an IPv4 packet. On success returns the header
@@ -53,6 +54,10 @@ pub fn parse(bytes: &[u8]) -> Result<(Ipv4Header, &[u8]), ParseError> {
     }
     if checksum::fold(&bytes[..header_len]) != 0 {
         return Err(ParseError::BadChecksum);
+    }
+    let flags_frag = u16::from_be_bytes([bytes[6], bytes[7]]);
+    if flags_frag & 0x3FFF != 0 {
+        return Err(ParseError::Fragmented);
     }
     let protocol = bytes[9];
     let mut src = [0u8; 4];


### PR DESCRIPTION
## Problem

`ipv4::parse` validated version, IHL, total length, and checksum — but never inspected the flags / fragment-offset field (`bytes[6..8]`). A packet with the More-Fragments bit set or a nonzero fragment offset parsed "cleanly," and its **partial** payload was handed up to TCP/UDP/ICMP as though it were a complete datagram. The module README claimed fragments were rejected; the code did not enforce it.

## Fix

Reject when `flags_frag & 0x3FFF != 0` (MF bit `0x2000` or offset `0x1FFF`; the DF bit `0x4000` is intentionally ignored) via a new `ParseError::Fragmented`. The sole caller (`ingress`) already maps any `ParseError` to a dropped `BadIp`, so no other code changes are needed. No reassembly is attempted (out of scope, unchanged).

## Verification

Regression-tested under QEMU/hvf with the `tcp_lifecycle` profile. Legitimate unfragmented traffic is unaffected — `CONNECT OK / CLOSE OK / PASSIVE-CLOSE OK`, which all require net_ip to forward whole IPv4 datagrams to L4, still pass (identical marker set to the pre-change baseline on the same harness). Observing the fragment-drop itself would require injecting a fragmented packet (no packet injector in this harness).


