### PR TITLE
fix(net): grant net.dhcp and net.dns the Crypto capability

### DIFF
--- a/src/userspace/capsule_net_dhcp/spawn.rs
+++ b/src/userspace/capsule_net_dhcp/spawn.rs
@@ -53,7 +53,7 @@ pub fn spawn_net_dhcp_capsule() -> Result<(), SpawnError> {
         manifest_bytes: NET_DHCP_MANIFEST_BYTES,
         attestation_trailer: NET_DHCP_ATTESTATION_BYTES,
         target_triple: TARGET_TRIPLE,
-        requested_caps: Capability::IPC.bit() | Capability::Memory.bit(),
+        requested_caps: Capability::IPC.bit() | Capability::Memory.bit() | Capability::Crypto.bit(),
         debug_tag: b"[NET-DHCP] load_elf_executable error:",
     };
     let pid = capsule_spawn::spawn_verified(&spec, &trust_anchor, None)?;

--- a/src/userspace/capsule_net_dns/spawn.rs
+++ b/src/userspace/capsule_net_dns/spawn.rs
@@ -46,7 +46,7 @@ pub fn spawn_net_dns_capsule() -> Result<(), SpawnError> {
         manifest_bytes: NET_DNS_MANIFEST_BYTES,
         attestation_trailer: NET_DNS_ATTESTATION_BYTES,
         target_triple: TARGET_TRIPLE,
-        requested_caps: Capability::IPC.bit() | Capability::Memory.bit(),
+        requested_caps: Capability::IPC.bit() | Capability::Memory.bit() | Capability::Crypto.bit(),
         debug_tag: b"[NET-DNS] load_elf_executable error:",
     };
     let pid = capsule_spawn::spawn_verified(&spec, &trust_anchor, None)?;

--- a/userland/capsule_net_dhcp/Capsule.mk
+++ b/userland/capsule_net_dhcp/Capsule.mk
@@ -11,7 +11,7 @@ CAPSULE_FEATURE          := nonos-capsule-net-dhcp
 CAPSULE_NAMESPACE        := systems.nonos.net.dhcp.client
 CAPSULE_SERVICE_ENDPOINT := service:4440:net.dhcp.client
 CAPSULE_REPLY_ENDPOINT   := reply:4441:endpoint.net.dhcp.client.reply
-CAPSULE_REQUIRED_CAPS    := 0x00019
+CAPSULE_REQUIRED_CAPS    := 0x00039
 CAPSULE_KERNEL_MIRROR    := src/userspace/capsule_net_dhcp
 
 include nonos-mk/capsule.mk

--- a/userland/capsule_net_dns/Capsule.mk
+++ b/userland/capsule_net_dns/Capsule.mk
@@ -10,7 +10,7 @@ CAPSULE_FEATURE          := nonos-capsule-net-dns
 CAPSULE_NAMESPACE        := systems.nonos.net.dns
 CAPSULE_SERVICE_ENDPOINT := service:4450:net.dns
 CAPSULE_REPLY_ENDPOINT   := reply:4451:endpoint.net.dns.reply
-CAPSULE_REQUIRED_CAPS    := 0x00019
+CAPSULE_REQUIRED_CAPS    := 0x00039
 CAPSULE_KERNEL_MIRROR    := src/userspace/capsule_net_dns
 
 include nonos-mk/capsule.mk


### PR DESCRIPTION
## Summary

**net-security-wave1 left DHCP (and DNS) unable to function**, taking the whole net stack down. `b95dd581d` made net.dhcp draw its DHCP xid from `crypto_random` and **fail closed** on failure (and `9c76b3f2d` did the same for net.dns's txid), but **neither capsule was granted `Capability::Crypto`**. The kernel `crypto_random` syscall gates on `CAP_CRYPTO`, so the draw always failed:

- `net.dhcp` `next_xid()` → `None` → DORA aborts **before sending a DISCOVER** → no lease → no ARP → no TCP. The entire net stack is dead.
- `net.dns` txid draw has the same latent failure.

(net.tcp/net.nym already carry `0x39` = with Crypto, which is why their `crypto_random` works — e.g. TCP `ISS-OK` passes.)

## Fix

Grant `Crypto` (`0x20`) in **both** hand-synced declarations (per the repo's manifest↔spawner contract):
- `Capsule.mk` `CAPSULE_REQUIRED_CAPS` `0x19 → 0x39` (net.dhcp, net.dns)
- kernel spawner `requested_caps |= Capability::Crypto.bit()` (net.dhcp, net.dns)

## How it was found

Markers lied (`RST-REFUSED OK` fires on connect-failure too), so I went to ground truth — a **pcap** showed **0 IPv4 packets** (no DISCOVER). Userland `mk_debug` markers in net.dhcp's DORA showed `link-ok` ×16 but **never** reaching `discover()` — isolating the silent `?` on `next_xid()`. The kernel `handle_crypto_random` cap-gate + net.dhcp's `0x19` caps confirmed it.

## Test plan
- [x] `tcp_lifecycle` (hvf): pcap shows **BOOTP Request/Reply (DORA) + full TCP handshake** to `10.0.2.200:7`; `CONNECT OK / ECHO OK / CLOSE OK` + all KATs green. Before: 16× DORA fail-closed, 0 IPv4 on the wire, no CONNECT.
- [x] Full production proof still passes (fleet signed + ZK-verified).