### PR TITLE
perf(desktop): drop ripgrep/std_proof embeds from the desktop kernel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -475,8 +475,6 @@ microkernel-desktop-gui = [
   "microkernel-core",
   "nonos-production",
   "nonos-capsule-proof-io",
-  "nonos-capsule-std-proof",
-  "nonos-capsule-ripgrep",
   "nonos-capsule-ramfs",
   "nonos-capsule-keyring",
   "nonos-capsule-entropy",


### PR DESCRIPTION
## Summary

`microkernel-desktop-gui` embedded the **ripgrep (24 MB)** and **std_proof** crates.io-app demos (added in #210) into the kernel via `include_bytes!`, ballooning the desktop kernel image to **72 MB**. That slows the bootloader's load + signature-verify at handoff, and the spawn/attest of a 24 MB capsule — the boot is noticeably sluggish "from the handoff."

Dropping the two demo capsules from the desktop profile returns the kernel to **~48 MB** and a fast handoff. They remain in their own profiles and the production-proof fleet, so they're still built, signed, and ZK-attested — just not baked into the desktop image.

## Test plan
- [x] `make nonos-mk-run` builds (`microkernel-desktop-gui`) and boots to desktop; kernel image 72 MB → 48 MB; ripgrep/std_proof no longer spawned; boot/handoff visibly faster.
- [x] Full production proof still passes (64 capsules signed + pairing-verified).

## Note / dependency
A clean-checkout build still runs the full production proof over the whole fleet (including ripgrep), so it needs the companion `nonos-mk` build fix (`CAPSULE_PREBUILT_BIN` staging + std-PAL stamp dep) to build ripgrep for the policy root. That fix lives in `nonos-mk` and should land there alongside this.