### PR TITLE
input: route key release to the press target

### DIFF
--- a/userland/capsule_input_router/src/route/keyboard.rs
+++ b/userland/capsule_input_router/src/route/keyboard.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use nonos_libc::InputEvent;
+use nonos_libc::{InputEvent, INPUT_KIND_KEY_UP};
 
 use crate::clients::wm;
 use crate::state::Context;
@@ -23,23 +23,45 @@ use super::deliver::deliver_one;
 use super::pointer::shell_pid;
 
 pub fn route_keyboard(ctx: &mut Context, event: &InputEvent) -> u32 {
-    let rid = ctx.issue_request_id();
-    let pid = match wm::query_focus(&mut ctx.wm_port, rid) {
-        Some(focused) => {
-            ctx.last_focus_pid = focused;
-            focused
+    let is_up = event.kind == INPUT_KIND_KEY_UP;
+    // A release goes to whoever received the matching press, so a focus change
+    // while a key is held cannot strand the key-down in the old window. A press
+    // routes to current focus. Resolving the release from the press target also
+    // avoids a synchronous WM query on every key-up.
+    let pid = if is_up {
+        ctx.key_targets
+            .take(event.code)
+            .filter(|&p| p != 0)
+            .unwrap_or_else(|| fallback_focus(ctx))
+    } else {
+        let rid = ctx.issue_request_id();
+        match wm::query_focus(&mut ctx.wm_port, rid) {
+            Some(focused) => {
+                ctx.last_focus_pid = focused;
+                focused
+            }
+            None => fallback_focus(ctx),
         }
-        None if ctx.last_focus_pid != 0 => ctx.last_focus_pid,
-        None => shell_pid(ctx),
     };
     if !ctx.subscriptions.allows(pid, event.kind) {
         ctx.record(0);
         return 0;
     }
     let delivered = deliver_one(pid, event);
+    if !is_up && delivered != 0 {
+        ctx.key_targets.remember(event.code, pid);
+    }
     if delivered == 0 {
         ctx.forget_pid(pid);
     }
     ctx.record(delivered);
     delivered
+}
+
+fn fallback_focus(ctx: &mut Context) -> u32 {
+    if ctx.last_focus_pid != 0 {
+        ctx.last_focus_pid
+    } else {
+        shell_pid(ctx)
+    }
 }

--- a/userland/capsule_input_router/src/state/context/forget_pid.rs
+++ b/userland/capsule_input_router/src/state/context/forget_pid.rs
@@ -29,6 +29,7 @@ impl Context {
             self.hover = None;
         }
         self.grabs.release(pid);
+        self.key_targets.forget_pid(pid);
         if self.shell_pid == pid {
             self.shell_pid = 0;
         }

--- a/userland/capsule_input_router/src/state/context/new.rs
+++ b/userland/capsule_input_router/src/state/context/new.rs
@@ -15,13 +15,14 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::Context;
-use crate::state::{CursorState, GrabTable, SubscriptionTable};
+use crate::state::{CursorState, GrabTable, KeyTargets, SubscriptionTable};
 
 impl Context {
     pub const fn new() -> Self {
         Self {
             subscriptions: SubscriptionTable::new(),
             grabs: GrabTable::new(),
+            key_targets: KeyTargets::new(),
             press: None,
             hover: None,
             hover_tick: 0,

--- a/userland/capsule_input_router/src/state/context/types.rs
+++ b/userland/capsule_input_router/src/state/context/types.rs
@@ -14,11 +14,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::state::{CursorState, GrabTable, Hover, Press, SubscriptionTable};
+use crate::state::{CursorState, GrabTable, Hover, KeyTargets, Press, SubscriptionTable};
 
 pub struct Context {
     pub subscriptions: SubscriptionTable,
     pub grabs: GrabTable,
+    pub key_targets: KeyTargets,
     pub press: Option<Press>,
     pub hover: Option<Hover>,
     pub hover_tick: u32,

--- a/userland/capsule_input_router/src/state/key_targets.rs
+++ b/userland/capsule_input_router/src/state/key_targets.rs
@@ -1,0 +1,66 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Tracks which capsule received the key-down for each currently held key, so
+// the matching key-up is delivered to that same capsule even if window focus
+// moved while the key was held. Without this, a release routed by current
+// focus lands in the wrong window and the original app sees a stuck key.
+
+const MAX_HELD_KEYS: usize = 16;
+
+#[derive(Clone, Copy)]
+struct Held {
+    code: u32,
+    pid: u32,
+}
+
+pub struct KeyTargets {
+    held: [Held; MAX_HELD_KEYS],
+}
+
+impl KeyTargets {
+    pub const fn new() -> Self {
+        Self { held: [Held { code: 0, pid: 0 }; MAX_HELD_KEYS] }
+    }
+
+    // Record that `pid` received the down for `code`. Updates an existing entry
+    // for the same key, else claims a free slot; a full table drops the record
+    // (that key-up then falls back to current focus).
+    pub fn remember(&mut self, code: u32, pid: u32) {
+        if let Some(slot) = self.held.iter_mut().find(|h| h.pid != 0 && h.code == code) {
+            slot.pid = pid;
+            return;
+        }
+        if let Some(slot) = self.held.iter_mut().find(|h| h.pid == 0) {
+            *slot = Held { code, pid };
+        }
+    }
+
+    // Return and clear the pid that received the down for `code`, if known.
+    pub fn take(&mut self, code: u32) -> Option<u32> {
+        let slot = self.held.iter_mut().find(|h| h.pid != 0 && h.code == code)?;
+        let pid = slot.pid;
+        *slot = Held { code: 0, pid: 0 };
+        Some(pid)
+    }
+
+    // Drop every entry for a pid that has gone away.
+    pub fn forget_pid(&mut self, pid: u32) {
+        for h in self.held.iter_mut().filter(|h| h.pid == pid) {
+            *h = Held { code: 0, pid: 0 };
+        }
+    }
+}

--- a/userland/capsule_input_router/src/state/mod.rs
+++ b/userland/capsule_input_router/src/state/mod.rs
@@ -18,6 +18,7 @@ pub mod context;
 pub mod cursor;
 pub mod grabs;
 pub mod hover;
+pub mod key_targets;
 pub mod press;
 pub mod subscriptions;
 
@@ -25,5 +26,6 @@ pub use context::Context;
 pub use cursor::CursorState;
 pub use grabs::GrabTable;
 pub use hover::Hover;
+pub use key_targets::KeyTargets;
 pub use press::Press;
 pub use subscriptions::SubscriptionTable;


### PR DESCRIPTION
A key-down and its matching key-up could be delivered to different focused windows if focus changed between the two events, leaving a capsule with a press and no release (stuck modifiers, held keys).

The input router now remembers which pid each press was delivered to and routes the release to that same pid, clearing the mapping when the pid exits.