### PR TITLE
fix(net-l2): evict the genuinely-oldest ARP entry

### DIFF
--- a/userland/capsule_net_l2/src/arp/cache/cache_type.rs
+++ b/userland/capsule_net_l2/src/arp/cache/cache_type.rs
@@ -20,4 +20,5 @@ use super::entry::Entry;
 pub struct Cache {
     pub(super) entries: [Option<Entry>; ENTRY_CAP],
     pub(super) len: usize,
+    pub(super) next_seq: u64,
 }

--- a/userland/capsule_net_l2/src/arp/cache/entry.rs
+++ b/userland/capsule_net_l2/src/arp/cache/entry.rs
@@ -20,5 +20,5 @@ use crate::ethernet::MacAddress;
 pub(super) struct Entry {
     pub(super) ipv4: [u8; 4],
     pub(super) mac: MacAddress,
-    pub(super) age_ticks: u32,
+    pub(super) seq: u64,
 }

--- a/userland/capsule_net_l2/src/arp/cache/evict_oldest.rs
+++ b/userland/capsule_net_l2/src/arp/cache/evict_oldest.rs
@@ -19,11 +19,11 @@ use super::cache_type::Cache;
 impl Cache {
     pub(super) fn evict_oldest(&mut self) {
         let mut oldest_idx = None;
-        let mut oldest_age = 0u32;
+        let mut oldest_seq = u64::MAX;
         for (i, slot) in self.entries.iter().enumerate() {
             if let Some(e) = slot {
-                if e.age_ticks >= oldest_age {
-                    oldest_age = e.age_ticks;
+                if e.seq < oldest_seq {
+                    oldest_seq = e.seq;
                     oldest_idx = Some(i);
                 }
             }

--- a/userland/capsule_net_l2/src/arp/cache/insert.rs
+++ b/userland/capsule_net_l2/src/arp/cache/insert.rs
@@ -20,23 +20,25 @@ use crate::ethernet::MacAddress;
 
 impl Cache {
     pub fn insert(&mut self, ipv4: [u8; 4], mac: MacAddress) {
+        let seq = self.next_seq;
+        self.next_seq = self.next_seq.wrapping_add(1);
         for slot in &mut self.entries {
             if let Some(e) = slot {
                 if e.ipv4 == ipv4 {
                     e.mac = mac;
-                    e.age_ticks = 0;
+                    e.seq = seq;
                     return;
                 }
             }
         }
         if let Some(slot) = self.entries.iter_mut().find(|e| e.is_none()) {
-            *slot = Some(Entry { ipv4, mac, age_ticks: 0 });
+            *slot = Some(Entry { ipv4, mac, seq });
             self.len += 1;
             return;
         }
         self.evict_oldest();
         if let Some(slot) = self.entries.iter_mut().find(|e| e.is_none()) {
-            *slot = Some(Entry { ipv4, mac, age_ticks: 0 });
+            *slot = Some(Entry { ipv4, mac, seq });
             self.len += 1;
         }
     }

--- a/userland/capsule_net_l2/src/arp/cache/new.rs
+++ b/userland/capsule_net_l2/src/arp/cache/new.rs
@@ -19,6 +19,6 @@ use super::constants::ENTRY_CAP;
 
 impl Cache {
     pub const fn new() -> Self {
-        Self { entries: [None; ENTRY_CAP], len: 0 }
+        Self { entries: [None; ENTRY_CAP], len: 0, next_seq: 0 }
     }
 }


### PR DESCRIPTION
## Problem

`Entry.age_ticks` was dead state — set to `0` on insert and **never incremented** (net_l2 has no clock or tick loop). So `evict_oldest` compared all-zero ages and, when the 64-entry cache filled, dropped an **arbitrary** slot rather than the oldest entry.

## Fix

Replace `age_ticks` with a monotonic `Cache.next_seq` stamped on every insert/refresh; `evict_oldest` now drops the minimum `seq` (the genuinely oldest). Self-contained to `arp/cache/`, no behavior change for the common (non-full) case.

## Deliberately deferred: TTL aging

A time-based TTL is **not** added here on purpose. `net_ip egress::send` does not retry on `NoNeighbour` (it fails the send outright), and TCP has no retransmission yet, so a mid-connection ARP entry expiry would drop a segment that nothing retransmits. TTL aging should land only after one of those gaps is closed.

## Verification

Regression-tested under QEMU/hvf (`tcp_lifecycle`): gateway ARP still resolves (`who-has 10.0.2.2 tell 10.0.2.15` → reply) and `CONNECT OK / CLOSE OK / PASSIVE-CLOSE OK` pass. The eviction path itself triggers only at 64 entries (not reachable in this harness), so eviction-order correctness rests on code reasoning (min-seq = oldest insert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
