### PR TITLE
syscall: bound user-supplied lengths and authorize proc_output

### DIFF
--- a/src/syscall/dispatch/router/surface_handlers.rs
+++ b/src/syscall/dispatch/router/surface_handlers.rs
@@ -53,10 +53,15 @@ pub(super) fn do_register(desc_ptr: u64) -> SyscallResult {
         Ok(v) => v,
         Err(_) => return errno(EFAULT),
     };
-    let pages = ((desc.byte_len as usize) + 4095) / 4096;
-    if pages == 0 || (desc.base_va & 0xFFF) != 0 {
+    // Bound the user-supplied length before deriving a page count: an
+    // unbounded byte_len would force a huge Vec allocation and a near-infinite
+    // translate loop in the kernel. 64 MiB covers any realistic surface
+    // (4K BGRA is ~33 MiB) while capping the work at 16384 pages.
+    const MAX_SURFACE_BYTES: u64 = 64 * 1024 * 1024;
+    if desc.byte_len == 0 || desc.byte_len > MAX_SURFACE_BYTES || (desc.base_va & 0xFFF) != 0 {
         return errno(EINVAL);
     }
+    let pages = ((desc.byte_len as usize) + 4095) / 4096;
     let mut frames = Vec::with_capacity(pages);
     for i in 0..pages {
         let va = VirtAddr::new(desc.base_va + (i as u64) * 4096);

--- a/src/syscall/microkernel/ipc/reply.rs
+++ b/src/syscall/microkernel/ipc/reply.rs
@@ -50,7 +50,9 @@ fn trace(caller_pid: u32, dest_pid: u64, label: &[u8], rc: i64, inbox: &str) {
 }
 
 pub fn sys_ipc_reply(dest_pid: u64, buf: u64, len: usize) -> i64 {
-    if len == 0 || dest_pid == 0 || dest_pid > u32::MAX as u64 {
+    if len == 0 || len > crate::ipc::channel::MAX_MESSAGE_SIZE || dest_pid == 0
+        || dest_pid > u32::MAX as u64
+    {
         trace(current_pid().unwrap_or(0), dest_pid, b"inval", ERRNO_INVAL, "");
         return ERRNO_INVAL;
     }

--- a/src/syscall/microkernel/ipc/send.rs
+++ b/src/syscall/microkernel/ipc/send.rs
@@ -49,7 +49,10 @@ pub fn sys_ipc_send(endpoint: u64, buf: u64, len: usize) -> i64 {
 }
 
 pub(super) fn send_with_correlation(endpoint: u64, buf: u64, len: usize, correlation: u64) -> i64 {
-    if len == 0 {
+    // Reject oversize before allocating: len is validated against the 64 MiB
+    // usercopy ceiling downstream, but the message itself is capped at 1 MiB,
+    // so bound it here to avoid a capsule forcing huge transient allocations.
+    if len == 0 || len > crate::ipc::channel::MAX_MESSAGE_SIZE {
         return ERRNO_INVAL;
     }
     if crate::usercopy::validate_user_read(buf, len).is_err() {

--- a/src/syscall/microkernel/ipc/send_to_pid.rs
+++ b/src/syscall/microkernel/ipc/send_to_pid.rs
@@ -42,7 +42,7 @@ fn trace(caller_pid: u32, dest_pid: u64, len: usize) {
 // registry. The kernel still records the sender in the message
 // envelope so the receiver can chain a follow-up reply.
 pub fn sys_ipc_send_to_pid(dest_pid: u64, buf: u64, len: usize) -> i64 {
-    if len == 0 {
+    if len == 0 || len > crate::ipc::channel::MAX_MESSAGE_SIZE {
         return ERRNO_INVAL;
     }
     if dest_pid == 0 || dest_pid > u32::MAX as u64 {

--- a/src/syscall/microkernel/proc_output.rs
+++ b/src/syscall/microkernel/proc_output.rs
@@ -19,13 +19,22 @@
 //! loaded capsule's output in its own window. Returns the number of
 //! bytes copied, 0 when the inbox is empty, or a negative errno.
 
-use super::errnos::{ERRNO_FAULT, ERRNO_INVAL};
+use super::errnos::{ERRNO_FAULT, ERRNO_INVAL, ERRNO_PERM};
+use crate::process::{current_pid, get_parent_pid};
 
 pub fn sys_proc_output(pid: u64, buf_ptr: u64, buf_len: usize) -> i64 {
-    if buf_ptr == 0 || buf_len == 0 {
+    if buf_ptr == 0 || buf_len == 0 || pid == 0 || pid > u32::MAX as u64 {
         return ERRNO_INVAL;
     }
-    let name = alloc::format!("proc.{}", pid as u32);
+    // Only the parent that loaded the capsule may drain its mirrored stdout.
+    // Without this any IPC-capable capsule could read another capsule's output
+    // by passing its pid, since the inbox name is derived from the argument.
+    let target = pid as u32;
+    let caller = current_pid().unwrap_or(0);
+    if caller == 0 || get_parent_pid(target) != Some(caller) {
+        return ERRNO_PERM;
+    }
+    let name = alloc::format!("proc.{}", target);
     let Some(msg) = crate::ipc::nonos_inbox::try_dequeue_existing(&name) else {
         return 0;
     };


### PR DESCRIPTION
Hardens the syscall boundary against unbounded user input:

- ipc send / reply / send_to_pid reject messages larger than MAX_MESSAGE_SIZE (1 MiB) before allocating, so a capsule cannot force huge transient kernel allocations.
- The surface register call bounds the user-supplied byte length to 64 MiB before deriving a page count, capping the work instead of looping over an arbitrary range.
- proc_output validates the pid and refuses to return output the caller does not own (EPERM), instead of exposing another process's buffer.

Verified: cargo check, microkernel-core, clean.