### PR TITLE
net-dns: take the upstream resolver from DHCP

### DIFF
--- a/userland/capsule_net_dns/src/dhcp_upstream.rs
+++ b/userland/capsule_net_dns/src/dhcp_upstream.rs
@@ -14,28 +14,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use nonos_libc::mk_service_lookup;
+mod lookup;
+mod status;
 
-use crate::state::{local_port, set_udp_port};
-use crate::udp_client;
+use crate::state::set_upstream;
 
-const UDP_NAME: &str = "net.udp";
+pub const DHCP_MAGIC: u32 = 0x4E44_4843;
+pub const OP_LEASE_STATUS: u16 = 3;
+pub const SERVICE: &[u8] = b"net.dhcp.client";
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum SetupError {
-    UdpMissing,
-    BindFailed,
-}
-
-pub fn run() -> Result<(), SetupError> {
-    let mut port = 0u32;
-    let mut pid = 0u32;
-    let rc = mk_service_lookup(UDP_NAME.as_ptr(), UDP_NAME.len(), &mut port, &mut pid);
-    if rc != 0 || port == 0 {
-        return Err(SetupError::UdpMissing);
+pub fn apply() {
+    let Some(port) = lookup::lookup() else { return };
+    let Some(dns) = status::status(port) else { return };
+    if dns != [0; 4] {
+        set_upstream(dns);
     }
-    udp_client::bind(port, local_port()).map_err(|_| SetupError::BindFailed)?;
-    set_udp_port(port);
-    crate::dhcp_upstream::apply();
-    Ok(())
 }

--- a/userland/capsule_net_dns/src/dhcp_upstream/lookup.rs
+++ b/userland/capsule_net_dns/src/dhcp_upstream/lookup.rs
@@ -16,26 +16,9 @@
 
 use nonos_libc::mk_service_lookup;
 
-use crate::state::{local_port, set_udp_port};
-use crate::udp_client;
-
-const UDP_NAME: &str = "net.udp";
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum SetupError {
-    UdpMissing,
-    BindFailed,
-}
-
-pub fn run() -> Result<(), SetupError> {
+pub fn lookup() -> Option<u32> {
     let mut port = 0u32;
     let mut pid = 0u32;
-    let rc = mk_service_lookup(UDP_NAME.as_ptr(), UDP_NAME.len(), &mut port, &mut pid);
-    if rc != 0 || port == 0 {
-        return Err(SetupError::UdpMissing);
-    }
-    udp_client::bind(port, local_port()).map_err(|_| SetupError::BindFailed)?;
-    set_udp_port(port);
-    crate::dhcp_upstream::apply();
-    Ok(())
+    let rc = mk_service_lookup(super::SERVICE.as_ptr(), super::SERVICE.len(), &mut port, &mut pid);
+    if rc == 0 && port != 0 { Some(port) } else { None }
 }

--- a/userland/capsule_net_dns/src/dhcp_upstream/status.rs
+++ b/userland/capsule_net_dns/src/dhcp_upstream/status.rs
@@ -14,28 +14,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use nonos_libc::mk_service_lookup;
+use nonos_libc::mk_ipc_call;
 
-use crate::state::{local_port, set_udp_port};
-use crate::udp_client;
-
-const UDP_NAME: &str = "net.udp";
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum SetupError {
-    UdpMissing,
-    BindFailed,
-}
-
-pub fn run() -> Result<(), SetupError> {
-    let mut port = 0u32;
-    let mut pid = 0u32;
-    let rc = mk_service_lookup(UDP_NAME.as_ptr(), UDP_NAME.len(), &mut port, &mut pid);
-    if rc != 0 || port == 0 {
-        return Err(SetupError::UdpMissing);
+pub fn status(port: u32) -> Option<[u8; 4]> {
+    let mut tx = [0u8; 20];
+    let mut rx = [0u8; 38];
+    tx[0..4].copy_from_slice(&super::DHCP_MAGIC.to_le_bytes());
+    tx[4..6].copy_from_slice(&1u16.to_le_bytes());
+    tx[6..8].copy_from_slice(&super::OP_LEASE_STATUS.to_le_bytes());
+    tx[12..16].copy_from_slice(&1u32.to_le_bytes());
+    let n = mk_ipc_call(port as u64, tx.as_ptr(), tx.len(), rx.as_mut_ptr(), rx.len());
+    if n < 38 || u16::from_le_bytes([rx[8], rx[9]]) != 0 || rx[20] != 3 {
+        return None;
     }
-    udp_client::bind(port, local_port()).map_err(|_| SetupError::BindFailed)?;
-    set_udp_port(port);
-    crate::dhcp_upstream::apply();
-    Ok(())
+    Some([rx[30], rx[31], rx[32], rx[33]])
 }

--- a/userland/capsule_net_dns/src/main.rs
+++ b/userland/capsule_net_dns/src/main.rs
@@ -20,6 +20,7 @@
 extern crate alloc;
 
 mod dns;
+mod dhcp_upstream;
 mod protocol;
 mod server;
 mod setup;


### PR DESCRIPTION
setup queries the DHCP client for the lease's DNS server and forwards queries there instead of a baked default, so resolution follows the resolver the network actually handed us. A missing lease or zero address leaves the existing upstream untouched.