### PR TITLE
feat(net): security hardening Wave 1 — ARP/DNS/TCP/DHCP

### DIFF
--- a/userland/capsule_net_dhcp/src/dora/acquire.rs
+++ b/userland/capsule_net_dhcp/src/dora/acquire.rs
@@ -32,7 +32,8 @@ pub fn acquire() -> Result<(), AcquireError> {
     if l2 == 0 || ip == 0 || mac == [0; 6] {
         return Err(AcquireError::NoLink);
     }
-    let msg = Message::new_request(&mac, STATE.next_xid());
+    let xid = STATE.next_xid().ok_or(AcquireError::NoLink)?;
+    let msg = Message::new_request(&mac, xid);
     *STATE.client_state.lock() = ClientState::Selecting;
     let offer = discover(l2, &msg).map_err(|e| reset(map_discover(e)))?;
     *STATE.client_state.lock() = ClientState::Requesting;

--- a/userland/capsule_net_dhcp/src/dora/acquire.rs
+++ b/userland/capsule_net_dhcp/src/dora/acquire.rs
@@ -38,6 +38,9 @@ pub fn acquire() -> Result<(), AcquireError> {
     let offer = discover(l2, &msg).map_err(|e| reset(map_discover(e)))?;
     *STATE.client_state.lock() = ClientState::Requesting;
     let ack = request(l2, &msg, &offer).map_err(|e| reset(map_request(e)))?;
+    if ack.yiaddr == [0; 4] {
+        return Err(reset(AcquireError::Nak));
+    }
     let prefix = install(ip, &ack).map_err(|_| reset(AcquireError::NoLink))?;
     let _ = crate::l2_client::set_ip(l2, ack.yiaddr);
     *STATE.lease.lock() = Lease {

--- a/userland/capsule_net_dhcp/src/dora/mask.rs
+++ b/userland/capsule_net_dhcp/src/dora/mask.rs
@@ -19,6 +19,9 @@
 // malformed server reply.
 pub fn mask_to_prefix(mask: &[u8; 4]) -> Option<u8> {
     let bits = u32::from_be_bytes(*mask);
+    if bits == 0 {
+        return None;
+    }
     let prefix = bits.leading_ones();
     let trailing = bits.trailing_zeros();
     if prefix + trailing == 32 {

--- a/userland/capsule_net_dhcp/src/server/handlers/lease_release.rs
+++ b/userland/capsule_net_dhcp/src/server/handlers/lease_release.rs
@@ -36,10 +36,11 @@ pub fn handle(sender_pid: u32, req: &Request, tx: &mut [u8]) {
     };
     let prior = *STATE.lease.lock();
     if prior.ipv4 != [0; 4] {
-        let xid = STATE.next_xid();
-        let mut msg = Message::new_request(&mac, xid);
-        msg.ciaddr = prior.ipv4;
-        let _ = release(l2, &msg, prior.server_id);
+        if let Some(xid) = STATE.next_xid() {
+            let mut msg = Message::new_request(&mac, xid);
+            msg.ciaddr = prior.ipv4;
+            let _ = release(l2, &msg, prior.server_id);
+        }
         let _ = clear_lease(ip);
     }
     *STATE.lease.lock() = Lease::empty();

--- a/userland/capsule_net_dhcp/src/server/handlers/lease_renew.rs
+++ b/userland/capsule_net_dhcp/src/server/handlers/lease_renew.rs
@@ -41,7 +41,13 @@ pub fn handle(sender_pid: u32, req: &Request, tx: &mut [u8]) {
         return;
     }
     *STATE.client_state.lock() = ClientState::Renewing;
-    let xid = STATE.next_xid();
+    let xid = match STATE.next_xid() {
+        Some(x) => x,
+        None => {
+            let _ = respond(sender_pid, OP_LEASE_RENEW, E_NO_LINK, req.request_id, 0, tx);
+            return;
+        }
+    };
     let mut msg = Message::new_request(&mac, xid);
     msg.ciaddr = prior.ipv4;
     let synthetic_offer = Message { yiaddr: prior.ipv4, server_id: prior.server_id, ..msg };

--- a/userland/capsule_net_dhcp/src/state/global.rs
+++ b/userland/capsule_net_dhcp/src/state/global.rs
@@ -24,7 +24,6 @@ pub struct Global {
     pub l2_port: AtomicU32,
     pub ip_port: AtomicU32,
     pub mac: Mutex<[u8; 6]>,
-    pub xid: AtomicU32,
     pub client_state: Mutex<ClientState>,
     pub lease: Mutex<Lease>,
 }
@@ -35,19 +34,14 @@ impl Global {
             l2_port: AtomicU32::new(0),
             ip_port: AtomicU32::new(0),
             mac: Mutex::new([0; 6]),
-            xid: AtomicU32::new(1),
             client_state: Mutex::new(ClientState::Init),
             lease: Mutex::new(Lease::empty()),
         }
     }
 
-    pub fn next_xid(&self) -> u32 {
-        let v = self.xid.fetch_add(1, Ordering::Relaxed);
-        if v == 0 {
-            self.xid.fetch_add(1, Ordering::Relaxed)
-        } else {
-            v
-        }
+    pub fn next_xid(&self) -> Option<u32> {
+        let v = rand_u32()?;
+        Some(if v == 0 { 1 } else { v })
     }
 
     pub fn l2(&self) -> u32 {
@@ -57,6 +51,15 @@ impl Global {
     pub fn ip(&self) -> u32 {
         self.ip_port.load(Ordering::Acquire)
     }
+}
+
+fn rand_u32() -> Option<u32> {
+    let mut b = [0u8; 4];
+    let n = nonos_libc::crypto_random(b.as_mut_ptr(), 4);
+    if n != 4i64 {
+        return None;
+    }
+    Some(u32::from_le_bytes(b))
 }
 
 pub static STATE: Global = Global::new();

--- a/userland/capsule_net_dns/src/dns/mod.rs
+++ b/userland/capsule_net_dns/src/dns/mod.rs
@@ -18,10 +18,12 @@ mod cache;
 mod header;
 mod name;
 mod query;
+mod question;
 mod response;
 mod types;
 
 pub use cache::Cache;
+pub use question::matches as question_matches;
 pub use header::{Header, HDR_LEN, RCODE_NO_ERROR, RCODE_NXDOMAIN};
 pub use name::{skip, NameError};
 pub use query::{build_a_query, build_aaaa_query};

--- a/userland/capsule_net_dns/src/dns/question.rs
+++ b/userland/capsule_net_dns/src/dns/question.rs
@@ -1,0 +1,66 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::dns::{HDR_LEN, LABEL_MAX, NAME_MAX, POINTER_MASK};
+
+pub fn matches(query: &[u8], response: &[u8]) -> bool {
+    let q_end = match name_end(query, HDR_LEN) {
+        Some(p) => p,
+        None => return false,
+    };
+    let r_end = match name_end(response, HDR_LEN) {
+        Some(p) => p,
+        None => return false,
+    };
+    if !names_equal(&query[HDR_LEN..q_end], &response[HDR_LEN..r_end]) {
+        return false;
+    }
+    q_end + 2 <= query.len()
+        && r_end + 2 <= response.len()
+        && query[q_end..q_end + 2] == response[r_end..r_end + 2]
+}
+
+fn name_end(message: &[u8], start: usize) -> Option<usize> {
+    let mut i = start;
+    let mut steps = 0;
+    loop {
+        let b = *message.get(i)?;
+        if b == 0 {
+            return Some(i + 1);
+        }
+        if b & POINTER_MASK == POINTER_MASK || b as usize > LABEL_MAX {
+            return None;
+        }
+        i += 1 + b as usize;
+        steps += 1;
+        if i > message.len() || steps > NAME_MAX {
+            return None;
+        }
+    }
+}
+
+fn names_equal(a: &[u8], b: &[u8]) -> bool {
+    a.len() == b.len()
+        && a.iter().zip(b.iter()).all(|(x, y)| fold(*x) == fold(*y))
+}
+
+fn fold(b: u8) -> u8 {
+    if b.is_ascii_uppercase() {
+        b + 32
+    } else {
+        b
+    }
+}

--- a/userland/capsule_net_dns/src/server/handlers/resolve_a.rs
+++ b/userland/capsule_net_dns/src/server/handlers/resolve_a.rs
@@ -30,7 +30,10 @@ pub fn handle(sender_pid: u32, req: &Request, body: &[u8], tx: &mut [u8]) {
     if let Some(ip) = CACHE.lock().lookup(qname, now) {
         return answer(sender_pid, req, ip, tx);
     }
-    let xid = xid();
+    let xid = match xid() {
+        Some(v) => v,
+        None => return status(sender_pid, req, E_SERVFAIL, tx),
+    };
     let mut query = [0u8; 512];
     let len = match build_a_query(xid, qname, &mut query) {
         Ok(n) => n,

--- a/userland/capsule_net_dns/src/server/handlers/resolve_aaaa.rs
+++ b/userland/capsule_net_dns/src/server/handlers/resolve_aaaa.rs
@@ -25,7 +25,10 @@ pub fn handle(sender_pid: u32, req: &Request, body: &[u8], tx: &mut [u8]) {
         Ok(v) => v,
         Err(e) => return status(sender_pid, req, e, tx),
     };
-    let xid = xid();
+    let xid = match xid() {
+        Some(v) => v,
+        None => return status(sender_pid, req, E_SERVFAIL, tx),
+    };
     let mut query = [0u8; 512];
     let len = match build_aaaa_query(xid, qname, &mut query) {
         Ok(n) => n,

--- a/userland/capsule_net_dns/src/server/handlers/resolve_common.rs
+++ b/userland/capsule_net_dns/src/server/handlers/resolve_common.rs
@@ -34,9 +34,10 @@ pub fn name(body: &[u8]) -> Result<&str, u16> {
 
 pub fn exchange(query: &[u8], xid: u16) -> Result<Answer, u16> {
     let upstream = upstream();
-    send_to(udp_port(), local_port(), upstream, DNS_PORT, query).map_err(|_| E_TIMEOUT)?;
+    let lport = local_port().ok_or(E_TIMEOUT)?;
+    send_to(udp_port(), lport, upstream, DNS_PORT, query).map_err(|_| E_TIMEOUT)?;
     for _ in 0..RECV_TRIES {
-        match recv_from(udp_port(), local_port()) {
+        match recv_from(udp_port(), lport) {
             Ok(d) if d.src == upstream && d.src_port == DNS_PORT => {
                 match parse_response(query, &d.payload, xid) {
                     Err(E_TIMEOUT) => mk_yield(),
@@ -52,7 +53,7 @@ pub fn exchange(query: &[u8], xid: u16) -> Result<Answer, u16> {
     Err(E_TIMEOUT)
 }
 
-pub fn xid() -> u16 {
+pub fn xid() -> Option<u16> {
     next_xid()
 }
 

--- a/userland/capsule_net_dns/src/server/handlers/resolve_common.rs
+++ b/userland/capsule_net_dns/src/server/handlers/resolve_common.rs
@@ -18,7 +18,7 @@ use core::str;
 
 use nonos_libc::mk_yield;
 
-use crate::dns::{first_address, Answer, RCODE_NO_ERROR, RCODE_NXDOMAIN};
+use crate::dns::{first_address, question_matches, Answer, RCODE_NO_ERROR, RCODE_NXDOMAIN};
 use crate::protocol::{E_NAME_INVALID, E_NXDOMAIN, E_SERVFAIL, E_TIMEOUT};
 use crate::state::{local_port, next_xid, udp_port, upstream, DNS_PORT};
 use crate::udp_client::{recv_from, send_to, UdpRecvError};
@@ -38,7 +38,10 @@ pub fn exchange(query: &[u8], xid: u16) -> Result<Answer, u16> {
     for _ in 0..RECV_TRIES {
         match recv_from(udp_port(), local_port()) {
             Ok(d) if d.src == upstream && d.src_port == DNS_PORT => {
-                return parse_response(&d.payload, xid);
+                match parse_response(query, &d.payload, xid) {
+                    Err(E_TIMEOUT) => mk_yield(),
+                    other => return other,
+                };
             }
             Ok(_) | Err(UdpRecvError::Empty) => {
                 mk_yield();
@@ -53,9 +56,9 @@ pub fn xid() -> u16 {
     next_xid()
 }
 
-fn parse_response(payload: &[u8], xid: u16) -> Result<Answer, u16> {
+fn parse_response(query: &[u8], payload: &[u8], xid: u16) -> Result<Answer, u16> {
     let (hdr, answer) = first_address(payload).map_err(|_| E_SERVFAIL)?;
-    if hdr.id != xid {
+    if hdr.id != xid || !question_matches(query, payload) {
         return Err(E_TIMEOUT);
     }
     if hdr.rcode() == RCODE_NXDOMAIN {

--- a/userland/capsule_net_dns/src/setup.rs
+++ b/userland/capsule_net_dns/src/setup.rs
@@ -34,7 +34,8 @@ pub fn run() -> Result<(), SetupError> {
     if rc != 0 || port == 0 {
         return Err(SetupError::UdpMissing);
     }
-    udp_client::bind(port, local_port()).map_err(|_| SetupError::BindFailed)?;
+    let lport = local_port().ok_or(SetupError::BindFailed)?;
+    udp_client::bind(port, lport).map_err(|_| SetupError::BindFailed)?;
     set_udp_port(port);
     Ok(())
 }

--- a/userland/capsule_net_dns/src/state.rs
+++ b/userland/capsule_net_dns/src/state.rs
@@ -27,10 +27,12 @@ pub static UDP_PORT: AtomicU32 = AtomicU32::new(0);
 static LOCAL_PORT: AtomicU16 = AtomicU16::new(0);
 static UPSTREAM: Mutex<[u8; 4]> = Mutex::new(DEFAULT_UPSTREAM);
 
-fn rand_u16() -> u16 {
+fn rand_u16() -> Option<u16> {
     let mut b = [0u8; 2];
-    let _ = nonos_libc::crypto_random(b.as_mut_ptr(), 2);
-    u16::from_le_bytes(b)
+    if nonos_libc::crypto_random(b.as_mut_ptr(), 2) != 2 {
+        return None;
+    }
+    Some(u16::from_le_bytes(b))
 }
 
 pub fn udp_port() -> u32 {
@@ -41,19 +43,19 @@ pub fn set_udp_port(port: u32) {
     UDP_PORT.store(port, Ordering::Release);
 }
 
-pub fn local_port() -> u16 {
+pub fn local_port() -> Option<u16> {
     let current = LOCAL_PORT.load(Ordering::Acquire);
     if current != 0 {
-        return current;
+        return Some(current);
     }
-    let port = 49152u16 + (rand_u16() as u32 % 16384) as u16;
+    let port = 49152u16 + (rand_u16()? as u32 % 16384) as u16;
     match LOCAL_PORT.compare_exchange(0, port, Ordering::AcqRel, Ordering::Acquire) {
-        Ok(_) => port,
-        Err(existing) => existing,
+        Ok(_) => Some(port),
+        Err(existing) => Some(existing),
     }
 }
 
-pub fn next_xid() -> u16 {
+pub fn next_xid() -> Option<u16> {
     rand_u16()
 }
 

--- a/userland/capsule_net_dns/src/state.rs
+++ b/userland/capsule_net_dns/src/state.rs
@@ -24,9 +24,14 @@ pub const DEFAULT_UPSTREAM: [u8; 4] = [1, 1, 1, 1];
 
 pub static CACHE: Mutex<Cache> = Mutex::new(Cache::new());
 pub static UDP_PORT: AtomicU32 = AtomicU32::new(0);
-static LOCAL_PORT: AtomicU16 = AtomicU16::new(53535);
-static XID: AtomicU16 = AtomicU16::new(0x3011);
+static LOCAL_PORT: AtomicU16 = AtomicU16::new(0);
 static UPSTREAM: Mutex<[u8; 4]> = Mutex::new(DEFAULT_UPSTREAM);
+
+fn rand_u16() -> u16 {
+    let mut b = [0u8; 2];
+    let _ = nonos_libc::crypto_random(b.as_mut_ptr(), 2);
+    u16::from_le_bytes(b)
+}
 
 pub fn udp_port() -> u32 {
     UDP_PORT.load(Ordering::Acquire)
@@ -37,11 +42,19 @@ pub fn set_udp_port(port: u32) {
 }
 
 pub fn local_port() -> u16 {
-    LOCAL_PORT.load(Ordering::Acquire)
+    let current = LOCAL_PORT.load(Ordering::Acquire);
+    if current != 0 {
+        return current;
+    }
+    let port = 49152u16 + (rand_u16() as u32 % 16384) as u16;
+    match LOCAL_PORT.compare_exchange(0, port, Ordering::AcqRel, Ordering::Acquire) {
+        Ok(_) => port,
+        Err(existing) => existing,
+    }
 }
 
 pub fn next_xid() -> u16 {
-    XID.fetch_add(1, Ordering::AcqRel).wrapping_add(1)
+    rand_u16()
 }
 
 pub fn now_ms() -> u64 {

--- a/userland/capsule_net_dns/src/udp_client/recv.rs
+++ b/userland/capsule_net_dns/src/udp_client/recv.rs
@@ -56,6 +56,9 @@ pub fn recv_from(udp_port: u32, local_port: u16) -> Result<UdpDatagram, UdpRecvE
         return Err(UdpRecvError::Refused(errno));
     }
     let end = HDR_LEN + len as usize;
+    if end > resp.len() {
+        return Err(UdpRecvError::BadResponse);
+    }
     let mut src = [0u8; 4];
     src.copy_from_slice(&resp[HDR_LEN..HDR_LEN + 4]);
     let src_port = u16::from_le_bytes([resp[HDR_LEN + 4], resp[HDR_LEN + 5]]);

--- a/userland/capsule_net_l2/src/arp/cache/cache_type.rs
+++ b/userland/capsule_net_l2/src/arp/cache/cache_type.rs
@@ -14,11 +14,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use super::constants::ENTRY_CAP;
+use super::constants::{ENTRY_CAP, PENDING_CAP};
 use super::entry::Entry;
 
 pub struct Cache {
     pub(super) entries: [Option<Entry>; ENTRY_CAP],
     pub(super) len: usize,
     pub(super) next_seq: u64,
+    pub(super) pending: [Option<[u8; 4]>; PENDING_CAP],
+    pub(super) pending_head: usize,
 }

--- a/userland/capsule_net_l2/src/arp/cache/learn.rs
+++ b/userland/capsule_net_l2/src/arp/cache/learn.rs
@@ -14,5 +14,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-pub(super) const ENTRY_CAP: usize = 64;
-pub(super) const PENDING_CAP: usize = 8;
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum Learn {
+    Insert,
+    Refresh,
+    Reject,
+}
+
+pub fn decide(existing_mac: Option<[u8; 6]>, sender_mac: [u8; 6], solicited: bool) -> Learn {
+    match existing_mac {
+        Some(m) if m == sender_mac => Learn::Refresh,
+        Some(_) => Learn::Reject,
+        None if solicited => Learn::Insert,
+        None => Learn::Reject,
+    }
+}

--- a/userland/capsule_net_l2/src/arp/cache/mod.rs
+++ b/userland/capsule_net_l2/src/arp/cache/mod.rs
@@ -19,7 +19,10 @@ mod constants;
 mod entry;
 mod evict_oldest;
 mod insert;
+mod learn;
 mod lookup;
 mod new;
+mod pending;
 
 pub use cache_type::Cache;
+pub use learn::{decide, Learn};

--- a/userland/capsule_net_l2/src/arp/cache/new.rs
+++ b/userland/capsule_net_l2/src/arp/cache/new.rs
@@ -15,10 +15,16 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::cache_type::Cache;
-use super::constants::ENTRY_CAP;
+use super::constants::{ENTRY_CAP, PENDING_CAP};
 
 impl Cache {
     pub const fn new() -> Self {
-        Self { entries: [None; ENTRY_CAP], len: 0, next_seq: 0 }
+        Self {
+            entries: [None; ENTRY_CAP],
+            len: 0,
+            next_seq: 0,
+            pending: [None; PENDING_CAP],
+            pending_head: 0,
+        }
     }
 }

--- a/userland/capsule_net_l2/src/arp/cache/pending.rs
+++ b/userland/capsule_net_l2/src/arp/cache/pending.rs
@@ -14,5 +14,23 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-pub(super) const ENTRY_CAP: usize = 64;
-pub(super) const PENDING_CAP: usize = 8;
+use super::cache_type::Cache;
+use super::constants::PENDING_CAP;
+
+impl Cache {
+    pub fn note_pending(&mut self, ipv4: [u8; 4]) {
+        if self.pending.iter().any(|p| *p == Some(ipv4)) {
+            return;
+        }
+        self.pending[self.pending_head] = Some(ipv4);
+        self.pending_head = (self.pending_head + 1) % PENDING_CAP;
+    }
+
+    pub fn is_pending(&mut self, ipv4: [u8; 4]) -> bool {
+        if let Some(slot) = self.pending.iter_mut().find(|p| **p == Some(ipv4)) {
+            *slot = None;
+            return true;
+        }
+        false
+    }
+}

--- a/userland/capsule_net_l2/src/arp/handle.rs
+++ b/userland/capsule_net_l2/src/arp/handle.rs
@@ -37,7 +37,8 @@ pub struct ReplyFrame {
 // not require a response.
 pub fn on_inbound(iface: &Iface, cache: &mut Cache, payload: &[u8]) -> Option<ReplyFrame> {
     let pkt = ArpPacket::parse(payload)?;
-    let solicited = cache.is_pending(pkt.sender_ip) || pkt.target_ip == iface.ipv4;
+    let solicited = cache.is_pending(pkt.sender_ip)
+        || (pkt.oper == OPER_REQUEST && pkt.target_ip == iface.ipv4);
     match crate::arp::cache::decide(cache.lookup(&pkt.sender_ip), pkt.sender_mac, solicited) {
         crate::arp::cache::Learn::Insert | crate::arp::cache::Learn::Refresh => {
             cache.insert(pkt.sender_ip, pkt.sender_mac);

--- a/userland/capsule_net_l2/src/arp/handle.rs
+++ b/userland/capsule_net_l2/src/arp/handle.rs
@@ -27,14 +27,23 @@ pub struct ReplyFrame {
     pub bytes: [u8; HDR_LEN + PACKET_LEN],
 }
 
-// Consume an inbound ARP packet payload. Always update the cache
-// with the sender's claim. If the packet is a request for our own
+// Consume an inbound ARP packet payload. Apply the learn policy
+// before touching the cache: refresh a matching binding, reject a
+// MAC rebind, and insert a new binding only when the packet is
+// solicited (a reply to our own outstanding request, or a request
+// that directly targets us). If the packet is a request for our own
 // IPv4 address, build and return the reply frame so the caller can
 // hand it to the NIC client. Returns `None` when the packet does
 // not require a response.
 pub fn on_inbound(iface: &Iface, cache: &mut Cache, payload: &[u8]) -> Option<ReplyFrame> {
     let pkt = ArpPacket::parse(payload)?;
-    cache.insert(pkt.sender_ip, pkt.sender_mac);
+    let solicited = cache.is_pending(pkt.sender_ip) || pkt.target_ip == iface.ipv4;
+    match crate::arp::cache::decide(cache.lookup(&pkt.sender_ip), pkt.sender_mac, solicited) {
+        crate::arp::cache::Learn::Insert | crate::arp::cache::Learn::Refresh => {
+            cache.insert(pkt.sender_ip, pkt.sender_mac);
+        }
+        crate::arp::cache::Learn::Reject => {}
+    }
     if pkt.oper != OPER_REQUEST || pkt.target_ip != iface.ipv4 {
         return None;
     }

--- a/userland/capsule_net_l2/src/server/handlers/arp_resolve.rs
+++ b/userland/capsule_net_l2/src/server/handlers/arp_resolve.rs
@@ -43,6 +43,7 @@ pub fn handle(sender_pid: u32, req: &Request, body: &[u8], tx: &mut [u8]) {
         return;
     }
     let iface = Iface { mac: *STATE.mac.lock(), ipv4: *STATE.ipv4.lock() };
+    STATE.arp.lock().note_pending(target);
     let req_frame = build_request(&iface, target);
     let _ = nic_send(nic, &req_frame);
     let _ = respond(sender_pid, OP_ARP_RESOLVE, E_NO_NEIGHBOUR, req.request_id, 0, tx);

--- a/userland/capsule_net_tcp/src/selftest.rs
+++ b/userland/capsule_net_tcp/src/selftest.rs
@@ -41,7 +41,33 @@ pub fn run() -> u32 {
     if cc_kat() {
         bits |= 1 << 6;
     }
+    if quota_kat() {
+        bits |= 1 << 7;
+    }
     bits
+}
+
+fn quota_kat() -> bool {
+    use crate::state::{quota_ok, Table};
+    use crate::tcp::{Endpoint4, Tcb, MAX_CONN_PER_PID};
+    if !(quota_ok(0, MAX_CONN_PER_PID)
+        && quota_ok(MAX_CONN_PER_PID - 1, MAX_CONN_PER_PID)
+        && !quota_ok(MAX_CONN_PER_PID, MAX_CONN_PER_PID))
+    {
+        return false;
+    }
+    let a = 0xAAAA_AAAA;
+    let b = 0xBBBB_BBBB;
+    let mut t = Table::new();
+    let mk = || Tcb::listen(Endpoint4 { ip: [0; 4], port: 0 });
+    for _ in 0..MAX_CONN_PER_PID {
+        if t.insert(a, 0, mk()).is_err() {
+            return false;
+        }
+    }
+    t.insert(a, 0, mk()).is_err()
+        && t.count_owned(a) == MAX_CONN_PER_PID
+        && t.insert(b, 0, mk()).is_ok()
 }
 
 fn cc_kat() -> bool {

--- a/userland/capsule_net_tcp/src/state/mod.rs
+++ b/userland/capsule_net_tcp/src/state/mod.rs
@@ -27,3 +27,6 @@ pub use reasm::Reasm;
 pub use retx::{RetxQueue, RetxSeg};
 pub use table::TABLE;
 pub use timers::{TimerKind, Timers};
+
+#[cfg(feature = "tcp-selftest")]
+pub use table::{quota_ok, Table};

--- a/userland/capsule_net_tcp/src/state/table/mod.rs
+++ b/userland/capsule_net_tcp/src/state/table/mod.rs
@@ -19,3 +19,8 @@ mod mutate;
 mod types;
 
 pub use types::TABLE;
+
+#[cfg(feature = "tcp-selftest")]
+pub use mutate::quota_ok;
+#[cfg(feature = "tcp-selftest")]
+pub use types::Table;

--- a/userland/capsule_net_tcp/src/state/table/mutate.rs
+++ b/userland/capsule_net_tcp/src/state/table/mutate.rs
@@ -14,14 +14,25 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::tcp::Tcb;
+use crate::tcp::{Tcb, MAX_CONN_PER_PID};
 
 use super::types::{Table, TableError, TABLE_CAP};
 use crate::state::Entry;
 
+pub fn quota_ok(owner_count: usize, cap: usize) -> bool {
+    owner_count < cap
+}
+
 impl Table {
+    pub fn count_owned(&self, owner: u32) -> usize {
+        self.entries.iter().filter(|e| e.owner_pid == owner).count()
+    }
+
     pub fn insert(&mut self, owner: u32, parent: u32, tcb: Tcb) -> Result<u32, TableError> {
         if self.entries.len() >= TABLE_CAP {
+            return Err(TableError::Full);
+        }
+        if !quota_ok(self.count_owned(owner), MAX_CONN_PER_PID) {
             return Err(TableError::Full);
         }
         let handle = self.next_handle;

--- a/userland/capsule_net_tcp/src/tcp/mod.rs
+++ b/userland/capsule_net_tcp/src/tcp/mod.rs
@@ -45,6 +45,8 @@ pub const MAX_RETX: u8 = 8;
 
 pub const REASM_MAX_SEGS: usize = 32;
 
+pub const MAX_CONN_PER_PID: usize = 32;
+
 pub const INIT_CWND: u32 = 3 * MSS as u32;
 pub const DUP_ACK_THRESH: u8 = 3;
 

--- a/userland/capsule_net_tcp_smoke/src/lifecycle/ops.rs
+++ b/userland/capsule_net_tcp_smoke/src/lifecycle/ops.rs
@@ -66,6 +66,9 @@ pub fn selftest(port: u32) {
     if bits & 64 != 0 {
         mark(b"[TCP] CC-KAT OK\n");
     }
+    if bits & 128 != 0 {
+        mark(b"[TCP] QUOTA-KAT OK\n");
+    }
 }
 
 pub fn connect_errno(port: u32, dst: [u8; 4], dport: u16) -> Option<(u16, u32)> {


### PR DESCRIPTION
## Net Security — Wave 1

Closes the high-severity, capsule-internal network security holes from the 2026-06-16 net-stack audit (`docs/audits/2026-06-16-net-stack-deepdive.md`). 9 commits, each implemented → reviewed → boot/cargo-verified. **Capsule-internal only — no kernel/ABI/capability changes.**

### What's fixed
| Item | Capsule | Hole → Fix |
|---|---|---|
| **ARP cache poisoning** | net_l2 | learned every inbound ARP unconditionally → MITM. Now: reject MAC-rebinding of an existing entry; learn a new binding only when *solicited* (a reply for an IP we're actively resolving via a pending-request ring, or a **request** targeting us). |
| **DNS spoofing** | net_dns | predictable txid (`0x3011++`) + fixed source port (`53535`) → trivial cache poisoning; plus a `recv_from` OOB panic and no response validation. Now: CSPRNG txid (per-query) + per-boot random source port, **fail-closed** if the RNG fails; `recv_from` length guard; response question-section validation (case-insensitive qname + qtype). |
| **TCP SYN-flood** | net_tcp | 256-slot table exhaustible by one principal / spoofed SYNs. Now: per-pid connection quota (32) in `Table::insert`; passively-accepted TCBs inherit the listener's kernel-attested pid, so a flood is bounded. |
| **DHCP rogue-server** | net_dhcp | predictable xid + installs malformed offers. Now: CSPRNG xid (one per transaction, fail-closed); reject `yiaddr == 0.0.0.0` and zero subnet mask (was installing a prefix-0 route). |

### Verification
- **Boot regression** (`make nonos-mk-boot-tcp-lifecycle`, hvf) stayed green for every datapath-touching change: `CONNECT / ECHO / CLOSE / RST-REFUSED` + all KATs, 0 `FAIL`. This exercises net_l2 ARP gateway-resolution + net_dhcp lease-bind + the TCP path, so a regression in those surfaces immediately.
- **TCP quota** adds a boot-time KAT (`[TCP] QUOTA-KAT OK`) exercising the real `Table::insert` path (bit 7 of the feature-gated `OP_SELFTEST` rig).
- **DNS** has no boot harness (not on any harness path) → gated on `cargo check` + code review.
- Every item was code-reviewed; review caught and fixed: a spoofed-REPLY ARP-learn bypass, a **fail-open CSPRNG** (zeroed buffer → predictable txid), and confirmed the SYN-flood quota binds the real `accept::syn` vector.

### Scope / honesty
- **Behavioral attack-rejection proofs** (reject a poisoned ARP / spoofed DNS reply / SYN flood on the wire) need a packet-injection harness (like the reliability arc's `tcp-chaos`) — **deferred**; this PR proves the decision logic (KAT/review) + no happy-path regression.
- **Explicitly deferred** (documented in `docs/superpowers/plans/2026-06-17-net-security-wave1.md`): control-op authorization (L2 `OP_SET_IP`, DNS `OP_SET_UPSTREAM`, nym `set_*`) needs a **kernel** service-owner-attestation mechanism a capsule can't implement alone; DHCP full lease lifecycle (T1/T2/expiry); DNS negative caching/TTL clamp; ARP gateway-pinning; TCP SYN-cookies.

### Reviewer note
- The boot-harness/marker changes (incl. the `QUOTA-KAT` assertion) live in the `tests` submodule (`hvf-boot-harnesses`), which couldn't be pushed (`403` for `senseix21` on `micro-kernel-only-tests`). The submodule pointer here is intentionally kept at the upstream commit so CI's submodule checkout succeeds; the harness marker is local-only until pushed from an authorized account.


