### PR TITLE
fix(ipc): yield instead of spin on capsule transport locks under preemption

### DIFF
--- a/src/fs/ramfs_capsule/client/transport.rs
+++ b/src/fs/ramfs_capsule/client/transport.rs
@@ -33,7 +33,7 @@ pub(super) struct ResponseBytes {
 }
 
 pub(super) fn round_trip(seq: u32, request: Vec<u8>) -> Result<ResponseBytes, CapsuleFsError> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         seq,
         &request,

--- a/src/fs/vfs_capsule/client/transport.rs
+++ b/src/fs/vfs_capsule/client/transport.rs
@@ -38,7 +38,7 @@ pub(super) fn round_trip(
     request_id: u32,
     request: Vec<u8>,
 ) -> Result<ResponseBytes, VfsCapsuleError> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/hardware/ahci_capsule/client/transport.rs
+++ b/src/hardware/ahci_capsule/client/transport.rs
@@ -36,7 +36,7 @@ pub(super) fn round_trip(
     request_id: u32,
     request: Vec<u8>,
 ) -> Result<ResponseBytes, DriverAhciError> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/hardware/e1000_capsule/client/transport.rs
+++ b/src/hardware/e1000_capsule/client/transport.rs
@@ -39,7 +39,7 @@ pub(super) fn round_trip(
     request_id: u32,
     request: Vec<u8>,
 ) -> Result<ResponseBytes, DriverNetError> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/hardware/hda_capsule/client/transport.rs
+++ b/src/hardware/hda_capsule/client/transport.rs
@@ -36,7 +36,7 @@ pub(super) fn round_trip(
     request_id: u32,
     request: Vec<u8>,
 ) -> Result<ResponseBytes, DriverHdaError> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/hardware/nvme_capsule/client/transport.rs
+++ b/src/hardware/nvme_capsule/client/transport.rs
@@ -36,7 +36,7 @@ pub(super) fn round_trip(
     request_id: u32,
     request: Vec<u8>,
 ) -> Result<ResponseBytes, DriverNvmeError> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/hardware/ps2_kbd_capsule/client/transport.rs
+++ b/src/hardware/ps2_kbd_capsule/client/transport.rs
@@ -41,7 +41,7 @@ pub(super) fn round_trip(
     request_id: u32,
     request: Vec<u8>,
 ) -> Result<ResponseBytes, DriverPs2Error> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/hardware/rtl8139_capsule/client/transport.rs
+++ b/src/hardware/rtl8139_capsule/client/transport.rs
@@ -36,7 +36,7 @@ pub(super) fn round_trip(
     request_id: u32,
     request: Vec<u8>,
 ) -> Result<ResponseBytes, DriverRtl8139Error> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/hardware/rtl8169_capsule/client/transport.rs
+++ b/src/hardware/rtl8169_capsule/client/transport.rs
@@ -36,7 +36,7 @@ pub(super) fn round_trip(
     request_id: u32,
     request: Vec<u8>,
 ) -> Result<ResponseBytes, DriverRtl8169Error> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/hardware/virtio_blk_capsule/client/transport.rs
+++ b/src/hardware/virtio_blk_capsule/client/transport.rs
@@ -41,7 +41,7 @@ pub(super) fn round_trip(
     request_id: u32,
     request: Vec<u8>,
 ) -> Result<ResponseBytes, DriverBlkError> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/hardware/virtio_net_capsule/client/transport.rs
+++ b/src/hardware/virtio_net_capsule/client/transport.rs
@@ -39,7 +39,7 @@ pub(super) fn round_trip(
     request_id: u32,
     request: Vec<u8>,
 ) -> Result<ResponseBytes, DriverNetError> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/hardware/virtio_rng_capsule/client/transport.rs
+++ b/src/hardware/virtio_rng_capsule/client/transport.rs
@@ -38,7 +38,7 @@ pub(super) fn round_trip(
     request_id: u32,
     request: Vec<u8>,
 ) -> Result<ResponseBytes, DriverRngError> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/hardware/xhci_capsule/client/transport.rs
+++ b/src/hardware/xhci_capsule/client/transport.rs
@@ -40,7 +40,7 @@ pub(super) fn round_trip(
     request_id: u32,
     request: Vec<u8>,
 ) -> Result<ResponseBytes, DriverXhciError> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/security/crypto_capsule/client/transport.rs
+++ b/src/security/crypto_capsule/client/transport.rs
@@ -39,7 +39,7 @@ pub(super) fn round_trip(
     request_id: u32,
     request: Vec<u8>,
 ) -> Result<ResponseBytes, CryptoCapsuleError> {
-    let guard = TRANSPORT_LOCK.lock();
+    let guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/security/entropy_capsule/client/transport.rs
+++ b/src/security/entropy_capsule/client/transport.rs
@@ -38,7 +38,7 @@ pub(super) fn round_trip(
     request_id: u32,
     request: Vec<u8>,
 ) -> Result<ResponseBytes, EntropyCapsuleError> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/security/keyring_capsule/client/transport.rs
+++ b/src/security/keyring_capsule/client/transport.rs
@@ -35,7 +35,7 @@ pub(super) struct ResponseBytes {
 }
 
 pub(super) fn round_trip(seq: u32, request: Vec<u8>) -> Result<ResponseBytes, KeyringCapsuleError> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         seq,
         &request,

--- a/src/security/market_capsule/client/transport.rs
+++ b/src/security/market_capsule/client/transport.rs
@@ -36,7 +36,7 @@ pub(super) struct ResponseBytes {
 }
 
 pub(super) fn round_trip(request_id: u32, request: Vec<u8>) -> Result<ResponseBytes, MarketError> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,

--- a/src/services/lifecycle/transport.rs
+++ b/src/services/lifecycle/transport.rs
@@ -27,11 +27,28 @@ use alloc::format;
 use alloc::vec::Vec;
 use core::sync::atomic::{AtomicU32, Ordering};
 
+use spin::{Mutex, MutexGuard};
+
 use super::state::CapsuleState;
 use crate::ipc::nonos_channel::IpcMessage;
 use crate::ipc::nonos_inbox;
 
 const RECV_YIELDS: u32 = 50_000;
+
+/// Acquire a per-capsule transport lock without busy-spinning. `round_trip`
+/// yields the CPU while it waits for the reply, so the holder is off-core for
+/// the whole exchange; a contending caller must yield too rather than spin, or
+/// on a single CPU with interrupts disabled it pins the core and the holder
+/// can never run to release the lock (the deadlock involuntary preemption now
+/// makes reachable). On contention, hand the CPU to the holder and retry.
+pub fn lock_yielding(lock: &'static Mutex<()>) -> MutexGuard<'static, ()> {
+    loop {
+        if let Some(guard) = lock.try_lock() {
+            return guard;
+        }
+        crate::sched::yield_now();
+    }
+}
 
 /// Bump a per-capsule request-id counter, skipping zero so callers can
 /// reserve `0` for "no request in flight". The atomic is owned by

--- a/src/userspace/capsule_driver_usb_hid/client/transport.rs
+++ b/src/userspace/capsule_driver_usb_hid/client/transport.rs
@@ -33,7 +33,7 @@ pub(super) struct ResponseBytes {
 }
 
 pub(super) fn round_trip(request_id: u32, request: Vec<u8>) -> Result<ResponseBytes, UsbHidError> {
-    let _guard = TRANSPORT_LOCK.lock();
+    let _guard = transport::lock_yielding(&TRANSPORT_LOCK);
     let resp = transport::round_trip(
         request_id,
         &request,


### PR DESCRIPTION
## Problem

After #216 (timer-tick preemption) merged to `main`, the desktop-gui boot **deadlocks at `[USER-FIRST] pid=0x17`** (net.dns) — the display stays on the bootloader splash, serial stops, no panic.

Root cause (QMP RIP-sampling + `llvm-objdump`): every kernel-side capsule IPC client holds a busy-spin `spin::Mutex` (`TRANSPORT_LOCK`) across `services::lifecycle::transport::round_trip`, which yields the CPU up to 50k times while waiting for the capsule reply. Cooperative scheduling tolerated lock-across-yield. Involuntary timer-tick preemption now lets a **second** caller run while the holder is mid-round-trip and **busy-spin on the held lock with IF=0**; on `-smp 1` the spinner pins the core, the timer can't fire, and the holder never resumes to release → deadlock.

It surfaced now because #221 granted net.dns the Crypto cap, so it draws `crypto_random` at first-run → a concurrent entropy-client caller, exactly the contention case.

## Fix

A shared `transport::lock_yielding(&TRANSPORT_LOCK)` (try_lock + `sched::yield_now` on contention) replaces `.lock()` in all 18 clients (+1 helper). A contended caller hands the CPU back to the holder, which runs to completion and releases. The entropy/transport code itself is unchanged — #216 was the trigger, lock-across-yield was the latent bug.

19 files, +35/−18; largest single-file change +17 (the helper).

## Verification

Serial-proven under QEMU/hvf: boot now reaches `USER-FIRST pid=0x2c` (was frozen at 0x17), `[PREEMPT] enter/switch away/restored` shows preemption working *without* deadlock, compositor `[SLOOK]` active, all apps spawn, no panic / `[DEMAND-CAP]` / `[HEAP-GUARD]`.

Regression from #216.

