### PR TITLE
chore(terminal): remove the autorun/autofocus GUI-smoke demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -922,21 +922,6 @@ nonos-mk-market-smoke: $(USERLAND_LIBC) $(MARKETPLACE_ABI_LIB)
 		--features smoketest-trust \
 		-Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
 
-ECOSYSTEM_GUI_SMOKE_FEATURES := terminal_CARGO_FEATURES=nonos-autorun-rg desktop-shell_CARGO_FEATURES=autofocus-terminal
-
-.PHONY: nonos-mk-terminal-autorun-rg nonos-mk-desktop-shell-autofocus nonos-mk-ecosystem-gui-smoke-capsules nonos-mk-ecosystem-gui-smoke-prod
-nonos-mk-terminal-autorun-rg:
-	@$(MAKE) -B terminal_CARGO_FEATURES=nonos-autorun-rg nonos-mk-terminal
-
-nonos-mk-desktop-shell-autofocus:
-	@$(MAKE) -B desktop-shell_CARGO_FEATURES=autofocus-terminal nonos-mk-desktop-shell
-
-nonos-mk-ecosystem-gui-smoke-capsules:
-	@$(MAKE) -B $(ECOSYSTEM_GUI_SMOKE_FEATURES) nonos-mk-terminal-sign nonos-mk-desktop-shell-sign
-
-nonos-mk-ecosystem-gui-smoke-prod: nonos-mk-ecosystem-gui-smoke-capsules
-	@$(MAKE) $(ECOSYSTEM_GUI_SMOKE_FEATURES) nonos-mk-desktop-gui-prod
-
 # Host-side marketplace-index CLI. This is the bridge an operator
 # runs offline: read JSON, encode canonical binary, sign with the
 # Ed25519 operator key, verify. The tool is host-native (no kernel
@@ -1890,14 +1875,6 @@ nonos-mk-boot-terminal:
 		echo "Restoring GUI terminal capsule (undo autorun-selftest artifact)..."; \
 		$(MAKE) -B nonos-mk-terminal-sign >/dev/null 2>&1; \
 		exit $$rc
-
-.PHONY: nonos-mk-boot-ecosystem-gui-smoke
-nonos-mk-boot-ecosystem-gui-smoke:
-	@DESKTOP_GUI_BUILD_TARGET=nonos-mk-ecosystem-gui-smoke-prod \
-		DESKTOP_GUI_REQUIRE_ECOSYSTEM_SMOKE=1 \
-		BOOT_TEST_TIMEOUT=300 \
-		BOOT_TEST_SETTLE=60 \
-		./tests/boot/desktop_gui_boot.sh
 
 nonos-mk-plan-a-runtime: nonos-mk-desktop-gui-prod nonos-mk-esp $(QEMU_BLK_IMG) $(QEMU_OVMF_VARS_RW)
 	@QEMU="$(QEMU)" OVMF="$(OVMF)" OVMF_VARS="$(OVMF_VARS)" \

--- a/userland/capsule_desktop_shell/Cargo.toml
+++ b/userland/capsule_desktop_shell/Cargo.toml
@@ -16,5 +16,3 @@ path = "src/main.rs"
 nonos_libc = { package = "nonos_userland_libc", path = "../libc" }
 nonos_toolkit = { path = "../toolkit" }
 
-[features]
-autofocus-terminal = []

--- a/userland/capsule_desktop_shell/src/server/runner/run.rs
+++ b/userland/capsule_desktop_shell/src/server/runner/run.rs
@@ -32,29 +32,9 @@ pub fn run(mut ctx: Context) -> ! {
     let mut tx = vec![0u8; HDR_LEN + IPC_PAYLOAD_MAX];
     let mut last_clock_ms: i64 = 0;
     refresh_clock(&mut ctx);
-    #[cfg(feature = "autofocus-terminal")]
-    let autofocus_start = mk_time_millis();
-    #[cfg(feature = "autofocus-terminal")]
-    let mut autofocus_done = false;
     loop {
         drain(&mut ctx, &mut rx, &mut tx);
         let now = mk_time_millis();
-        // Smoke build only: focus the terminal once after the apps have
-        // registered, so a headless boot drives the same focus path a user
-        // click would, letting the terminal tick.
-        #[cfg(feature = "autofocus-terminal")]
-        if !autofocus_done && now.wrapping_sub(autofocus_start) > 5000 {
-            let sent = crate::server::handlers::launcher_request::request(
-                &crate::state::apps::LAUNCHER_APPS[0],
-            );
-            if sent {
-                autofocus_done = true;
-                debug_marker(b"[DESKTOP-SHELL] autofocus terminal sent\n");
-            } else if now.wrapping_sub(autofocus_start) > 30000 {
-                autofocus_done = true;
-                debug_marker(b"[DESKTOP-SHELL] autofocus terminal failed\n");
-            }
-        }
         if now.wrapping_sub(last_clock_ms) >= CLOCK_REFRESH_MS as i64 {
             refresh_clock(&mut ctx);
             if !ctx.input_ready {
@@ -78,9 +58,4 @@ pub fn run(mut ctx: Context) -> ! {
         }
         let _ = mk_display_vsync_wait(0);
     }
-}
-
-#[cfg(feature = "autofocus-terminal")]
-fn debug_marker(msg: &[u8]) {
-    let _ = nonos_libc::mk_debug(msg.as_ptr(), msg.len());
 }

--- a/userland/capsule_terminal/Cargo.toml
+++ b/userland/capsule_terminal/Cargo.toml
@@ -19,10 +19,6 @@ name = "terminal"
 path = "src/main.rs"
 
 [features]
-# Smoke build: auto-run a real install command after boot so a headless
-# run proves a loaded capsule's output reaches the terminal.
-nonos-autorun-rg = []
-
 # Self-test build: once vfs answers, auto-run the unproven shell paths
 # (echo, vfs round trip, pipe, statement gating) and emit graded
 # [TERMINAL-TEST] serial markers for the boot harness.

--- a/userland/capsule_terminal/src/event/mod.rs
+++ b/userland/capsule_terminal/src/event/mod.rs
@@ -27,6 +27,6 @@ mod on_tab;
 mod on_up;
 mod paste_clipboard;
 
-#[cfg(any(feature = "nonos-autorun-rg", feature = "nonos-autorun-selftest"))]
+#[cfg(feature = "nonos-autorun-selftest")]
 pub use on_enter::on_enter;
 pub use on_event::on_event;

--- a/userland/capsule_terminal/src/term/terminal/app_impl.rs
+++ b/userland/capsule_terminal/src/term/terminal/app_impl.rs
@@ -30,30 +30,4 @@ impl App for Terminal {
     fn paint(&mut self, fb: &mut PaintBuffer) {
         self.paint_inner(fb)
     }
-
-    // Smoke build only: once services have settled, run a real command
-    // through the normal submit path so a headless boot proves command output
-    // flows back into the terminal grid. Searches the seeded /docs/demo.txt for
-    // a known term so the result is deterministic.
-    #[cfg(feature = "nonos-autorun-rg")]
-    fn on_tick(&mut self) -> bool {
-        if self.autorun_done {
-            return false;
-        }
-        self.autorun_ticks += 1;
-        if self.autorun_ticks < 6 {
-            return false;
-        }
-        self.autorun_done = true;
-        debug_marker(b"[TERMINAL-AUTORUN] grep demo start\n");
-        self.state.line.replace(b"grep nonos < /docs/demo.txt");
-        crate::event::on_enter(&mut self.state);
-        debug_marker(b"[TERMINAL-AUTORUN] grep demo returned\n");
-        true
-    }
-}
-
-#[cfg(feature = "nonos-autorun-rg")]
-fn debug_marker(msg: &[u8]) {
-    let _ = nonos_libc::mk_debug(msg.as_ptr(), msg.len());
 }

--- a/userland/capsule_terminal/src/term/terminal/new.rs
+++ b/userland/capsule_terminal/src/term/terminal/new.rs
@@ -20,12 +20,6 @@ use crate::term::state::State;
 impl Terminal {
     pub fn new() -> Self {
         let state = State::new();
-        Self {
-            state,
-            #[cfg(feature = "nonos-autorun-rg")]
-            autorun_ticks: 0,
-            #[cfg(feature = "nonos-autorun-rg")]
-            autorun_done: false,
-        }
+        Self { state }
     }
 }

--- a/userland/capsule_terminal/src/term/terminal/types.rs
+++ b/userland/capsule_terminal/src/term/terminal/types.rs
@@ -18,8 +18,4 @@ use crate::term::state::State;
 
 pub struct Terminal {
     pub(crate) state: State,
-    #[cfg(feature = "nonos-autorun-rg")]
-    pub(crate) autorun_ticks: u32,
-    #[cfg(feature = "nonos-autorun-rg")]
-    pub(crate) autorun_done: bool,
 }


### PR DESCRIPTION
Removes the GUI-smoke autorun/autofocus terminal demo — the terminal no longer auto-opens or auto-runs anything. (Follow-up to #230/#231; base merged in so this is conflict-free.)

## What
- **`nonos-autorun-rg`** (terminal): the `on_tick` that auto-ran a command at boot, the `autorun_ticks`/`autorun_done` state, and the Cargo feature.
- **`autofocus-terminal`** (desktop-shell): the loop block that auto-focused the terminal after boot, its `debug_marker`, and the Cargo feature.
- **Makefile**: `ECOSYSTEM_GUI_SMOKE_FEATURES`, the four smoke targets, and the `nonos-mk-boot-ecosystem-gui-smoke` harness.

## Why
The auto-open/auto-run only ran in the `ecosystem-gui-smoke` build (never in the production desktop) and isn't wanted. The VT terminal render is already covered by the `vt-*` boot markers (`make nonos-mk-terminal-test`) and desktop pixel checks, so the auto-output demo is redundant.

## Verification
`capsule_terminal` checks clean (default + `nonos-autorun-selftest`); `capsule_desktop_shell` builds; Makefile parses with the smoke targets gone; no remaining references to the removed features; 8 files, −92/+2.


