### PR TITLE
smp/apic: x2apic detection and IPI vector handlers

### DIFF
--- a/src/arch/x86_64/idt/handlers/exports.rs
+++ b/src/arch/x86_64/idt/handlers/exports.rs
@@ -34,3 +34,8 @@ pub(crate) use super::isr_irqs::{
     isr_irq2 as isr_34, isr_irq3 as isr_35, isr_irq4 as isr_36, isr_irq5 as isr_37,
     isr_irq6 as isr_38, isr_irq7 as isr_39, isr_irq8 as isr_40, isr_irq9 as isr_41, isr_syscall,
 };
+
+pub(crate) use super::isr_irqs::{
+    isr_ipi_64 as isr_64, isr_ipi_65 as isr_65, isr_ipi_66 as isr_66, isr_ipi_67 as isr_67,
+    isr_ipi_68 as isr_68,
+};

--- a/src/arch/x86_64/idt/handlers/isr_irqs.rs
+++ b/src/arch/x86_64/idt/handlers/isr_irqs.rs
@@ -41,4 +41,12 @@ irq_entry!(isr_irq13, 45);
 irq_entry!(isr_irq14, 46);
 irq_entry!(isr_irq15, 47);
 irq_entry!(isr_generic_48, 48);
+// Inter-processor interrupt vectors (0x40-0x44). Without these gates the first
+// IPI sent once SMP is enabled faults the target CPU; the handlers route
+// through the registered other-handlers and signal LAPIC EOI.
+irq_entry!(isr_ipi_64, 64);
+irq_entry!(isr_ipi_65, 65);
+irq_entry!(isr_ipi_66, 66);
+irq_entry!(isr_ipi_67, 67);
+irq_entry!(isr_ipi_68, 68);
 irq_entry!(isr_syscall, 0x80);

--- a/src/arch/x86_64/idt/ops/init_irqs.rs
+++ b/src/arch/x86_64/idt/ops/init_irqs.rs
@@ -36,5 +36,14 @@ pub unsafe fn setup_irqs(idt: &mut Idt) {
     idt.entries[45] = IdtEntry::interrupt_gate(isr_45, KERNEL_CS, 0, DPL_KERNEL);
     idt.entries[46] = IdtEntry::interrupt_gate(isr_46, KERNEL_CS, 0, DPL_KERNEL);
     idt.entries[47] = IdtEntry::interrupt_gate(isr_47, KERNEL_CS, 0, DPL_KERNEL);
+    // Inter-processor interrupt vectors 0x40-0x44 (decimal 64-68). Installed
+    // unconditionally: the handlers only fire once SMP sends IPIs, but having
+    // the gates present also stops a stray vector in this range from
+    // escalating to a fault.
+    idt.entries[64] = IdtEntry::interrupt_gate(isr_64, KERNEL_CS, 0, DPL_KERNEL);
+    idt.entries[65] = IdtEntry::interrupt_gate(isr_65, KERNEL_CS, 0, DPL_KERNEL);
+    idt.entries[66] = IdtEntry::interrupt_gate(isr_66, KERNEL_CS, 0, DPL_KERNEL);
+    idt.entries[67] = IdtEntry::interrupt_gate(isr_67, KERNEL_CS, 0, DPL_KERNEL);
+    idt.entries[68] = IdtEntry::interrupt_gate(isr_68, KERNEL_CS, 0, DPL_KERNEL);
     idt.entries[0x80] = IdtEntry::trap_gate(isr_syscall, KERNEL_CS, 0, DPL_USER);
 }

--- a/src/smp/init/bsp.rs
+++ b/src/smp/init/bsp.rs
@@ -34,6 +34,10 @@ pub fn init_bsp() -> Result<(), &'static str> {
     let cpu_count = topology::detect_cpus();
     CPU_COUNT.store(cpu_count, Ordering::Release);
     percpu::init_bsp();
+    // Bind the IPI vectors now so cross-CPU TLB shootdown, panic, stop, and
+    // call-function delivery work the moment APs come online. Harmless on a
+    // single-CPU boot: nothing sends IPIs until APs start.
+    super::super::ipi_idt::register_ipi_handlers();
 
     crate::log_info!("[SMP] BSP initialized: APIC ID={}, {} CPUs detected", bsp_apic, cpu_count);
 

--- a/src/smp/ipi_idt.rs
+++ b/src/smp/ipi_idt.rs
@@ -1,0 +1,63 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Binds the IPI vectors (0x40-0x44) to their handlers in the interrupt
+// dispatch table and signals LAPIC end-of-interrupt. The IDT gates for these
+// vectors are installed unconditionally in idt setup; registering the handlers
+// here is harmless until SMP actually sends IPIs. Without this, a delivered IPI
+// would find no handler, never EOI, and wedge the local APIC.
+
+use crate::arch::x86_64::idt::entry::InterruptFrame;
+use crate::arch::x86_64::idt::ops::register_handler;
+use crate::arch::x86_64::interrupt::apic::eoi;
+
+use super::constants::{IPI_PANIC, IPI_RESCHEDULE, IPI_STOP, IPI_TLB_SHOOTDOWN};
+use super::ipi::IPI_CALL_FUNCTION;
+
+fn ipi_tlb_shootdown(_frame: &mut InterruptFrame) {
+    super::tlb::handle_tlb_shootdown_ipi();
+    eoi();
+}
+
+fn ipi_reschedule(_frame: &mut InterruptFrame) {
+    // Acknowledge only. A migrated task is picked up by the target CPU's next
+    // timer tick; triggering an immediate reschedule from interrupt context is
+    // wired separately once the per-CPU scheduler path is live.
+    eoi();
+}
+
+fn ipi_panic(_frame: &mut InterruptFrame) {
+    eoi();
+    super::ipi_handler::handle_panic_ipi();
+}
+
+fn ipi_stop(_frame: &mut InterruptFrame) {
+    eoi();
+    super::ipi_handler::handle_stop_ipi();
+}
+
+fn ipi_call_function(_frame: &mut InterruptFrame) {
+    super::ipi::handle_call_function_ipi();
+    eoi();
+}
+
+pub(crate) fn register_ipi_handlers() {
+    let _ = register_handler(IPI_TLB_SHOOTDOWN, ipi_tlb_shootdown);
+    let _ = register_handler(IPI_RESCHEDULE, ipi_reschedule);
+    let _ = register_handler(IPI_PANIC, ipi_panic);
+    let _ = register_handler(IPI_STOP, ipi_stop);
+    let _ = register_handler(IPI_CALL_FUNCTION, ipi_call_function);
+}

--- a/src/smp/mod.rs
+++ b/src/smp/mod.rs
@@ -21,6 +21,7 @@ mod constants;
 mod cpu;
 mod init;
 mod ipi_handler;
+mod ipi_idt;
 mod preempt;
 mod state;
 mod stats;

--- a/src/sys/apic/local/init.rs
+++ b/src/sys/apic/local/init.rs
@@ -32,6 +32,10 @@ pub fn init_local_apic() {
     }
     serial::println(b"[APIC] Initializing Local APIC...");
 
+    // Detect x2APIC hand-off before touching any register: if firmware left
+    // the APIC in x2APIC mode the accessors below must use MSRs, not MMIO.
+    super::x2apic::detect_mode();
+
     unsafe {
         // Boot phase: still on identity-mapped physical. VM init will
         // republish to the kernel-half UC virtual page via rebind.

--- a/src/sys/apic/local/mod.rs
+++ b/src/sys/apic/local/mod.rs
@@ -22,6 +22,7 @@ pub(super) mod regs;
 mod state;
 mod stop_timer;
 mod timer;
+mod x2apic;
 
 pub use constants::{LAPIC_PHYS_BASE, TIMER_VECTOR};
 pub use eoi::eoi;

--- a/src/sys/apic/local/regs.rs
+++ b/src/sys/apic/local/regs.rs
@@ -17,12 +17,17 @@
 use core::sync::atomic::Ordering;
 
 use super::state::LAPIC_BASE;
+use super::x2apic;
 
 // SAFETY: Caller guarantees LAPIC_BASE points at a mapped UC page and
 // `reg` is a valid LAPIC register offset (0..=0x3F0 step 0x10). All
 // LAPIC registers are 32 bits, naturally aligned. The volatile pair
-// suppresses re-ordering.
+// suppresses re-ordering. In x2APIC mode the MMIO window is gone, so the
+// access is routed to the equivalent MSR instead.
 pub(in crate::sys::apic) unsafe fn lapic_read_raw(reg: u32) -> u32 {
+    if x2apic::is_x2(Ordering::Relaxed) {
+        return x2apic::read(reg);
+    }
     unsafe {
         let base = LAPIC_BASE.load(Ordering::Relaxed);
         let ptr = (base + reg as u64) as *const u32;
@@ -31,6 +36,10 @@ pub(in crate::sys::apic) unsafe fn lapic_read_raw(reg: u32) -> u32 {
 }
 
 pub(in crate::sys::apic) unsafe fn lapic_write_raw(reg: u32, value: u32) {
+    if x2apic::is_x2(Ordering::Relaxed) {
+        x2apic::write(reg, value);
+        return;
+    }
     unsafe {
         let base = LAPIC_BASE.load(Ordering::Relaxed);
         let ptr = (base + reg as u64) as *mut u32;

--- a/src/sys/apic/local/state.rs
+++ b/src/sys/apic/local/state.rs
@@ -28,3 +28,9 @@ pub(super) static LAPIC_BASE: AtomicU64 = AtomicU64::new(LOCAL_APIC_DEFAULT_BASE
 // Init guard for the surface; readers in eoi() and timer fast path
 // skip work when this is false rather than risk poking an uninit base.
 pub static LAPIC_INIT: AtomicBool = AtomicBool::new(false);
+
+// True when firmware handed off with the local APIC already in x2APIC mode.
+// In that mode the MMIO window is disabled and registers are MSRs, so the
+// register accessors route through rdmsr/wrmsr. Latched once at init; never
+// forced on, so an xAPIC machine (QEMU included) keeps the MMIO path.
+pub(in crate::sys::apic) static LAPIC_X2: AtomicBool = AtomicBool::new(false);

--- a/src/sys/apic/local/x2apic.rs
+++ b/src/sys/apic/local/x2apic.rs
@@ -1,0 +1,64 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// x2APIC register access for the BSP local-APIC surface. Real UEFI firmware
+// frequently hands off with x2APIC already enabled, in which case the MMIO
+// window is disabled and the registers are model-specific registers. We detect
+// that hand-off state (without ever forcing the mode) and map an MMIO register
+// offset to its MSR index: MSR = 0x800 + (offset >> 4).
+
+use core::sync::atomic::Ordering;
+
+use super::state::LAPIC_X2;
+
+const IA32_APIC_BASE: u32 = 0x1B;
+const APIC_BASE_X2_ENABLE: u64 = 1 << 10;
+const X2APIC_MSR_BASE: u32 = 0x800;
+
+// Latch whether firmware left the APIC in x2APIC mode. Must run before any
+// register access so the accessors pick the right transport.
+pub(in crate::sys::apic) fn detect_mode() {
+    let enabled = unsafe { rdmsr(IA32_APIC_BASE) } & APIC_BASE_X2_ENABLE != 0;
+    LAPIC_X2.store(enabled, Ordering::Release);
+}
+
+pub(in crate::sys::apic) fn is_x2(reg_order: Ordering) -> bool {
+    LAPIC_X2.load(reg_order)
+}
+
+pub(in crate::sys::apic) fn read(reg: u32) -> u32 {
+    unsafe { rdmsr(X2APIC_MSR_BASE + (reg >> 4)) as u32 }
+}
+
+pub(in crate::sys::apic) fn write(reg: u32, value: u32) {
+    unsafe { wrmsr(X2APIC_MSR_BASE + (reg >> 4), value as u64) }
+}
+
+unsafe fn rdmsr(msr: u32) -> u64 {
+    let (lo, hi): (u32, u32);
+    unsafe {
+        core::arch::asm!("rdmsr", in("ecx") msr, out("eax") lo, out("edx") hi,
+            options(nomem, nostack, preserves_flags));
+    }
+    ((hi as u64) << 32) | lo as u64
+}
+
+unsafe fn wrmsr(msr: u32, value: u64) {
+    unsafe {
+        core::arch::asm!("wrmsr", in("ecx") msr, in("eax") value as u32,
+            in("edx") (value >> 32) as u32, options(nomem, nostack, preserves_flags));
+    }
+}


### PR DESCRIPTION
Adds a conservative x2APIC accessor that reads IA32_APIC_BASE and switches to MSR register access in x2APIC mode, keeping the MMIO path otherwise. Registers IPI vectors 0x40-0x44 with ISR stubs and IDT entries so the BSP can signal application processors.

This is compile-ready groundwork for multi-core bring-up. Single-core boot behaviour is unchanged; full SMP runtime is a later step.

Verified: cargo check, microkernel-core, clean.