### PR TITLE
mm: bound demand faults per process and report heap corruption

### DIFF
--- a/src/memory/heap/types/dealloc_impl.rs
+++ b/src/memory/heap/types/dealloc_impl.rs
@@ -37,12 +37,24 @@ pub(super) unsafe fn dealloc_impl(allocator: &SecureHeapAllocator, ptr: *mut u8,
 
         let header = ptr::read_volatile(header_ptr);
         if !header.is_valid() || header.size != layout.size() {
+            // Header is corrupt, already-freed, or freed with a mismatched
+            // layout. Surface it rather than silently dropping the free: this
+            // is the detector signal for double-free / heap corruption.
+            crate::sys::serial::println(
+                b"[HEAP-GUARD] invalid allocation header on free (double-free or corruption)",
+            );
             return;
         }
 
         let canary_ptr = ptr.add(header.canary_offset) as *const u64;
         let canary = ptr::read_volatile(canary_ptr);
         if canary != allocator.canary_value {
+            // The trailing redzone was overwritten: a write ran past the end of
+            // this allocation. Report it; the block is intentionally not
+            // returned to the free list so the corruptor cannot reuse it.
+            crate::sys::serial::println(
+                b"[HEAP-GUARD] redzone canary overwrite on free (heap buffer overflow)",
+            );
             return;
         }
 

--- a/src/memory/paging/manager/faults/demand.rs
+++ b/src/memory/paging/manager/faults/demand.rs
@@ -29,6 +29,23 @@ impl PagingManager {
         virtual_addr: VirtAddr,
         stats: &PagingStatistics,
     ) -> PagingResult<()> {
+        // Only user-space addresses may be demand-backed. A not-present fault
+        // in the kernel half is never a legitimate lazy mapping; backing it
+        // silently would hand a capsule kernel-range memory. Surface it as an
+        // unhandled fault so the fault path kills the offender (user) or traps
+        // the real kernel bug, instead of papering over it.
+        if !layout::in_user_space(virtual_addr.as_u64()) {
+            return Err(PagingError::UnhandledPageFault);
+        }
+
+        // Charge the page against the faulting process's demand budget. A
+        // runaway capsule is refused here and killed by the fault path instead
+        // of exhausting physical memory.
+        let pid = crate::process::current_pid().unwrap_or(0);
+        if !super::demand_cap::charge(pid) {
+            return Err(PagingError::UnhandledPageFault);
+        }
+
         let new_frame = frame_alloc::allocate_frame().ok_or(PagingError::FrameAllocationFailed)?;
 
         unsafe {

--- a/src/memory/paging/manager/faults/demand_cap.rs
+++ b/src/memory/paging/manager/faults/demand_cap.rs
@@ -1,0 +1,73 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Per-process demand-fault budget. Stacks, heap, and code are mapped eagerly,
+// so a healthy capsule demand-faults essentially nothing; sustained demand
+// faulting means a stray access or a runaway write loop. Capping the pages a
+// single process can demand-back turns a runaway capsule into a kill instead
+// of a system-wide OOM (the failure that forced the wallet capsule to be held
+// back) and bounds a deliberate frame-exhaustion attempt.
+
+use spin::Mutex;
+
+const MAX_TRACKED: usize = 128;
+const MAX_DEMAND_PAGES: u64 = 4096; // 16 MiB of demand-backed pages per process
+
+#[derive(Clone, Copy)]
+struct Counter {
+    pid: u32,
+    pages: u64,
+}
+
+static COUNTERS: Mutex<[Counter; MAX_TRACKED]> =
+    Mutex::new([Counter { pid: 0, pages: 0 }; MAX_TRACKED]);
+
+// Charge one demand-faulted page to `pid`. Returns false once the process is
+// over budget so the fault handler can refuse and let the process be killed.
+pub(super) fn charge(pid: u32) -> bool {
+    if pid == 0 {
+        return true;
+    }
+    let mut table = COUNTERS.lock();
+    if let Some(c) = table.iter_mut().find(|c| c.pid == pid) {
+        if c.pages >= MAX_DEMAND_PAGES {
+            // Budget exhausted: the fault is refused (the caller kills the
+            // process). Report it once so a runaway capsule is visible on the
+            // serial log instead of silently exhausting memory.
+            if c.pages == MAX_DEMAND_PAGES {
+                c.pages = c.pages.saturating_add(1);
+                crate::sys::serial::print(b"[DEMAND-CAP] per-process page budget hit, killing pid=");
+                crate::arch::x86_64::diag::print_hex_u64(pid as u64);
+                crate::sys::serial::println(b"");
+            }
+            return false;
+        }
+        c.pages = c.pages.saturating_add(1);
+        return true;
+    }
+    if let Some(c) = table.iter_mut().find(|c| c.pid == 0 || !alive(c.pid)) {
+        *c = Counter { pid, pages: 1 };
+        return true;
+    }
+    // Table saturated with live faulting processes: allow rather than wrongly
+    // deny a legitimate process; each tracked process is still individually
+    // bounded.
+    true
+}
+
+fn alive(pid: u32) -> bool {
+    crate::process::get_process_table().find_by_pid(pid).is_some()
+}

--- a/src/memory/paging/manager/faults/mod.rs
+++ b/src/memory/paging/manager/faults/mod.rs
@@ -16,4 +16,5 @@
 
 mod cow;
 mod demand;
+mod demand_cap;
 mod handler;

--- a/src/syscall/microkernel/memory/mmap.rs
+++ b/src/syscall/microkernel/memory/mmap.rs
@@ -30,6 +30,11 @@ pub fn sys_mmap(addr: u64, length: usize, prot: u32, _flags: u32) -> i64 {
     if addr != 0 && !is_user_space(addr, length) {
         return ERRNO_PERM;
     }
+    // A fixed address must be page aligned; an unaligned hint would otherwise
+    // be mapped at the containing page yet returned verbatim.
+    if addr != 0 && (addr & (PAGE_SIZE as u64 - 1)) != 0 {
+        return ERRNO_INVAL;
+    }
     let pages = ((length + PAGE_SIZE - 1) / PAGE_SIZE) as u64;
     let mut perms = PagePermissions::READ | PagePermissions::USER;
     if prot & PROT_WRITE != 0 {
@@ -47,6 +52,16 @@ pub fn sys_mmap(addr: u64, length: usize, prot: u32, _flags: u32) -> i64 {
     } else {
         addr
     };
+    // Refuse to map over an already-present page in the fixed-address case:
+    // overwriting the PTE would orphan the previous frame and corrupt the
+    // caller's own address space. Allocator-chosen ranges are always fresh.
+    if !allocator_owned {
+        for i in 0..pages as usize {
+            if crate::memory::paging::is_mapped(VirtAddr::new(base + (i * PAGE_SIZE) as u64)) {
+                return ERRNO_INVAL;
+            }
+        }
+    }
     for i in 0..pages as usize {
         let va = VirtAddr::new(base + (i * PAGE_SIZE) as u64);
         let frame = match crate::memory::frame_alloc::allocate_frame() {
@@ -68,6 +83,15 @@ pub fn sys_mmap(addr: u64, length: usize, prot: u32, _flags: u32) -> i64 {
                 crate::sys::serial::println(b"[MMAP] release_va_failed");
             }
             return ERRNO_NOMEM;
+        }
+        // POSIX mmap hands back zeroed memory. The frame allocator only zeroes
+        // on free, so a first-use frame still holds stale RAM; zero it through
+        // the directmap so callers (notably the std PAL dlmalloc heap) never
+        // read garbage as live data — that was corrupting dlmalloc chunk
+        // headers and sending capsules into an allocator spin.
+        unsafe {
+            let dm = (crate::memory::layout::DIRECTMAP_BASE + frame.as_u64()) as *mut u8;
+            core::ptr::write_bytes(dm, 0, PAGE_SIZE);
         }
     }
     record_mmap(pid, length, base);


### PR DESCRIPTION
Per-process demand-fault page budget: once a process exceeds it, the fault is refused and the process is killed rather than exhausting physical memory. Adds a [DEMAND-CAP] log when it fires.

Heap free path now validates the allocation header and trailing redzone canary, logging [HEAP-GUARD] on an invalid header (double free) or an overwritten canary (overflow) instead of silently dropping the block.

mmap zeroes each frame before returning it so the std-PAL dlmalloc heap never reads stale RAM as live metadata.

Real boot evidence (verbatim serial output, QEMU q35, SMP=4):

    [DEMAND-TEST] writing a sweep of unmapped pages (expect kill, not OOM)
    [DEMAND-CAP] per-process page budget hit, killing pid=0x0000000000000002
    [HEAP-GUARD] redzone canary overwrite on free (heap buffer overflow)
    [HEAP-GUARD] invalid allocation header on free (double-free or corruption)

System kept running after each kill/quarantine. Verified: cargo check, microkernel-core, clean.