### PR TITLE
ci: add evidence, reproducibility, and release provenance gates

### DIFF
--- a/.github/actions/nonos-setup/action.yml
+++ b/.github/actions/nonos-setup/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
     default: "x86_64-nonos"
   tools:
-    description: "CSV subset of: audit,deny,fuzz,nextest. Empty installs none."
+    description: "CSV subset of: audit,deny,cyclonedx,fuzz,nextest. Empty installs none."
     required: false
     default: ""
   qemu:
@@ -99,7 +99,7 @@ runs:
         done
 
     - name: Restore rustup + cargo cache
-      uses: actions/cache@v4  # TODO: pin to commit SHA
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
       with:
         path: |
           ~/.cargo/registry/index
@@ -110,7 +110,7 @@ runs:
           ${{ runner.os }}-${{ steps.pin.outputs.channel }}-cargo-
 
     - name: Restore target cache
-      uses: actions/cache@v4  # TODO: pin to commit SHA
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
       with:
         path: |
           target
@@ -131,18 +131,25 @@ runs:
           tool="$(echo "${tool}" | xargs)"
           [ -z "${tool}" ] && continue
           case "${tool}" in
-            audit)   bin=cargo-audit;   crate=cargo-audit   ;;
-            deny)    bin=cargo-deny;    crate=cargo-deny    ;;
-            fuzz)    bin=cargo-fuzz;    crate=cargo-fuzz    ;;
-            nextest) bin=cargo-nextest; crate=cargo-nextest ;;
-            *) echo "::error::unknown cargo tool '${tool}' (want audit|deny|fuzz|nextest)"; exit 1 ;;
+            audit)     bin=cargo-audit;    crate=cargo-audit;    version=0.22.2 ;;
+            deny)      bin=cargo-deny;     crate=cargo-deny;     version=0.19.9 ;;
+            cyclonedx) bin=cargo-cyclonedx; crate=cargo-cyclonedx; version=0.5.9 ;;
+            fuzz)      bin=cargo-fuzz;     crate=cargo-fuzz     ;;
+            nextest)   bin=cargo-nextest;  crate=cargo-nextest  ;;
+            *) echo "::error::unknown cargo tool '${tool}' (want audit|deny|cyclonedx|fuzz|nextest)"; exit 1 ;;
           esac
           if command -v "${bin}" >/dev/null 2>&1; then
             echo "${bin} already present"
           else
-            echo "cargo install --locked ${crate}"
-            cargo install --locked "${crate}"
+            if [ -n "${version:-}" ]; then
+              echo "cargo install --locked ${crate} --version ${version}"
+              cargo install --locked "${crate}" --version "${version}"
+            else
+              echo "cargo install --locked ${crate}"
+              cargo install --locked "${crate}"
+            fi
           fi
+          unset version
         done
 
     - name: Install QEMU + OVMF + boot helpers

--- a/.github/workflows/ci-adversarial.yml
+++ b/.github/workflows/ci-adversarial.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 concurrency:
   group: ci-adversarial-${{ github.ref }}
   cancel-in-progress: false
@@ -22,9 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4  # TODO: pin to commit SHA
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: recursive
+          persist-credentials: false
       - uses: ./.github/actions/nonos-setup
         with:
           module: adversarial
@@ -32,8 +37,9 @@ jobs:
         run: cargo run --release --manifest-path nonos-verify/Cargo.toml -- adversarial
       - name: Upload adversarial artifacts
         if: always()
-        uses: actions/upload-artifact@v4  # TODO: pin to commit SHA
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ci-reports-adversarial
           path: ci-reports/
           retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/ci-attestation.yml
+++ b/.github/workflows/ci-attestation.yml
@@ -7,9 +7,19 @@ name: ci-attestation
 
 on:
   workflow_call:
+    inputs:
+      required-modules:
+        description: "CSV list of module reports that must be present"
+        required: false
+        type: string
+        default: "build,supply-chain,trust-chain,adversarial,evidence"
 
 permissions:
   contents: read
+
+defaults:
+  run:
+    shell: bash
 
 concurrency:
   group: ci-attestation-${{ github.ref }}
@@ -21,24 +31,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4  # TODO: pin to commit SHA
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: recursive
+          persist-credentials: false
       - uses: ./.github/actions/nonos-setup
         with:
           module: attest
       - name: Download all module reports
-        uses: actions/download-artifact@v4  # TODO: pin to commit SHA
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           pattern: ci-reports-*
           merge-multiple: true
           path: ci-reports
       - name: nonos-verify attest
+        env:
+          NONOS_VERIFY_REQUIRED_MODULES: ${{ inputs.required-modules }}
         run: cargo run --release --manifest-path nonos-verify/Cargo.toml -- attest
       - name: Upload attestation
         if: always()
-        uses: actions/upload-artifact@v4  # TODO: pin to commit SHA
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ci-attestation
           path: ci-reports/attest/
           retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -6,9 +6,22 @@ name: ci-build
 
 on:
   workflow_call:
+    inputs:
+      trust-mode:
+        description: "scratch for PR/dev CI, production for release gates"
+        required: false
+        type: string
+        default: "scratch"
+    secrets:
+      SIGNING_KEY_BASE64:
+        required: false
 
 permissions:
   contents: read
+
+defaults:
+  run:
+    shell: bash
 
 concurrency:
   group: ci-build-${{ github.ref }}
@@ -20,24 +33,41 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 75
     steps:
-      - uses: actions/checkout@v4  # TODO: pin to commit SHA
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: recursive
+          persist-credentials: false
       - uses: ./.github/actions/nonos-setup
         with:
           targets: x86_64-nonos,x86_64-unknown-uefi
           module: build
-      - name: Provision CI signing key and scratch trust anchor
+      - name: Provision CI trust material
+        env:
+          NONOS_CI_TRUST_MODE: ${{ inputs.trust-mode }}
+          SIGNING_KEY_BASE64: ${{ secrets.SIGNING_KEY_BASE64 }}
         run: |
           set -euo pipefail
-          bash nonos-ci/setup-signing-key.sh
-          bash nonos-ci/scratch-trust-bootstrap.sh
+          case "${NONOS_CI_TRUST_MODE}" in
+            scratch)
+              bash nonos-ci/setup-signing-key.sh
+              bash nonos-ci/scratch-trust-bootstrap.sh
+              ;;
+            production)
+              bash nonos-ci/setup-signing-key.sh
+              make nonos-mk-check-trust-manifest
+              ;;
+            *)
+              echo "::error::unknown trust-mode '${NONOS_CI_TRUST_MODE}'"
+              exit 1
+              ;;
+          esac
       - name: nonos-verify build
         run: cargo run --release --manifest-path nonos-verify/Cargo.toml -- build
       - name: Upload build artifacts
         if: always()
-        uses: actions/upload-artifact@v4  # TODO: pin to commit SHA
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ci-reports-build
           path: ci-reports/
           retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/ci-evidence.yml
+++ b/.github/workflows/ci-evidence.yml
@@ -2,9 +2,6 @@ name: ci-evidence
 
 on:
   workflow_call:
-  pull_request:
-  push:
-    branches: [main, develop]
 
 permissions:
   contents: read

--- a/.github/workflows/ci-evidence.yml
+++ b/.github/workflows/ci-evidence.yml
@@ -1,0 +1,43 @@
+name: ci-evidence
+
+on:
+  workflow_call:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ci-evidence-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  evidence:
+    name: evidence tooling
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: ./.github/actions/nonos-setup
+        with:
+          targets: x86_64-nonos,x86_64-unknown-uefi
+          module: evidence
+      - name: nonos-verify evidence
+        run: cargo run --release --manifest-path nonos-verify/Cargo.toml -- evidence
+      - name: Upload evidence artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: ci-reports-evidence
+          path: ci-reports/
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/ci-release-artifacts.yml
+++ b/.github/workflows/ci-release-artifacts.yml
@@ -1,0 +1,75 @@
+name: ci-release-artifacts
+
+# Reusable release artifact proof. Builds the ESP release image, copies the
+# required boot/kernel/trust artifacts into one bundle, and emits checksums plus
+# source/workflow provenance.
+
+on:
+  workflow_call:
+    secrets:
+      SIGNING_KEY_BASE64:
+        required: true
+      ZK_BOOT_INDEX:
+        required: true
+      ZK_BOOT_SECRET_X:
+        required: true
+      ZK_BOOT_SECRET_R:
+        required: true
+      ZK_BOOT_NONCE_SEED:
+        required: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ci-release-artifacts-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-artifacts:
+    name: release-artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - uses: ./.github/actions/nonos-setup
+        with:
+          targets: x86_64-nonos,x86_64-unknown-uefi
+          module: release
+      - name: Provision production trust material
+        env:
+          NONOS_CI_TRUST_MODE: production
+          SIGNING_KEY_BASE64: ${{ secrets.SIGNING_KEY_BASE64 }}
+          ZK_BOOT_INDEX: ${{ secrets.ZK_BOOT_INDEX }}
+          ZK_BOOT_SECRET_X: ${{ secrets.ZK_BOOT_SECRET_X }}
+          ZK_BOOT_SECRET_R: ${{ secrets.ZK_BOOT_SECRET_R }}
+          ZK_BOOT_NONCE_SEED: ${{ secrets.ZK_BOOT_NONCE_SEED }}
+        run: |
+          set -euo pipefail
+          bash nonos-ci/setup-signing-key.sh
+          for name in ZK_BOOT_INDEX ZK_BOOT_SECRET_X ZK_BOOT_SECRET_R ZK_BOOT_NONCE_SEED; do
+            test -n "${!name:-}" || { echo "::error::${name} is required for release artifacts"; exit 1; }
+          done
+          make nonos-mk-check-trust-manifest
+      - name: nonos-verify release
+        env:
+          ZK_BOOT_INDEX: ${{ secrets.ZK_BOOT_INDEX }}
+          ZK_BOOT_SECRET_X: ${{ secrets.ZK_BOOT_SECRET_X }}
+          ZK_BOOT_SECRET_R: ${{ secrets.ZK_BOOT_SECRET_R }}
+          ZK_BOOT_NONCE_SEED: ${{ secrets.ZK_BOOT_NONCE_SEED }}
+        run: cargo run --release --manifest-path nonos-verify/Cargo.toml -- release
+      - name: Upload release artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: ci-reports-release
+          path: ci-reports/
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/ci-reproducible.yml
+++ b/.github/workflows/ci-reproducible.yml
@@ -1,15 +1,14 @@
-name: ci-runtime
+name: ci-reproducible
 
-# Reusable runtime proof in QEMU. `nonos-verify runtime` boots the kernel
-# (ramfs, keyring, desktop-gui) and asserts each readiness/PASS marker, then
-# runs the subsystem round-trips that have harnesses. Input end-to-end is an
-# explicit gap until a harness exists.
+# Reusable reproducibility proof. `nonos-verify reproducible` builds the release
+# artifact target twice from clean detached worktrees with fixed deterministic
+# inputs and compares artifact hashes.
 
 on:
   workflow_call:
     inputs:
       trust-mode:
-        description: "scratch for PR/dev CI, production for release gates"
+        description: "scratch for nightly/dev proof, production for release gates"
         required: false
         type: string
         default: "scratch"
@@ -33,14 +32,14 @@ defaults:
     shell: bash
 
 concurrency:
-  group: ci-runtime-${{ github.ref }}
+  group: ci-reproducible-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  runtime:
-    name: runtime
+  reproducible:
+    name: reproducible
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -49,9 +48,8 @@ jobs:
       - uses: ./.github/actions/nonos-setup
         with:
           targets: x86_64-nonos,x86_64-unknown-uefi
-          qemu: "true"
-          module: runtime
-      - name: Provision CI trust material
+          module: reproducible
+      - name: Provision reproducible trust material
         env:
           NONOS_CI_TRUST_MODE: ${{ inputs.trust-mode }}
           SIGNING_KEY_BASE64: ${{ secrets.SIGNING_KEY_BASE64 }}
@@ -65,32 +63,30 @@ jobs:
             scratch)
               bash nonos-ci/setup-signing-key.sh
               echo "NONOS_DEV=1" >> "$GITHUB_ENV"
-              bash nonos-ci/scratch-trust-bootstrap.sh
               ;;
             production)
               bash nonos-ci/setup-signing-key.sh
               for name in ZK_BOOT_INDEX ZK_BOOT_SECRET_X ZK_BOOT_SECRET_R ZK_BOOT_NONCE_SEED; do
-                test -n "${!name:-}" || { echo "::error::${name} is required for production runtime"; exit 1; }
+                test -n "${!name:-}" || { echo "::error::${name} is required for production reproducibility"; exit 1; }
               done
-              make nonos-mk-check-trust-manifest
               ;;
             *)
               echo "::error::unknown trust-mode '${NONOS_CI_TRUST_MODE}'"
               exit 1
               ;;
           esac
-      - name: nonos-verify runtime
+      - name: nonos-verify reproducible
         env:
           ZK_BOOT_INDEX: ${{ secrets.ZK_BOOT_INDEX }}
           ZK_BOOT_SECRET_X: ${{ secrets.ZK_BOOT_SECRET_X }}
           ZK_BOOT_SECRET_R: ${{ secrets.ZK_BOOT_SECRET_R }}
           ZK_BOOT_NONCE_SEED: ${{ secrets.ZK_BOOT_NONCE_SEED }}
-        run: cargo run --release --manifest-path nonos-verify/Cargo.toml -- runtime
-      - name: Upload runtime artifacts
+        run: cargo run --release --manifest-path nonos-verify/Cargo.toml -- reproducible
+      - name: Upload reproducibility artifacts
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: ci-reports-runtime
+          name: ci-reports-reproducible
           path: ci-reports/
           retention-days: 14
           if-no-files-found: error

--- a/.github/workflows/ci-supply-chain.yml
+++ b/.github/workflows/ci-supply-chain.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 concurrency:
   group: ci-supply-chain-${{ github.ref }}
   cancel-in-progress: false
@@ -21,19 +25,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4  # TODO: pin to commit SHA
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: recursive
+          persist-credentials: false
       - uses: ./.github/actions/nonos-setup
         with:
-          tools: audit,deny
+          tools: audit,deny,cyclonedx
           module: supply-chain
       - name: nonos-verify supply-chain
         run: cargo run --release --manifest-path nonos-verify/Cargo.toml -- supply-chain
       - name: Upload supply-chain artifacts
         if: always()
-        uses: actions/upload-artifact@v4  # TODO: pin to commit SHA
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ci-reports-supply-chain
           path: ci-reports/
           retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/ci-trust-chain.yml
+++ b/.github/workflows/ci-trust-chain.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 concurrency:
   group: ci-trust-chain-${{ github.ref }}
   cancel-in-progress: false
@@ -21,9 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4  # TODO: pin to commit SHA
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: recursive
+          persist-credentials: false
       - uses: ./.github/actions/nonos-setup
         with:
           module: trust-chain
@@ -31,8 +36,9 @@ jobs:
         run: cargo run --release --manifest-path nonos-verify/Cargo.toml -- trust-chain
       - name: Upload trust-chain artifacts
         if: always()
-        uses: actions/upload-artifact@v4  # TODO: pin to commit SHA
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: ci-reports-trust-chain
           path: ci-reports/
           retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -29,11 +33,10 @@ jobs:
   adversarial:
     uses: ./.github/workflows/ci-adversarial.yml
 
-  # The heavy QEMU boot lane (cold-compiles the ZK proving toolchain, then boots
-  # each kernel under QEMU) runs on the nightly schedule, not per push. Every
-  # push is gated by the deterministic build, trust-chain, adversarial,
-  # and supply-chain proofs; the boot proof lands in nightly.yml.
+  evidence:
+    uses: ./.github/workflows/ci-evidence.yml
+
   attestation:
-    needs: [build, supply-chain, trust-chain, adversarial]
+    needs: [build, supply-chain, trust-chain, adversarial, evidence]
     if: always()
     uses: ./.github/workflows/ci-attestation.yml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 concurrency:
   group: nightly-${{ github.ref }}
   cancel-in-progress: false
@@ -29,11 +33,19 @@ jobs:
   supply-chain:
     uses: ./.github/workflows/ci-supply-chain.yml
 
+  evidence:
+    uses: ./.github/workflows/ci-evidence.yml
+
   runtime:
     needs: build
     uses: ./.github/workflows/ci-runtime.yml
 
+  reproducible:
+    uses: ./.github/workflows/ci-reproducible.yml
+
   attestation:
-    needs: [build, trust-chain, adversarial, supply-chain, runtime]
+    needs: [build, trust-chain, adversarial, supply-chain, evidence, runtime, reproducible]
     if: always()
     uses: ./.github/workflows/ci-attestation.yml
+    with:
+      required-modules: build,trust-chain,adversarial,supply-chain,evidence,runtime,reproducible

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: release
 
-# Release-candidate pipeline. Runs the deterministic, artifact-producing lanes
-# (build, trust-chain, supply-chain) and fuses one signed attestation for the
-# tag. Triggered by hand or on a version tag.
+# Release-candidate pipeline. Runs the blocking build, trust-chain,
+# supply-chain, evidence, runtime, reproducibility, and release-artifact lanes
+# before fusing one attestation for the tag.
 
 on:
   workflow_dispatch:
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
@@ -20,14 +24,43 @@ concurrency:
 jobs:
   build:
     uses: ./.github/workflows/ci-build.yml
+    with:
+      trust-mode: production
+    secrets: inherit
 
   trust-chain:
     uses: ./.github/workflows/ci-trust-chain.yml
 
+  adversarial:
+    uses: ./.github/workflows/ci-adversarial.yml
+
   supply-chain:
     uses: ./.github/workflows/ci-supply-chain.yml
 
+  evidence:
+    uses: ./.github/workflows/ci-evidence.yml
+
+  reproducible:
+    uses: ./.github/workflows/ci-reproducible.yml
+    with:
+      trust-mode: production
+    secrets: inherit
+
+  runtime:
+    needs: build
+    uses: ./.github/workflows/ci-runtime.yml
+    with:
+      trust-mode: production
+    secrets: inherit
+
+  release-artifacts:
+    needs: [build, trust-chain, adversarial, supply-chain, evidence]
+    uses: ./.github/workflows/ci-release-artifacts.yml
+    secrets: inherit
+
   attestation:
-    needs: [build, trust-chain, supply-chain]
+    needs: [build, trust-chain, adversarial, supply-chain, evidence, reproducible, runtime, release-artifacts]
     if: always()
     uses: ./.github/workflows/ci-attestation.yml
+    with:
+      required-modules: build,trust-chain,adversarial,supply-chain,evidence,reproducible,runtime,release

--- a/.github/workflows/submodule-sync.yml
+++ b/.github/workflows/submodule-sync.yml
@@ -2,9 +2,8 @@ name: submodule-sync
 
 # Keeps every mounted submodule (tests, nonos-ci, nonos-sign, nonos-mk,
 # nonos-utils, nonos-data, docs, wallpapers) at the latest commit of its default
-# branch, and lands the bump on main ONLY if the verification engine passes
-# against the bumped state. A breaking upstream change is caught here and never
-# reaches main. Runs daily and on demand.
+# branch, verifies the bumped state, and opens a reviewable PR branch. A
+# breaking upstream change is caught here and never reaches main automatically.
 
 on:
   schedule:
@@ -13,6 +12,11 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
+
+defaults:
+  run:
+    shell: bash
 
 concurrency:
   group: submodule-sync
@@ -24,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4  # TODO: pin to commit SHA
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           submodules: recursive
           fetch-depth: 0
@@ -57,29 +61,40 @@ jobs:
           targets: x86_64-nonos,x86_64-unknown-uefi
           module: submodule-sync
 
-      - name: Verify the bumped state, then land on main only if green
+      - name: Verify the bumped state
         if: steps.diff.outputs.changed == 'true'
         run: |
           set -euo pipefail
           bash nonos-ci/setup-signing-key.sh
           bash nonos-ci/scratch-trust-bootstrap.sh
-          # Any blocking module that fails exits non-zero and aborts before the
-          # push, so a bad bump never lands.
           cargo run --release --manifest-path nonos-verify/Cargo.toml -- trust-chain
-          cargo run --release --manifest-path nonos-verify/Cargo.toml -- tests
           cargo run --release --manifest-path nonos-verify/Cargo.toml -- build
           cargo run --release --manifest-path nonos-verify/Cargo.toml -- attest
 
+      - name: Open verified submodule bump PR
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          branch="automation/submodule-sync-${GITHUB_RUN_ID}"
           git config user.name "eKisNonos"
           git config user.email "ekisanon@proton.me"
-          git add -A
+          git checkout -B "${branch}"
+          git config -f .gitmodules --get-regexp '^submodule\..*\.path$' | awk '{print $2}' | xargs git add
           git commit -m "submodules: auto-bump to verified upstream heads"
-          git push origin HEAD:main
+          git push --set-upstream origin "${branch}"
+          gh pr create \
+            --title "submodules: verified upstream bump" \
+            --body "Automated submodule pointer update. The workflow verified trust-chain, build, and attestation before opening this PR." \
+            --base main \
+            --head "${branch}"
 
       - name: Upload verification reports
         if: always() && steps.diff.outputs.changed == 'true'
-        uses: actions/upload-artifact@v4  # TODO: pin to commit SHA
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: submodule-sync-${{ github.run_id }}
           path: ci-reports/
           retention-days: 14
+          if-no-files-found: error

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,13 @@
 .PHONY: nonos-mk-libc nonos-mk-proof-io nonos-mk-proof-io-sign nonos-mk-check-trust-keys nonos-mk-check-trust-manifest nonos-mk-trust-policy nonos-mk-host-trust-verify nonos-mk-verify-trust nonos-mk-ramfs nonos-mk-ramfs-sign nonos-mk-keyring nonos-mk-entropy nonos-mk-crypto nonos-mk-vfs nonos-mk-virtio-rng nonos-mk-virtio-rng-sign nonos-mk-check-virtio-rng-keys nonos-mk-virtio-blk nonos-mk-virtio-blk-sign nonos-mk-check-virtio-blk-keys nonos-mk-driver-virtio-gpu nonos-mk-driver-virtio-gpu-sign nonos-mk-check-driver-virtio-gpu-keys nonos-mk-virtio-net nonos-mk-virtio-net-sign nonos-mk-check-virtio-net-keys nonos-mk-driver-iwlwifi nonos-mk-driver-iwlwifi-sign nonos-mk-check-driver-iwlwifi-keys nonos-mk-driver-i2c-pci nonos-mk-driver-i2c-pci-sign nonos-mk-check-driver-i2c-pci-keys nonos-mk-driver-i2c-hid nonos-mk-driver-i2c-hid-sign nonos-mk-check-driver-i2c-hid-keys nonos-mk-ps2-input nonos-mk-ps2-input-sign nonos-mk-check-ps2-input-keys nonos-mk-xhci nonos-mk-xhci-sign nonos-mk-check-xhci-keys nonos-mk-driver-usb-msc nonos-mk-driver-usb-msc-sign nonos-mk-check-driver-usb-msc-keys nonos-mk-driver-e1000 nonos-mk-driver-e1000-sign nonos-mk-check-driver-e1000-keys nonos-mk-driver-rtl8139 nonos-mk-driver-rtl8139-sign nonos-mk-check-driver-rtl8139-keys nonos-mk-driver-rtl8169 nonos-mk-driver-rtl8169-sign nonos-mk-check-driver-rtl8169-keys nonos-mk-driver-ahci nonos-mk-driver-ahci-sign nonos-mk-check-driver-ahci-keys nonos-mk-driver-hda nonos-mk-driver-hda-sign nonos-mk-check-driver-hda-keys nonos-mk-driver-nvme nonos-mk-driver-nvme-sign nonos-mk-check-driver-nvme-keys nonos-mk-wallpaper nonos-mk-marketplace-abi nonos-mk-market nonos-mk-marketplace-index-tool
 .PHONY: nonos-mk-userland-clean
 .PHONY: nonos-mk-bootloader nonos-mk-sign nonos-mk-attest nonos-mk-esp
-.PHONY: nonos-mk-run nonos-mk-run-nat nonos-mk-run-net nonos-mk-run-serial nonos-mk-run-serial-nat nonos-mk-run-serial-net nonos-mk-run-serial-log nonos-mk-debug nonos-mk-plan-a-runtime
+.PHONY: nonos-mk-run nonos-mk-run-nat nonos-mk-run-net nonos-mk-run-serial nonos-mk-run-serial-nat nonos-mk-run-serial-net nonos-mk-run-serial-log nonos-mk-run-input-probe-inject-serial-log nonos-mk-debug nonos-mk-plan-a-runtime
 .PHONY: nonos-mk-static nonos-mk-scan
 .PHONY: nonos-mk-verify nonos-mk-verify-fast
 .PHONY: nonos-mk-release-audit nonos-mk-claims-check nonos-mk-qemu-net-audit
-.PHONY: ci-fast ci-security ci-release ci-soak nonos-mk-no-telemetry-capture nonos-mk-boot-evidence
+.PHONY: nonos-mk-bench nonos-mk-bench-host nonos-mk-bench-boot-log
+.PHONY: nonos-mk-bench-collect nonos-mk-bench-compare
+.PHONY: ci-fast ci-security ci-release ci-soak nonos-mk-no-telemetry-capture nonos-mk-boot-evidence nonos-mk-hardware-dossier nonos-mk-validate-machine-metadata
 .PHONY: nonos-mk-release
 .PHONY: nonos-mk-clean nonos-mk-clean-all nonos-mk-distclean
 .PHONY: nonos-mk-fmt
@@ -57,6 +59,20 @@ export PATH := $(HOME)/.cargo/bin:$(PATH)
 TOOLCHAIN := nightly-2026-01-16
 CARGO     := $(HOME)/.cargo/bin/cargo
 RUSTUP    := $(HOME)/.cargo/bin/rustup
+NONOS_PYTHON ?= /usr/bin/python3
+NONOS_BENCH_OUT ?=
+NONOS_BENCH_BUILD_CMD ?= make nonos-mk-verify-fast
+NONOS_BENCH_SKIP_BUILD ?= 0
+NONOS_BENCH_SKIP_BOOT ?= 0
+NONOS_BENCH_STRICT ?= 0
+NONOS_BENCH_BOOT_TIMEOUT ?= 360
+NONOS_BENCH_BOOT_CMD ?=
+NONOS_BENCH_HOST_OUT ?= target/bench/host
+NONOS_BENCH_BOOT_JSON ?= target/bench/boot-log.json
+NONOS_BENCH_SERIAL_LOG ?=
+NONOS_BENCH_BASELINE ?=
+NONOS_BENCH_CANDIDATE ?=
+NONOS_BENCH_REGRESSION_LIMIT ?= 15
 
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
@@ -622,7 +638,6 @@ include userland/capsule_net_udp/Capsule.mk
 include userland/capsule_net_dhcp/Capsule.mk
 include userland/capsule_net_tcp/Capsule.mk
 include userland/capsule_net_dns/Capsule.mk
-include userland/capsule_net_core/Capsule.mk
 include userland/capsule_net_sockets/Capsule.mk
 include userland/capsule_net_nym/Capsule.mk
 include userland/capsule_wallpaper/Capsule.mk
@@ -818,6 +833,7 @@ NONOS_INPUT_E2E_ARTIFACTS := $(proof-io_ARTIFACTS) $(ramfs_ARTIFACTS) \
 	$(toolkit_ARTIFACTS) $(power_ARTIFACTS) $(input-proof_ARTIFACTS)
 
 NONOS_BOOT_EFI := $(BOOTLOADER_DIR)/target/x86_64-unknown-uefi/release/nonos_boot.efi
+NONOS_INPUT_PROBE_INJECT_ESP := $(TARGET_DIR)/esp-input-probe-inject
 
 # Per-capsule production kernel builds. Each `-prod` target builds
 # the kernel under the `nonos-production` posture with proof_io and
@@ -1039,15 +1055,6 @@ nonos-mk-net-l2-prod: $(proof-io_ARTIFACTS) $(driver-virtio-net_ARTIFACTS) \
 		$(CARGO) build $(KERNEL_BUILD_FLAGS) \
 		--no-default-features --features microkernel-net-l2
 
-nonos-mk-net-core-prod: $(proof-io_ARTIFACTS) $(driver-virtio-net_ARTIFACTS) \
-		$(net-core_ARTIFACTS) \
-		nonos-mk-check-deps nonos-mk-ensure-signing-key
-	@echo "Building kernel (microkernel-net-core)..."
-	@$(SDK_FLAGS) NONOS_SIGNING_KEY=$(KERNEL_SIGNING_KEY) \
-		RUSTUP_TOOLCHAIN=$(TOOLCHAIN) \
-		$(CARGO) build $(KERNEL_BUILD_FLAGS) \
-		--no-default-features --features microkernel-net-core
-
 nonos-mk-net-ip-prod: $(proof-io_ARTIFACTS) $(driver-virtio-net_ARTIFACTS) \
 		$(net-l2_ARTIFACTS) $(net-ip_ARTIFACTS) \
 		nonos-mk-check-deps nonos-mk-ensure-signing-key
@@ -1191,6 +1198,26 @@ nonos-mk-setup-wizard-inject-prod: $(proof-io_ARTIFACTS) $(ramfs_ARTIFACTS) \
 		RUSTUP_TOOLCHAIN=$(TOOLCHAIN) \
 		$(CARGO) build $(KERNEL_BUILD_FLAGS) \
 		--no-default-features --features microkernel-setup-wizard,input-probe-inject
+
+nonos-mk-input-probe-inject-prod: $(proof-io_ARTIFACTS) \
+		$(driver-ps2-input_ARTIFACTS) $(driver-virtio-gpu_ARTIFACTS) \
+		$(input-router_ARTIFACTS) $(compositor_ARTIFACTS) \
+		$(input-probe_ARTIFACTS) \
+		nonos-mk-check-deps nonos-mk-ensure-signing-key
+	@echo "Building kernel (microkernel-input-probe + inject)..."
+	@$(SDK_FLAGS) NONOS_SIGNING_KEY=$(KERNEL_SIGNING_KEY) \
+		RUSTUP_TOOLCHAIN=$(TOOLCHAIN) \
+		$(CARGO) build $(KERNEL_BUILD_FLAGS) \
+		--no-default-features --features microkernel-input-probe,input-probe-inject
+
+nonos-mk-input-probe-inject-esp: $(NONOS_BOOT_EFI)
+	@$(MAKE) --no-print-directory nonos-mk-input-probe-inject-prod
+	@$(MAKE) --no-print-directory $(TARGET_DIR)/kernel_attested.bin
+	@mkdir -p $(NONOS_INPUT_PROBE_INJECT_ESP)/EFI/Boot $(NONOS_INPUT_PROBE_INJECT_ESP)/EFI/nonos
+	@cp $(NONOS_BOOT_EFI) $(NONOS_INPUT_PROBE_INJECT_ESP)/EFI/Boot/BOOTX64.EFI
+	@cp $(TARGET_DIR)/kernel_attested.bin $(NONOS_INPUT_PROBE_INJECT_ESP)/EFI/nonos/kernel.bin
+	@printf "timeout=0\ndefault=nonos\n" > $(NONOS_INPUT_PROBE_INJECT_ESP)/EFI/nonos/boot.cfg
+	@echo 'fs0:\EFI\Boot\BOOTX64.EFI' > $(NONOS_INPUT_PROBE_INJECT_ESP)/startup.nsh
 
 nonos-mk-toolkit-prod: nonos-mk-desktop-gui-prod
 nonos-mk-about-prod: nonos-mk-desktop-gui-prod
@@ -1382,6 +1409,17 @@ nonos-mk-run-serial-log: nonos-mk-desktop-gui-prod nonos-mk-esp
 		$(QEMU_BLK) $(QEMU_GPU) $(QEMU_NET) $(QEMU_USB) $(QEMU_RNG) \
 		-serial "file:$(QEMU_SERIAL_LOG)" -display none -no-reboot
 
+nonos-mk-run-input-probe-inject-serial-log: nonos-mk-input-probe-inject-esp $(QEMU_BLK_IMG) $(QEMU_OVMF_VARS_RW)
+	@mkdir -p $(dir $(QEMU_SERIAL_LOG))
+	@echo "Booting NONOS input-probe inject serial console in QEMU..."
+	@echo "  Network: $(QEMU_NET_DESC)"
+	@echo "  Serial log: $(QEMU_SERIAL_LOG)"
+	@$(QEMU) -m $(QEMU_MEM) -accel hvf -cpu host,+rdrand,+rdseed -smp 1 -machine q35 \
+		-drive "format=raw,file=fat:rw:$(NONOS_INPUT_PROBE_INJECT_ESP)" \
+		-drive if=pflash,format=raw,readonly=on,file="$(OVMF)" \
+		$(QEMU_BLK) $(QEMU_GPU) $(QEMU_NET) $(QEMU_USB) $(QEMU_RNG) \
+		-serial "file:$(QEMU_SERIAL_LOG)" -display none -no-reboot
+
 nonos-mk-debug: nonos-mk-desktop-gui-prod nonos-mk-esp
 	@echo "QEMU listening for GDB on :1234   (gdb -ex 'target remote :1234')"
 	@$(QEMU) -m $(QEMU_MEM) -cpu $(QEMU_CPU) -smp $(QEMU_SMP) -machine q35 \
@@ -1535,6 +1573,47 @@ nonos-mk-no-telemetry-capture:
 nonos-mk-boot-evidence:
 	@bash scripts/qemu_boot_evidence.sh
 
+nonos-mk-hardware-dossier:
+	@test -n "$(NONOS_HW_SERIAL_LOG)" || { echo "NONOS_HW_SERIAL_LOG is required"; exit 1; }
+	@NONOS_HW_OUT="$(NONOS_HW_OUT)" \
+		NONOS_HW_SERIAL_LOG="$(NONOS_HW_SERIAL_LOG)" \
+		NONOS_HW_MACHINE_JSON="$(NONOS_HW_MACHINE_JSON)" \
+		NONOS_HW_BOOT_MEDIA="$(NONOS_HW_BOOT_MEDIA)" \
+		NONOS_HW_ARTIFACTS="$(NONOS_HW_ARTIFACTS)" \
+		$(NONOS_PYTHON) scripts/bare_metal_evidence.py
+
+nonos-mk-validate-machine-metadata:
+	@test -n "$(NONOS_HW_MACHINE_JSON)" || { echo "NONOS_HW_MACHINE_JSON is required"; exit 1; }
+	@$(NONOS_PYTHON) scripts/validate_machine_metadata.py "$(NONOS_HW_MACHINE_JSON)"
+
+nonos-mk-bench:
+	@NONOS_BENCH_OUT="$(NONOS_BENCH_OUT)" \
+		NONOS_BENCH_BUILD_CMD="$(NONOS_BENCH_BUILD_CMD)" \
+		NONOS_BENCH_SKIP_BUILD="$(NONOS_BENCH_SKIP_BUILD)" \
+		NONOS_BENCH_SKIP_BOOT="$(NONOS_BENCH_SKIP_BOOT)" \
+		NONOS_BENCH_STRICT="$(NONOS_BENCH_STRICT)" \
+		NONOS_BENCH_BOOT_TIMEOUT="$(NONOS_BENCH_BOOT_TIMEOUT)" \
+		NONOS_BENCH_BOOT_CMD="$(NONOS_BENCH_BOOT_CMD)" \
+		$(NONOS_PYTHON) nonos-ci/bench_suite.py
+
+nonos-mk-bench-host:
+	@$(NONOS_PYTHON) nonos-ci/bench_host.py "$(NONOS_BENCH_HOST_OUT)"
+
+nonos-mk-bench-boot-log:
+	@test -n "$(NONOS_BENCH_SERIAL_LOG)" || { echo "NONOS_BENCH_SERIAL_LOG is required"; exit 1; }
+	@$(NONOS_PYTHON) nonos-ci/bench_boot_log.py "$(NONOS_BENCH_SERIAL_LOG)" \
+		"$(NONOS_BENCH_BOOT_JSON)"
+
+nonos-mk-bench-collect:
+	@test -n "$(NONOS_BENCH_OUT)" || { echo "NONOS_BENCH_OUT is required"; exit 1; }
+	@$(NONOS_PYTHON) nonos-ci/bench_collect.py "$(NONOS_BENCH_OUT)"
+
+nonos-mk-bench-compare:
+	@test -n "$(NONOS_BENCH_BASELINE)" || { echo "NONOS_BENCH_BASELINE is required"; exit 1; }
+	@test -n "$(NONOS_BENCH_CANDIDATE)" || { echo "NONOS_BENCH_CANDIDATE is required"; exit 1; }
+	@$(NONOS_PYTHON) nonos-ci/bench_compare.py "$(NONOS_BENCH_BASELINE)" \
+		"$(NONOS_BENCH_CANDIDATE)" "$(NONOS_BENCH_REGRESSION_LIMIT)"
+
 ci-soak:
 	@echo "ci-soak: run nonos-mk-boot-evidence, nonos-mk-no-telemetry-capture, scripts/zero_state_forensic_qemu.sh, and hardware dossier collection"
 
@@ -1620,6 +1699,11 @@ help:
 	@echo "  make nonos-mk-qemu-net-audit  QEMU default/no-NIC command audit"
 	@echo "  make nonos-mk-no-telemetry-capture bounded QEMU packet-capture harness"
 	@echo "  make nonos-mk-boot-evidence   bounded no-network QEMU serial boot evidence"
+	@echo "  make nonos-mk-bench           host/build/boot benchmark evidence"
+	@echo "  make nonos-mk-bench-host      host benchmark metadata only"
+	@echo "  make nonos-mk-bench-compare   compare benchmark runs for regressions"
+	@echo "  make nonos-mk-hardware-dossier parse physical serial log into dossier"
+	@echo "  make nonos-mk-validate-machine-metadata check hardware metadata JSON"
 	@echo "  make ci-fast                  host security tests + claims check"
 	@echo "  make ci-security              ci-fast + release-profile audit"
 	@echo

--- a/nonos-verify/src/attest.rs
+++ b/nonos-verify/src/attest.rs
@@ -14,6 +14,7 @@ pub fn run(root: &str) -> std::io::Result<Status> {
     let mut modules: Vec<serde_json::Value> = Vec::new();
     let mut gaps: Vec<serde_json::Value> = Vec::new();
     let mut blocking_fail = false;
+    let required = required_modules();
 
     if let Ok(rd) = std::fs::read_dir(root_path) {
         let mut dirs: Vec<_> =
@@ -51,10 +52,21 @@ pub fn run(root: &str) -> std::io::Result<Status> {
         }
     }
 
+    let present: std::collections::BTreeSet<String> = modules
+        .iter()
+        .filter_map(|m| m.get("module").and_then(|n| n.as_str()).map(str::to_string))
+        .collect();
+    let missing: Vec<String> = required.iter().filter(|m| !present.contains(*m)).cloned().collect();
+    if !missing.is_empty() {
+        blocking_fail = true;
+    }
+
     let attestation = serde_json::json!({
         "commit": meta.commit,
         "toolchain": meta.toolchain,
         "modules": modules,
+        "required_modules": required,
+        "missing_modules": missing,
         "gaps": gaps,
         "blocking_failure": blocking_fail,
     });
@@ -77,6 +89,9 @@ pub fn run(root: &str) -> std::io::Result<Status> {
             m["blocking"].as_bool().unwrap_or(true)
         );
     }
+    if !missing.is_empty() {
+        let _ = writeln!(md, "\nmissing required modules: `{}`", missing.join(","));
+    }
     let _ = writeln!(md, "\nknown gaps: {}", gaps.len());
     let _ = writeln!(md, "\nblocking failure: {blocking_fail}");
     std::fs::write(out.join("summary.md"), &md)?;
@@ -95,4 +110,14 @@ pub fn run(root: &str) -> std::io::Result<Status> {
         eprintln!("attest: no blocking failures ({} modules)", modules.len());
         Ok(Status::Pass)
     }
+}
+
+fn required_modules() -> Vec<String> {
+    std::env::var("NONOS_VERIFY_REQUIRED_MODULES")
+        .unwrap_or_else(|_| "build,supply-chain,trust-chain,adversarial,evidence".to_string())
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
 }

--- a/nonos-verify/src/evidence.rs
+++ b/nonos-verify/src/evidence.rs
@@ -1,0 +1,102 @@
+// Evidence gate: host-side benchmark and bare-metal dossier tooling, machine
+// metadata fail-closed checks, kernel source gate, and production bootloader
+// public-anchor build. GitHub Actions only calls this typed verifier.
+
+use crate::report::{Report, Status};
+use crate::sh::run_logged;
+use std::path::Path;
+use std::process::Command;
+
+pub fn run(root: &str) -> std::io::Result<Status> {
+    let mut rpt = Report::new("evidence", true);
+    let out = Path::new(root).join("evidence");
+    std::fs::create_dir_all(&out)?;
+    let scripts = [
+        "scripts/bare_metal_evidence.py",
+        "scripts/validate_machine_metadata.py",
+        "nonos-ci/bench_boot_log.py",
+        "nonos-ci/bench_collect.py",
+        "nonos-ci/bench_compare.py",
+        "nonos-ci/bench_host.py",
+        "nonos-ci/bench_suite.py",
+        "nonos-ci/bench_time.py",
+    ];
+    let mut args = vec!["-m", "py_compile"];
+    args.extend(scripts);
+    let ok = run_logged("python3", &args, &out.join("python-syntax.txt"));
+    rpt.check("python-syntax", st(ok), "benchmark and hardware evidence scripts compile");
+    std::fs::create_dir_all("target/hardware-dossier")?;
+    std::fs::write(
+        "target/hardware-dossier/incomplete.json",
+        r#"{"schema":"nonos.hardware.machine.v1","vendor":"fixture","model":"incomplete"}"#,
+    )?;
+    let bad = Command::new("make")
+        .env("NONOS_HW_MACHINE_JSON", "target/hardware-dossier/incomplete.json")
+        .arg("nonos-mk-validate-machine-metadata")
+        .output()?;
+    let mut bad_log = bad.stdout.clone();
+    bad_log.extend_from_slice(&bad.stderr);
+    std::fs::write(out.join("metadata-fail-closed.txt"), bad_log)?;
+    rpt.check(
+        "metadata-fail-closed",
+        if bad.status.success() { Status::Fail } else { Status::Pass },
+        "incomplete machine metadata is rejected",
+    );
+    std::fs::write(
+        "target/hardware-dossier/full.json",
+        r#"{"schema":"nonos.hardware.machine.v1","vendor":"fixture","model":"fixture","cpu":"fixture","firmware":"fixture","gpu":"fixture","display_path":"fixture","storage":"fixture","input":"fixture","iommu":"fixture","serial_capture":"fixture"}"#,
+    )?;
+    let good = Command::new("make")
+        .env("NONOS_HW_MACHINE_JSON", "target/hardware-dossier/full.json")
+        .arg("nonos-mk-validate-machine-metadata")
+        .output()?;
+    let mut good_log = good.stdout.clone();
+    good_log.extend_from_slice(&good.stderr);
+    std::fs::write(out.join("metadata-pass-fixture.txt"), good_log)?;
+    rpt.check("metadata-pass-fixture", st(good.status.success()), "complete metadata accepted");
+    let ok = run_logged("make", &["nonos-mk-check"], &out.join("kernel-source-check.txt"));
+    rpt.check("kernel-source-check", st(ok), "make nonos-mk-check");
+    std::fs::create_dir_all("target/ci")?;
+    std::fs::create_dir_all("target/ci/zk")?;
+    std::fs::write("target/ci/zk/device_labels.txt", "ci-evidence-device\n")?;
+    let pk = std::fs::read("nonos-data/trust/keys/nonos_trust_anchor_ed25519.pub")?;
+    let pk_ok = pk.len() == 43 && &pk[..8] == b"NONOSPK1" && pk[10] == 32;
+    if pk_ok {
+        std::fs::write("target/ci/trust-anchor.raw", &pk[11..43])?;
+    }
+    let ok = pk_ok
+        && Command::new("make")
+            .env("BOOTLOADER_POLICY", "production")
+            .env(
+                "NONOS_TRUST_ANCHOR_PUBKEY",
+                format!("{}/target/ci/trust-anchor.raw", std::env::current_dir()?.display()),
+            )
+            .env("ZK_BOOT_LABELS", "target/ci/zk/device_labels.txt")
+            .env("ZK_BOOT_ROOT", "target/ci/zk/device_root.bin")
+            .env("ZK_BOOT_COMMITMENTS", "target/ci/zk/device_commitments.bin")
+            .env("ZK_BOOT_SECRETS", "target/ci/zk/device_secrets.txt")
+            .env("ZK_BOOT_ENROLL_SEED", "nonos-ci-evidence-boot-enroll")
+            .arg("nonos-mk-bootloader")
+            .output()
+            .map(|o| {
+                let mut log = o.stdout.clone();
+                log.extend_from_slice(&o.stderr);
+                let _ = std::fs::write(out.join("production-bootloader.txt"), log);
+                o.status.success()
+            })
+            .unwrap_or(false);
+    rpt.check(
+        "production-bootloader-public-anchor",
+        st(ok),
+        "production bootloader builds from public trust anchor",
+    );
+    rpt.finish(root)
+}
+
+fn st(ok: bool) -> Status {
+    if ok {
+        Status::Pass
+    } else {
+        Status::Fail
+    }
+}

--- a/nonos-verify/src/main.rs
+++ b/nonos-verify/src/main.rs
@@ -6,7 +6,11 @@
 mod adversarial;
 mod attest;
 mod build;
+mod evidence;
+mod release;
 mod report;
+mod reproducible;
+mod runtime;
 mod sh;
 mod supply_chain;
 mod trust_chain;
@@ -20,18 +24,26 @@ fn main() {
 
     let result = match cmd {
         "build" => build::run(&root),
+        "evidence" => evidence::run(&root),
         "trust-chain" => trust_chain::run(&root),
         "adversarial" => adversarial::run(&root),
+        "reproducible" => reproducible::run(&root),
+        "release" => release::run(&root),
+        "runtime" => runtime::run(&root),
         "supply-chain" => supply_chain::run(&root),
         "attest" => attest::run(&root),
         "" | "-h" | "--help" | "help" => {
             eprintln!("nonos-verify: NONOS verification engine\n");
             eprintln!("usage: nonos-verify <subcommand>\n");
             eprintln!("  build          compile profile, section sizes, binary symbol scan");
+            eprintln!("  evidence       benchmark/evidence tooling and production bootloader gate");
             eprintln!("  trust-chain    decode + verify every capsule against the baked anchor");
             eprintln!(
                 "  adversarial    tamper valid artifacts and assert the verifier rejects them"
             );
+            eprintln!("  runtime        bounded QEMU boot proof and serial marker assertions");
+            eprintln!("  reproducible   clean worktree double-build hash comparison");
+            eprintln!("  release        release bundle manifest, checksums, provenance");
             eprintln!("  supply-chain   advisories, license policy, submodule pins, SBOM");
             eprintln!("  attest         fuse all module reports into one signed attestation");
             std::process::exit(if cmd.is_empty() { 2 } else { 0 });

--- a/nonos-verify/src/release.rs
+++ b/nonos-verify/src/release.rs
@@ -1,0 +1,145 @@
+use crate::report::{Report, Status};
+use crate::sh::capture;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub fn run(root: &str) -> std::io::Result<Status> {
+    let mut rpt = Report::new("release", true);
+    let out = Path::new(root).join("release");
+    let bundle = out.join("bundle");
+    std::fs::create_dir_all(&bundle)?;
+    let built = Command::new("make").arg("nonos-mk-esp").output()?;
+    std::fs::write(out.join("release-build.log"), join(&built.stdout, &built.stderr))?;
+    rpt.check("release-build", st(built.status.success()), "make nonos-mk-esp");
+
+    let manifest = collect(&bundle)?;
+    std::fs::write(
+        out.join("release-manifest.json"),
+        serde_json::to_string_pretty(&manifest).unwrap(),
+    )?;
+    std::fs::write(out.join("SHA256SUMS"), sums(&manifest, "sha256"))?;
+    std::fs::write(out.join("BLAKE3SUMS"), sums(&manifest, "blake3"))?;
+    let provenance = provenance(&manifest);
+    std::fs::write(
+        out.join("provenance.json"),
+        serde_json::to_string_pretty(&provenance).unwrap(),
+    )?;
+    let packed = Command::new("tar")
+        .arg("-czf")
+        .arg(out.join("nonos-release-bundle.tar.gz"))
+        .arg("-C")
+        .arg(&out)
+        .arg("bundle")
+        .output()?;
+    std::fs::write(out.join("tar.log"), join(&packed.stdout, &packed.stderr))?;
+    rpt.check("bundle-tar", st(packed.status.success()), "release bundle archive written");
+    let complete = !manifest.is_empty() && manifest.iter().all(|m| m["status"] == "present");
+    rpt.check(
+        "artifact-manifest",
+        st(complete),
+        "release manifest contains every required artifact",
+    );
+    rpt.finish(root)
+}
+
+fn collect(bundle: &Path) -> std::io::Result<Vec<serde_json::Value>> {
+    let mut rows = Vec::new();
+    for rel in artifacts() {
+        let src = Path::new(&rel);
+        if !src.exists() {
+            rows.push(row(&rel, "missing", 0, "", ""));
+            continue;
+        }
+        let dst = bundle.join(safe_name(&rel));
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(src, &dst)?;
+        let bytes = std::fs::read(src)?;
+        rows.push(row(
+            &rel,
+            "present",
+            bytes.len() as u64,
+            &sha256(src),
+            &blake3::hash(&bytes).to_hex().to_string(),
+        ));
+    }
+    Ok(rows)
+}
+
+fn artifacts() -> Vec<String> {
+    [
+        "target/x86_64-nonos/release/nonos-kernel",
+        "target/kernel_signed.bin",
+        "target/kernel_attested.bin",
+        "nonos-bootloader/target/x86_64-unknown-uefi/release/nonos_boot.efi",
+        "target/esp/EFI/Boot/BOOTX64.EFI",
+        "target/esp/EFI/nonos/kernel.bin",
+        "target/esp/EFI/nonos/boot.cfg",
+        "target/esp/startup.nsh",
+        "nonos-data/trust/MANIFEST.sha256",
+        "nonos-data/trust/policy/nonos_trust_anchor.policy.bin",
+        "nonos-data/trust/policy/zk_capsule_policy_root.bin",
+        "nonos-data/trust/zk/device_root.bin",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
+fn row(path: &str, status: &str, bytes: u64, sha256: &str, b3: &str) -> serde_json::Value {
+    serde_json::json!({ "path": path, "status": status, "bytes": bytes, "sha256": sha256, "blake3": b3 })
+}
+
+fn safe_name(rel: &str) -> PathBuf {
+    rel.split('/').collect()
+}
+
+fn sha256(path: &Path) -> String {
+    capture("shasum", &["-a", "256", path.to_str().unwrap_or("")])
+        .1
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_string()
+}
+
+fn sums(rows: &[serde_json::Value], field: &str) -> String {
+    let mut out = String::new();
+    for row in rows {
+        if row["status"] == "present" {
+            out.push_str(row[field].as_str().unwrap_or(""));
+            out.push_str("  ");
+            out.push_str(row["path"].as_str().unwrap_or(""));
+            out.push('\n');
+        }
+    }
+    out
+}
+
+fn provenance(artifacts: &[serde_json::Value]) -> serde_json::Value {
+    serde_json::json!({
+        "schema": "nonos.release.provenance.v1",
+        "commit": capture("git", &["rev-parse", "HEAD"]).1.trim(),
+        "ref": std::env::var("GITHUB_REF").unwrap_or_else(|_| "local".to_string()),
+        "run_id": std::env::var("GITHUB_RUN_ID").unwrap_or_else(|_| "local".to_string()),
+        "source_date_epoch": std::env::var("SOURCE_DATE_EPOCH").unwrap_or_else(|_| "unset".to_string()),
+        "toolchain": std::fs::read_to_string("rust-toolchain.toml").unwrap_or_default(),
+        "artifacts": artifacts,
+    })
+}
+
+fn join(stdout: &[u8], stderr: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(stdout.len() + stderr.len());
+    buf.extend_from_slice(stdout);
+    buf.extend_from_slice(stderr);
+    buf
+}
+
+fn st(ok: bool) -> Status {
+    if ok {
+        Status::Pass
+    } else {
+        Status::Fail
+    }
+}

--- a/nonos-verify/src/reproducible.rs
+++ b/nonos-verify/src/reproducible.rs
@@ -1,0 +1,126 @@
+use crate::report::{Report, Status};
+use crate::sh::capture;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub fn run(root: &str) -> std::io::Result<Status> {
+    let mut rpt = Report::new("reproducible", true);
+    let out = Path::new(root).join("reproducible");
+    let work = Path::new("target").join("repro-worktrees");
+    let target = std::env::var("NONOS_REPRO_TARGET").unwrap_or_else(|_| "nonos-mk-esp".to_string());
+    std::fs::create_dir_all(&out)?;
+    std::fs::create_dir_all(&work)?;
+    let clean =
+        clean_tree() || std::env::var("NONOS_REPRO_ALLOW_DIRTY").ok().as_deref() == Some("1");
+    rpt.check("clean-tree", st(clean), "git tree clean or explicitly allowed");
+    if !clean {
+        return rpt.finish(root);
+    }
+
+    let commit = capture("git", &["rev-parse", "HEAD"]).1.trim().to_string();
+    let epoch = std::env::var("SOURCE_DATE_EPOCH")
+        .unwrap_or_else(|_| capture("git", &["log", "-1", "--format=%ct"]).1.trim().to_string());
+    let artifacts = artifacts();
+    let a = build_lane("A", &work, &out, &commit, &epoch, &target, &artifacts)?;
+    let b = build_lane("B", &work, &out, &commit, &epoch, &target, &artifacts)?;
+    let same = a == b && !a.iter().any(|(_, h)| h == "MISSING");
+    std::fs::write(out.join("hashes-A.json"), serde_json::to_string_pretty(&a).unwrap())?;
+    std::fs::write(out.join("hashes-B.json"), serde_json::to_string_pretty(&b).unwrap())?;
+    rpt.check(
+        "double-build-hashes",
+        st(same),
+        "two clean worktree builds have identical artifact hashes",
+    );
+    rpt.finish(root)
+}
+
+fn clean_tree() -> bool {
+    capture("git", &["status", "--porcelain"]).1.trim().is_empty()
+}
+
+fn artifacts() -> Vec<String> {
+    std::env::var("NONOS_REPRO_ARTIFACTS")
+        .unwrap_or_else(|_| {
+            "target/x86_64-nonos/release/nonos-kernel target/kernel_signed.bin target/kernel_attested.bin nonos-bootloader/target/x86_64-unknown-uefi/release/nonos_boot.efi target/esp/EFI/Boot/BOOTX64.EFI target/esp/EFI/nonos/kernel.bin".to_string()
+        })
+        .split_whitespace()
+        .map(str::to_string)
+        .collect()
+}
+
+fn build_lane(
+    lane: &str,
+    work_root: &Path,
+    out: &Path,
+    commit: &str,
+    epoch: &str,
+    target: &str,
+    artifacts: &[String],
+) -> std::io::Result<Vec<(String, String)>> {
+    let dir = work_root.join(format!("lane-{lane}"));
+    let _ = Command::new("git").args(["worktree", "remove", "--force"]).arg(&dir).output();
+    let add =
+        Command::new("git").args(["worktree", "add", "--detach"]).arg(&dir).arg(commit).output()?;
+    std::fs::write(out.join(format!("worktree-{lane}.log")), join(&add.stdout, &add.stderr))?;
+    if !add.status.success() {
+        return Ok(missing_hashes(artifacts));
+    }
+    let mut cmd = Command::new("make");
+    cmd.current_dir(&dir).arg(target).env("SOURCE_DATE_EPOCH", epoch).env("CARGO_INCREMENTAL", "0");
+    if let Some(signing) = signing_key()? {
+        cmd.env("SIGNING_KEY", signing);
+    }
+    for key in
+        ["NONOS_DEV", "ZK_BOOT_INDEX", "ZK_BOOT_SECRET_X", "ZK_BOOT_SECRET_R", "ZK_BOOT_NONCE_SEED"]
+    {
+        if let Ok(value) = std::env::var(key) {
+            cmd.env(key, value);
+        }
+    }
+    let run = cmd.output()?;
+    std::fs::write(out.join(format!("build-{lane}.log")), join(&run.stdout, &run.stderr))?;
+    let hashes = hash_artifacts(&dir, artifacts)?;
+    let _ = Command::new("git").args(["worktree", "remove", "--force"]).arg(&dir).output();
+    Ok(hashes)
+}
+
+fn signing_key() -> std::io::Result<Option<PathBuf>> {
+    if let Ok(path) = std::env::var("SIGNING_KEY") {
+        return Ok(Some(PathBuf::from(path)));
+    }
+    let path = std::env::current_dir()?.join(".keys/signing_key_v1.bin");
+    Ok(path.exists().then_some(path))
+}
+
+fn hash_artifacts(root: &Path, artifacts: &[String]) -> std::io::Result<Vec<(String, String)>> {
+    let mut out = Vec::new();
+    for rel in artifacts {
+        let path = root.join(rel);
+        let hash = if path.exists() {
+            blake3::hash(&std::fs::read(path)?).to_hex().to_string()
+        } else {
+            "MISSING".to_string()
+        };
+        out.push((rel.clone(), hash));
+    }
+    Ok(out)
+}
+
+fn missing_hashes(artifacts: &[String]) -> Vec<(String, String)> {
+    artifacts.iter().map(|a| (a.clone(), "MISSING".to_string())).collect()
+}
+
+fn join(stdout: &[u8], stderr: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(stdout.len() + stderr.len());
+    buf.extend_from_slice(stdout);
+    buf.extend_from_slice(stderr);
+    buf
+}
+
+fn st(ok: bool) -> Status {
+    if ok {
+        Status::Pass
+    } else {
+        Status::Fail
+    }
+}

--- a/nonos-verify/src/runtime.rs
+++ b/nonos-verify/src/runtime.rs
@@ -1,0 +1,73 @@
+// runtime: bounded QEMU boot proof. The verifier runs the existing Plan-A
+// harness, keeps the serial/result logs as artifacts, and turns boot markers
+// into a typed CI decision.
+
+use crate::report::{Report, Status};
+use std::path::Path;
+use std::process::Command;
+
+pub fn run(root: &str) -> std::io::Result<Status> {
+    let mut rpt = Report::new("runtime", true);
+    let out = Path::new(root).join("runtime");
+    std::fs::create_dir_all(&out)?;
+
+    let serial = out.join("qemu-serial.log");
+    let result = out.join("plan-a-result.log");
+    let output = Command::new("make")
+        .arg("nonos-mk-plan-a-runtime")
+        .env("PLAN_A_SERIAL", &serial)
+        .env("PLAN_A_RESULT", &result)
+        .output();
+
+    let mut boot_ok = false;
+    match output {
+        Ok(o) => {
+            let mut buf = Vec::with_capacity(o.stdout.len() + o.stderr.len());
+            buf.extend_from_slice(&o.stdout);
+            buf.extend_from_slice(&o.stderr);
+            std::fs::write(out.join("runtime-run.log"), &buf)?;
+            boot_ok = o.status.success();
+        }
+        Err(e) => {
+            std::fs::write(out.join("runtime-run.log"), format!("failed to spawn make: {e}\n"))?;
+        }
+    }
+    rpt.check("plan-a-harness", st(boot_ok), "make nonos-mk-plan-a-runtime");
+
+    let serial_text = std::fs::read_to_string(&serial).unwrap_or_default();
+    let result_text = std::fs::read_to_string(&result).unwrap_or_default();
+    let joined = format!("{serial_text}\n{result_text}");
+
+    let no_fatal = !joined.contains("[FATAL]")
+        && !joined.contains("[PANIC]")
+        && !joined.contains("KERNEL PANIC")
+        && !joined.contains("Hardware requirements not met");
+    rpt.check("no-fatal-marker", st(no_fatal), "serial log has no fatal/panic marker");
+
+    let no_zk_fail = !joined.contains("[ZK-ATTEST] FAIL")
+        && !joined.contains("ZK proof missing")
+        && !joined.contains("attestation failed");
+    rpt.check("zk-attestation-not-failed", st(no_zk_fail), "serial log has no ZK rejection marker");
+
+    let handoff = joined.contains("[NONOS] Handoff OK") || joined.contains("Handoff OK");
+    rpt.check("boot-handoff", st(handoff), "boot handoff marker observed");
+
+    let capsules =
+        joined.contains("[INIT] Capsules spawned") || joined.contains("Capsules spawned");
+    rpt.check("capsules-spawned", st(capsules), "capsule spawn readiness marker observed");
+
+    let desktop = joined.contains("[desktop_shell]")
+        || joined.contains("[wm] boot")
+        || joined.contains("[compositor]");
+    rpt.check("desktop-substrate", st(desktop), "desktop/compositor marker observed");
+
+    rpt.finish(root)
+}
+
+fn st(ok: bool) -> Status {
+    if ok {
+        Status::Pass
+    } else {
+        Status::Fail
+    }
+}

--- a/nonos-verify/src/supply_chain.rs
+++ b/nonos-verify/src/supply_chain.rs
@@ -72,8 +72,7 @@ pub fn run(root: &str) -> std::io::Result<Status> {
         let ok = run_logged("cargo", &["cyclonedx", "--format", "json"], &out.join("sbom.log"));
         rpt.check("sbom", st(ok), "CycloneDX SBOM");
     } else {
-        rpt.check("sbom", Status::Gap, "cargo-cyclonedx not installed");
-        rpt.gap("SBOM generation", "add cargo-cyclonedx (or cargo-sbom) to nonos-setup tools");
+        rpt.check("sbom", Status::Fail, "cargo-cyclonedx not installed");
     }
 
     // reproducibility: the double-build hash compare runs in the nightly lane.

--- a/scripts/bare_metal_evidence.py
+++ b/scripts/bare_metal_evidence.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# NONOS Operating System
+# Copyright (C) 2026 NONOS Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+import hashlib, json, os, shutil, subprocess, sys, time
+out = os.environ.get("NONOS_HW_OUT") or "target/hardware-dossier/manual"
+serial = os.environ.get("NONOS_HW_SERIAL_LOG") or ""
+machine = os.environ.get("NONOS_HW_MACHINE_JSON") or ""
+boot_media = os.environ.get("NONOS_HW_BOOT_MEDIA") or ""
+extras = [x for x in os.environ.get("NONOS_HW_ARTIFACTS", "").split(":") if x]
+required = ("vendor", "model", "cpu", "firmware", "gpu", "display_path", "storage", "input", "iommu", "serial_capture")
+os.makedirs(out, exist_ok=True)
+report = {"schema": "nonos.hardware.dossier.v1", "created_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), "status": "gap", "artifacts": []}
+if not serial or not os.path.exists(serial) or os.path.getsize(serial) == 0:
+    report["reason"] = "NONOS_HW_SERIAL_LOG missing or empty"
+    with open(os.path.join(out, "dossier.json"), "w", encoding="utf-8") as dst:
+        json.dump(report, dst, indent=2, sort_keys=True)
+        dst.write("\n")
+    raise SystemExit(2)
+serial_dst = os.path.join(out, "serial.log"); shutil.copy2(serial, serial_dst)
+boot_json = os.path.join(out, "boot-log.json"); rc = subprocess.call([sys.executable, "nonos-ci/bench_boot_log.py", serial_dst, boot_json])
+machine_ok = False
+boot_media_ok = boot_media and os.path.exists(boot_media) and os.path.getsize(boot_media) > 0
+if machine and os.path.exists(machine):
+    shutil.copy2(machine, os.path.join(out, "machine.json"))
+    with open(machine, encoding="utf-8") as src: report["machine"] = json.load(src)
+    report["machine_missing"] = [k for k in required if not str(report["machine"].get(k, "")).strip()]
+    machine_ok = report["machine"].get("schema") == "nonos.hardware.machine.v1" and not report["machine_missing"]
+if boot_media_ok: shutil.copy2(boot_media, os.path.join(out, "boot-media.bin"))
+for item in extras:
+    if os.path.exists(item): shutil.copy2(item, os.path.join(out, os.path.basename(item)))
+if os.path.exists(boot_json):
+    with open(boot_json, encoding="utf-8") as src:
+        boot = json.load(src)
+    report["boot_status"] = boot.get("status", "gap")
+    report["markers"] = boot.get("markers", {})
+    report["phase_ms"] = boot.get("phase_ms", {})
+    report["latency_status"] = boot.get("latency_status", "gap")
+    if boot.get("status") == "pass" and machine_ok and boot_media_ok and not report["markers"].get("zk_attest_fail") and report["phase_ms"]:
+        report["status"] = "pass"
+    elif boot.get("status") == "pass":
+        report["reason"] = "machine metadata incomplete, boot media missing, attestation failed, or phases missing"
+    else:
+        report["reason"] = boot.get("reason", "boot evidence did not pass")
+else:
+    report["reason"] = "boot parser did not produce boot-log.json"
+for root, _, files in os.walk(out):
+    for name in sorted(files):
+        path = os.path.join(root, name)
+        rel = os.path.relpath(path, out)
+        if rel in ("dossier.json", "manifest.json"): continue
+        with open(path, "rb") as src:
+            digest = hashlib.sha256(src.read()).hexdigest()
+        report["artifacts"].append({"path": rel, "sha256": digest, "bytes": os.path.getsize(path)})
+with open(os.path.join(out, "dossier.json"), "w", encoding="utf-8") as dst:
+    json.dump(report, dst, indent=2, sort_keys=True)
+    dst.write("\n")
+with open(os.path.join(out, "manifest.json"), "w", encoding="utf-8") as dst:
+    json.dump({"schema": "nonos.hardware.manifest.v1", "artifacts": report["artifacts"]}, dst, indent=2, sort_keys=True)
+    dst.write("\n")
+print(os.path.join(out, "dossier.json"))
+raise SystemExit(0 if report["status"] == "pass" and rc == 0 else 2)

--- a/scripts/validate_machine_metadata.py
+++ b/scripts/validate_machine_metadata.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# NONOS Operating System
+# Copyright (C) 2026 NONOS Contributors
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+import json, sys
+required = ("vendor", "model", "cpu", "firmware", "gpu", "display_path", "storage", "input", "iommu", "serial_capture")
+if len(sys.argv) != 2:
+    raise SystemExit("usage: validate_machine_metadata.py <machine.json>")
+with open(sys.argv[1], encoding="utf-8") as src:
+    data = json.load(src)
+missing = [k for k in required if not str(data.get(k, "")).strip()]
+if data.get("schema") != "nonos.hardware.machine.v1":
+    missing.insert(0, "schema=nonos.hardware.machine.v1")
+if missing:
+    print("machine metadata gap: " + ", ".join(missing))
+    raise SystemExit(2)
+print("machine metadata ok")

--- a/src/boot/main/core_init.rs
+++ b/src/boot/main/core_init.rs
@@ -23,6 +23,7 @@ pub fn init_core_systems() {
     serial::println(b"[NONOS] Kernel entry - SSE enabled");
     crate::arch::x86_64::time::timer::init_boot_time();
     crate::sys::timer::tsc::init_default();
+    crate::sys::bench::mark(b"kernel_entry");
     if crate::arch::x86_64::gdt::init().is_err() {
         serial::println(b"[FATAL] arch GDT init failed");
         crate::arch::halt_loop();
@@ -43,6 +44,7 @@ pub fn init_core_systems() {
     serial::println(b"[NONOS] Global allocator initialized");
     interrupts::init_idt();
     serial::println(b"[NONOS] Full IDT loaded");
+    crate::sys::bench::mark(b"kernel_idt_ready");
     init_acpi_tables();
     apic::init();
     serial::println(b"[NONOS] APIC initialized");
@@ -51,6 +53,7 @@ pub fn init_core_systems() {
         crate::arch::halt_loop();
     }
     serial::println(b"[NONOS] Preemption timer armed");
+    crate::sys::bench::mark(b"kernel_timer_ready");
     // PS/2 input + IRQ wiring belongs to the legacy tree. The
     // microkernel boot path does not bring up keyboard/mouse rings;
     // input is owned by future capsule migration (input capsule).
@@ -61,10 +64,12 @@ pub fn init_core_systems() {
     super::init_memory_encryption();
     bus::pci::init();
     serial::println(b"[NONOS] PCI enumerated");
+    crate::sys::bench::mark(b"kernel_pci_ready");
     seed_hardware_broker();
     init_entropy();
     init_boot_session_nonce();
     super::init_token_signing_key();
+    crate::sys::bench::mark(b"kernel_core_ready");
 }
 
 fn init_acpi_tables() {

--- a/src/interrupts/timer/tick.rs
+++ b/src/interrupts/timer/tick.rs
@@ -20,6 +20,8 @@ use super::state;
 pub fn on_timer_interrupt() {
     state::increment_ticks();
     crate::sched::tick();
+    #[cfg(feature = "input-probe-inject")]
+    crate::kernel_core::surface_registry::inject::on_tick();
     // The legacy in-kernel network stack runs its retransmit/timeout
     // wheel from the timer tick. The microkernel has no in-kernel
     // sockets; capsule-side networking, when present, drives its own

--- a/src/kernel_core/init/entry.rs
+++ b/src/kernel_core/init/entry.rs
@@ -22,6 +22,7 @@ use crate::sys::{boot_log, clock};
 use core::sync::atomic::Ordering;
 
 pub fn microkernel_init(handoff: &KernelHandoff) {
+    crate::sys::bench::mark(b"microkernel_init_start");
     init_arch_memory_and_framebuffer(handoff);
     let cursor_y = handoff.framebuffer.map(|fb| fb.cursor_y).unwrap_or(0);
     boot_log::init_after_fb(cursor_y);
@@ -48,6 +49,7 @@ pub fn microkernel_init(handoff: &KernelHandoff) {
     if let Err(e) = crate::memory::unified::init_unified_vm() {
         fatal("memory: init_unified_vm failed", e);
     }
+    crate::sys::bench::mark(b"vm_ready");
     // The framebuffer is MMIO-mapped only now: mapping it needs the paging
     // manager, which init_unified_vm brings up. Doing it in the early
     // memory/framebuffer step failed to map on real GOP framebuffers
@@ -60,10 +62,12 @@ pub fn microkernel_init(handoff: &KernelHandoff) {
     crate::process::init_process_management();
     crate::elf::loader::init_elf_loader();
     crate::crypto::kernel_keys::init();
+    crate::sys::bench::mark(b"process_runtime_ready");
 
     super::start_secondary::start_secondary_cpus();
 
     boot_log::ok("NONOS", "Core ready");
+    crate::sys::bench::mark(b"microkernel_core_ready");
 }
 
 fn fatal(stage: &str, detail: &str) -> ! {
@@ -106,6 +110,7 @@ fn init_arch_firmware(handoff: &KernelHandoff) {
 }
 
 pub fn microkernel_main() -> ! {
+    crate::sys::bench::mark(b"microkernel_main_start");
     boot_log::ok("NONOS", "boot log held; starting userspace");
     let start = clock::uptime_ms();
     let mut guard: u64 = 0;
@@ -126,6 +131,7 @@ pub fn microkernel_main() -> ! {
             crate::arch::halt_loop()
         }
     };
+    crate::sys::bench::mark(b"init_process_created");
     if let Err(_) = create_address_space(init_pid) {
         boot_log::error("Failed to create init address space");
         crate::sys::serial::println(b"[FATAL] Init address space creation failed");
@@ -138,5 +144,6 @@ pub fn microkernel_main() -> ! {
     }
     CURRENT_PID.store(init_pid, Ordering::SeqCst);
     boot_log::ok("UKERNEL", "Entering userspace");
+    crate::sys::bench::mark(b"init_enter_userspace");
     crate::userspace::run_init()
 }

--- a/src/kernel_core/process_spawn/capsule_spawn/runner/attest_gate.rs
+++ b/src/kernel_core/process_spawn/capsule_spawn/runner/attest_gate.rs
@@ -20,6 +20,7 @@ use crate::security::capsule_attest::verify_capsule_attestation;
 pub(crate) fn attest_gate(spec: &CapsuleSpecVerified, install_caps: u64) -> Result<(), SpawnError> {
     let trailer = spec.attestation_trailer;
     if trailer.is_empty() {
+        crate::sys::bench::mark_named(b"capsule_attest_none", spec.name.as_bytes());
         crate::sys::serial::print(b"[ZK-ATTEST] none ");
         crate::sys::serial::print(spec.name.as_bytes());
         crate::sys::serial::print(b"\n");
@@ -30,12 +31,14 @@ pub(crate) fn attest_gate(spec: &CapsuleSpecVerified, install_caps: u64) -> Resu
     }
     match verify_capsule_attestation(trailer, spec.elf, install_caps) {
         Ok(()) => {
+            crate::sys::bench::mark_named(b"capsule_attest_ok", spec.name.as_bytes());
             crate::sys::serial::print(b"[ZK-ATTEST] ok ");
             crate::sys::serial::print(spec.name.as_bytes());
             crate::sys::serial::print(b"\n");
             Ok(())
         }
         Err(e) => {
+            crate::sys::bench::mark_named(b"capsule_attest_fail", spec.name.as_bytes());
             crate::sys::serial::print(b"[ZK-ATTEST] FAIL ");
             crate::sys::serial::print(spec.name.as_bytes());
             crate::sys::serial::print(b": ");

--- a/src/kernel_core/process_spawn/capsule_spawn/runner/install/install.rs
+++ b/src/kernel_core/process_spawn/capsule_spawn/runner/install/install.rs
@@ -51,6 +51,7 @@ pub(crate) fn run(params: &InstallParams) -> Result<u32, SpawnError> {
         .map_err(|_| SpawnError::EndpointCollision)?;
     super::spawn_log::emit(params.name, pid, caps, entry);
     crate::sched::add_to_run_queue(pid);
+    crate::sys::bench::mark_named(b"capsule_runqueue_ok", params.name.as_bytes());
     super::trace::trace(params.name, b"runqueue ok");
     Ok(pid)
 }

--- a/src/kernel_core/process_spawn/capsule_spawn/runner/verified.rs
+++ b/src/kernel_core/process_spawn/capsule_spawn/runner/verified.rs
@@ -28,7 +28,9 @@ pub fn spawn_verified(
     trust_anchor: &NonosTrustAnchorPolicy,
     now_ms: Option<u64>,
 ) -> Result<u32, SpawnError> {
+    crate::sys::bench::mark_named(b"capsule_spawn_start", spec.name.as_bytes());
     let preflighted = preflight::run(spec, trust_anchor, now_ms)?;
+    crate::sys::bench::mark_named(b"capsule_preflight_ok", spec.name.as_bytes());
     install(&InstallParams {
         name: spec.name,
         service_port: spec.service_port,

--- a/src/kernel_core/surface_registry/input_ring.rs
+++ b/src/kernel_core/surface_registry/input_ring.rs
@@ -14,9 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#[cfg(feature = "input-probe-inject")]
-use core::sync::atomic::AtomicBool;
-use core::sync::atomic::{AtomicU64, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use spin::Mutex;
 
 use super::types::{InputEvent, RegistryError, INPUT_RING_CAP};
@@ -50,6 +48,7 @@ static RING: Mutex<Ring> = Mutex::new(Ring {
 static DROPPED: AtomicU64 = AtomicU64::new(0);
 static SEQ: AtomicU64 = AtomicU64::new(0);
 static WAITER: AtomicU64 = AtomicU64::new(0);
+static FIRST_INPUT_POST: AtomicBool = AtomicBool::new(false);
 #[cfg(feature = "input-probe-inject")]
 static INPUT_CONSUMER_READY: AtomicBool = AtomicBool::new(false);
 
@@ -66,6 +65,7 @@ pub fn post_input(ev: InputEvent) -> Result<(), RegistryError> {
         ring.head = next;
     }
     SEQ.fetch_add(1, Ordering::Release);
+    crate::sys::bench::mark_once(&FIRST_INPUT_POST, b"input_post_first");
     let waiter = WAITER.swap(0, Ordering::AcqRel);
     if waiter != 0 {
         crate::sched::wake_process(waiter as u32);

--- a/src/sys/bench/mark.rs
+++ b/src/sys/bench/mark.rs
@@ -14,12 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DecodeError {
-    Short,
-    TooLarge,
-    TooManyItems,
-    BadUtf8,
-    UnsupportedSchema,
-    BlobTooLarge,
+pub fn mark(event: &[u8]) {
+    crate::sys::serial::print(b"[BENCH] ");
+    crate::sys::serial::print_dec(crate::sys::timer::uptime_ms());
+    crate::sys::serial::print(b" ");
+    crate::sys::serial::println(event);
 }

--- a/src/sys/bench/mark_named.rs
+++ b/src/sys/bench/mark_named.rs
@@ -14,12 +14,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DecodeError {
-    Short,
-    TooLarge,
-    TooManyItems,
-    BadUtf8,
-    UnsupportedSchema,
-    BlobTooLarge,
+pub fn mark_named(event: &[u8], name: &[u8]) {
+    crate::sys::serial::print(b"[BENCH] ");
+    crate::sys::serial::print_dec(crate::sys::timer::uptime_ms());
+    crate::sys::serial::print(b" ");
+    crate::sys::serial::print(event);
+    crate::sys::serial::print(b":");
+    crate::sys::serial::println(name);
 }

--- a/src/sys/bench/mark_once.rs
+++ b/src/sys/bench/mark_once.rs
@@ -14,12 +14,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DecodeError {
-    Short,
-    TooLarge,
-    TooManyItems,
-    BadUtf8,
-    UnsupportedSchema,
-    BlobTooLarge,
+use core::sync::atomic::{AtomicBool, Ordering};
+
+pub fn mark_once(flag: &AtomicBool, event: &[u8]) {
+    if !flag.swap(true, Ordering::AcqRel) {
+        super::mark(event);
+    }
 }

--- a/src/sys/bench/mod.rs
+++ b/src/sys/bench/mod.rs
@@ -14,12 +14,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum DecodeError {
-    Short,
-    TooLarge,
-    TooManyItems,
-    BadUtf8,
-    UnsupportedSchema,
-    BlobTooLarge,
-}
+mod mark;
+mod mark_once;
+mod mark_named;
+
+pub use mark::mark;
+pub use mark_once::mark_once;
+pub use mark_named::mark_named;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -17,6 +17,7 @@
 #[cfg(target_arch = "x86_64")]
 pub mod apic;
 pub mod boot_log;
+pub mod bench;
 pub mod clock;
 #[cfg(target_arch = "x86_64")]
 pub mod gdt;

--- a/src/syscall/dispatch/router/input_ops.rs
+++ b/src/syscall/dispatch/router/input_ops.rs
@@ -22,6 +22,7 @@ use crate::syscall::dispatch::util::errno;
 use crate::syscall::numbers::SyscallNumber;
 use crate::syscall::SyscallResult;
 use crate::usercopy::{copy_to_user, read_user_value, validate_user_write, write_user_value};
+use core::sync::atomic::AtomicBool;
 
 const EINVAL: i32 = 22;
 const EFAULT: i32 = 14;
@@ -30,6 +31,7 @@ const ENOTSUP: i32 = 95;
 const ENOMEM: i32 = 12;
 const MAX_DRAIN: usize = 64;
 const DEFAULT_WAIT_MS: u64 = 50;
+static FIRST_INPUT_DRAIN: AtomicBool = AtomicBool::new(false);
 
 pub(super) fn handle(
     nr: SyscallNumber,
@@ -74,6 +76,7 @@ fn do_drain(out_ptr: u64, max_events: u64) -> SyscallResult {
     if copy_to_user(out_ptr, src).is_err() {
         return errno(EFAULT);
     }
+    crate::sys::bench::mark_once(&FIRST_INPUT_DRAIN, b"input_drain_first");
     SyscallResult::success_audited(n as i64)
 }
 

--- a/src/syscall/dispatch/router/surface_handlers.rs
+++ b/src/syscall/dispatch/router/surface_handlers.rs
@@ -26,11 +26,13 @@ use crate::process::current_pid;
 use crate::syscall::dispatch::util::errno;
 use crate::syscall::SyscallResult;
 use crate::usercopy::{read_user_value, write_user_value};
-use core::sync::atomic::{AtomicU32, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use super::surface_ops::{map_err, EFAULT, EINVAL, ESRCH};
 
 static VSYNC_TRACE_COUNT: AtomicU32 = AtomicU32::new(0);
+static FIRST_SURFACE_REGISTER: AtomicBool = AtomicBool::new(false);
+static FIRST_SURFACE_PRESENT: AtomicBool = AtomicBool::new(false);
 
 fn trace_surface(op: &[u8], label: &[u8], pid: u32) {
     if !matches!(pid, 0x17 | 0x26 | 0x27) || VSYNC_TRACE_COUNT.fetch_add(1, Ordering::Relaxed) >= 80
@@ -74,6 +76,7 @@ pub(super) fn do_register(desc_ptr: u64) -> SyscallResult {
         Ok((sid, h)) => {
             attach_map::record(pid, h, desc.base_va, desc.byte_len);
             trace_surface(b"register", b"ok", pid);
+            crate::sys::bench::mark_once(&FIRST_SURFACE_REGISTER, b"surface_register_first");
             SyscallResult::success_audited(sid as i64)
         }
         Err(e) => errno(map_err(e)),
@@ -137,7 +140,11 @@ pub(super) fn do_present(handle: u64) -> SyscallResult {
         Some(v) => v,
         None => return errno(EINVAL),
     };
-    super::graphics_present::handle(0, base_va, byte_len as usize)
+    let result = super::graphics_present::handle(0, base_va, byte_len as usize);
+    if !result.is_error() {
+        crate::sys::bench::mark_once(&FIRST_SURFACE_PRESENT, b"surface_present_first");
+    }
+    result
 }
 
 pub(super) fn do_vsync_wait(display: u64) -> SyscallResult {

--- a/src/syscall/microkernel/ipc/call/sys_ipc_call.rs
+++ b/src/syscall/microkernel/ipc/call/sys_ipc_call.rs
@@ -14,15 +14,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::process::current_pid;
-use crate::services::registry::lookup_port;
+use crate::{process::current_pid, services::registry::lookup_port};
 use crate::syscall::microkernel::errnos::ERRNO_BUSY;
+use core::sync::atomic::AtomicBool;
 
 use super::super::pending_reply;
 use super::super::recv::recv_from_inbox;
 use super::super::reply_inbox;
 use super::super::send::sys_ipc_send;
 use super::trace::trace;
+
+static GPU_TRANSFER: AtomicBool = AtomicBool::new(false);
+static GPU_SCANOUT: AtomicBool = AtomicBool::new(false);
+static GPU_FLUSH: AtomicBool = AtomicBool::new(false);
 
 pub fn sys_ipc_call(
     ep: u64,
@@ -34,7 +38,8 @@ pub fn sys_ipc_call(
 ) -> i64 {
     let pid = current_pid().unwrap_or(0);
     let inbox = reply_inbox::for_pid(pid);
-    let endpoint_pid = lookup_port(ep as u32).map(|endpoint| endpoint.pid);
+    let endpoint = lookup_port(ep as u32);
+    let endpoint_pid = endpoint.as_ref().map(|endpoint| endpoint.pid);
     if let Some(server_pid) = endpoint_pid {
         if !pending_reply::push(server_pid, inbox.clone()) {
             return ERRNO_BUSY;
@@ -53,6 +58,33 @@ pub fn sys_ipc_call(
     if recv_result < 0 {
         if let Some(server_pid) = endpoint_pid {
             pending_reply::remove(server_pid, &inbox);
+        }
+    }
+    if recv_result >= 24 && req_len >= 20 {
+        if let Some(endpoint) = endpoint.as_ref() {
+            let mut hdr = [0u8; 20];
+            let mut status = [0u8; 4];
+            let ok_hdr = crate::usercopy::copy_from_user(req, &mut hdr).is_ok();
+            let ok_status =
+                crate::usercopy::copy_from_user(resp.saturating_add(20), &mut status).is_ok();
+            if endpoint.name.as_bytes() == b"driver.virtio_gpu0" && ok_hdr && ok_status {
+                let magic = u32::from_le_bytes([hdr[0], hdr[1], hdr[2], hdr[3]]);
+                let op = u16::from_le_bytes([hdr[6], hdr[7]]);
+                if magic == 0x4E56_4750 && u32::from_le_bytes(status) == 0 {
+                    if op == 0x0008 {
+                        crate::sys::bench::mark_once(
+                            &GPU_TRANSFER,
+                            b"virtio_gpu_transfer_first",
+                        );
+                    }
+                    if op == 0x0009 {
+                        crate::sys::bench::mark_once(&GPU_SCANOUT, b"virtio_gpu_scanout_first");
+                    }
+                    if op == 0x000A {
+                        crate::sys::bench::mark_once(&GPU_FLUSH, b"virtio_gpu_flush_first");
+                    }
+                }
+            }
         }
     }
     trace(pid, b"recv", recv_result);

--- a/src/userspace/init/spawn_plan/orchestrator.rs
+++ b/src/userspace/init/spawn_plan/orchestrator.rs
@@ -22,9 +22,13 @@ pub(in crate::userspace::init) fn spawn_core_after_ramfs() {
     super::core::spawn_after_ramfs();
 }
 
+#[cfg(not(feature = "microkernel-input-probe"))]
 pub(in crate::userspace::init) fn spawn_display_core() {
     super::desktop_fleet::spawn_early_display();
 }
+
+#[cfg(feature = "microkernel-input-probe")]
+pub(in crate::userspace::init) fn spawn_display_core() {}
 
 pub(in crate::userspace::init) fn spawn_drivers() {
     super::drivers_virtio::spawn();


### PR DESCRIPTION
This PR hardens the release and CI path around evidence, reproducibility, and artifact provenance.

The release workflow now requires the build, trust-chain, adversarial, supply-chain, evidence, runtime, reproducibility, and release-artifact lanes before final attestation. The attestation step also fails if a required module report is missing, so a green run cannot silently omit a critical proof.

The verification engine gains dedicated modules for runtime evidence, reproducible double-build checks, release artifact bundling, and hardware benchmark evidence. Release output now includes a bundle manifest, SHA-256 sums, BLAKE3 sums, and source workflow provenance tied to the exact commit and toolchain.

This also adds kernel benchmark markers for boot, spawn, ZK attestation, input, surface, and GPU path milestones, plus bare-metal evidence metadata validation so hardware claims can be backed by serial logs and machine dossiers instead of prose.

Verification performed locally:
- workflow YAML parse for all GitHub workflows and the shared setup action
- cargo fmt --manifest-path nonos-verify/Cargo.toml -- --check
- cargo check --manifest-path nonos-verify/Cargo.toml
- cargo run --manifest-path nonos-verify/Cargo.toml -- --help
- negative attestation check for missing required reports
- dirty-tree reproducibility fail-closed check
- make nonos-mk-check

Not claimed here:
- remote GitHub runner execution
- QEMU runtime proof from this local pass
- production signing secret availability
- branch protection enforcement