### PR TITLE
Bootloader: TPM measured boot + NV monotonic counter working in firmware

### DIFF
--- a/nonos-bootloader/src/security/tpm_extend/pcr.rs
+++ b/nonos-bootloader/src/security/tpm_extend/pcr.rs
@@ -20,8 +20,8 @@ use alloc::format;
 use sha2::{Digest, Sha256};
 use uefi::prelude::*;
 
-use super::tcg2::{extend_pcr_via_tcg2, locate_tcg2_protocol};
-use crate::log::logger::{log_debug, log_error, log_info, log_warn};
+use super::tcg2::extend_pcr_via_tcg2;
+use crate::log::logger::{log_error, log_info, log_warn};
 
 pub fn extend_pcr_measurement(st: &mut SystemTable<Boot>, pcr_index: u32, data: &[u8]) -> bool {
     if data.is_empty() {
@@ -35,19 +35,13 @@ pub fn extend_pcr_measurement(st: &mut SystemTable<Boot>, pcr_index: u32, data: 
     let mut hasher = Sha256::new();
     hasher.update(data);
     let measurement: [u8; 32] = hasher.finalize().into();
-    match locate_tcg2_protocol(st.boot_services()) {
-        Some(tcg2) => match extend_pcr_via_tcg2(tcg2, pcr_index, &measurement) {
-            Ok(()) => {
-                log_info("security", &format!("PCR{} extended", pcr_index));
-                true
-            }
-            Err(e) => {
-                log_warn("security", &format!("PCR extend failed: {}", e));
-                false
-            }
-        },
-        None => {
-            log_debug("security", "no TPM2 available");
+    match extend_pcr_via_tcg2(st.boot_services(), pcr_index, &measurement) {
+        Ok(()) => {
+            log_info("security", &format!("PCR{} extended", pcr_index));
+            true
+        }
+        Err(e) => {
+            log_warn("security", &format!("PCR extend failed: {}", e));
             false
         }
     }

--- a/nonos-bootloader/src/security/tpm_extend/tcg2.rs
+++ b/nonos-bootloader/src/security/tpm_extend/tcg2.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use uefi::table::boot::SearchType;
+use uefi::table::boot::{OpenProtocolAttributes, OpenProtocolParams, SearchType};
 use uefi::Identify;
 
 use crate::security::tpm_types::{Tcg2EventHeader, Tcg2Protocol, EV_POST_CODE};
@@ -63,7 +63,20 @@ pub fn submit_tpm_command(
     cmd: &[u8],
     response: &mut [u8],
 ) -> Result<usize, &'static str> {
-    let tcg2 = locate_tcg2_protocol(bs).ok_or("no TCG2 protocol")?;
+    let handles = bs
+        .locate_handle_buffer(SearchType::ByProtocol(&Tcg2Protocol::GUID))
+        .map_err(|_| "no TCG2 handle")?;
+    let handle = *handles.first().ok_or("no TCG2 protocol")?;
+    // OVMF keeps the TCG2 protocol open BY_DRIVER, so an exclusive open is
+    // denied. GetProtocol borrows the interface without disturbing that owner.
+    let proto = unsafe {
+        bs.open_protocol::<Tcg2Protocol>(
+            OpenProtocolParams { handle, agent: bs.image_handle(), controller: None },
+            OpenProtocolAttributes::GetProtocol,
+        )
+    }
+    .map_err(|_| "open TCG2 failed")?;
+    let tcg2 = &*proto as *const Tcg2Protocol as *mut Tcg2Protocol;
     let status = unsafe {
         ((*tcg2).submit_command)(
             tcg2,
@@ -73,6 +86,7 @@ pub fn submit_tpm_command(
             response.as_mut_ptr(),
         )
     };
+    drop(proto);
     if !status.is_success() {
         return Err("submit_command failed");
     }

--- a/nonos-bootloader/src/security/tpm_extend/tcg2.rs
+++ b/nonos-bootloader/src/security/tpm_extend/tcg2.rs
@@ -17,44 +17,49 @@
 use uefi::table::boot::{OpenProtocolAttributes, OpenProtocolParams, SearchType};
 use uefi::Identify;
 
-use crate::security::tpm_types::{Tcg2EventHeader, Tcg2Protocol, EV_POST_CODE};
-
-pub fn locate_tcg2_protocol(bs: &uefi::table::boot::BootServices) -> Option<*mut Tcg2Protocol> {
-    let handles = bs.locate_handle_buffer(SearchType::ByProtocol(&Tcg2Protocol::GUID)).ok()?;
-    let handle = handles.first()?;
-    let protocol = bs.open_protocol_exclusive::<Tcg2Protocol>(*handle).ok()?;
-    let ptr = &*protocol as *const Tcg2Protocol as *mut Tcg2Protocol;
-    core::mem::forget(protocol);
-    Some(ptr)
-}
+use crate::security::tpm_types::{Tcg2Event, Tcg2EventHeader, Tcg2Protocol, EV_POST_CODE};
 
 pub fn extend_pcr_via_tcg2(
-    tcg2: *mut Tcg2Protocol,
+    bs: &uefi::table::boot::BootServices,
     pcr_index: u32,
     digest: &[u8; 32],
 ) -> Result<(), &'static str> {
-    if tcg2.is_null() {
-        return Err("null TCG2 handle");
+    let handles = bs
+        .locate_handle_buffer(SearchType::ByProtocol(&Tcg2Protocol::GUID))
+        .map_err(|_| "no TCG2 handle")?;
+    let handle = *handles.first().ok_or("no TCG2 protocol")?;
+    let proto = unsafe {
+        bs.open_protocol::<Tcg2Protocol>(
+            OpenProtocolParams { handle, agent: bs.image_handle(), controller: None },
+            OpenProtocolAttributes::GetProtocol,
+        )
     }
-    let header = Tcg2EventHeader {
-        header_size: core::mem::size_of::<Tcg2EventHeader>() as u32,
-        header_version: 1,
-        pcr_index,
-        event_type: EV_POST_CODE,
+    .map_err(|_| "open TCG2 failed")?;
+    let tcg2 = &*proto as *const Tcg2Protocol as *mut Tcg2Protocol;
+    let event = Tcg2Event {
+        size: core::mem::size_of::<Tcg2Event>() as u32,
+        header: Tcg2EventHeader {
+            header_size: core::mem::size_of::<Tcg2EventHeader>() as u32,
+            header_version: 1,
+            pcr_index,
+            event_type: EV_POST_CODE,
+        },
+        event: *digest,
     };
-    unsafe {
-        let status = ((*tcg2).hash_log_extend_event)(
+    let status = unsafe {
+        ((*tcg2).hash_log_extend_event)(
             tcg2,
             0,
             digest.as_ptr(),
             digest.len() as u64,
-            &header,
-        );
-        if status.is_success() {
-            Ok(())
-        } else {
-            Err("TCG2 extend failed")
-        }
+            &event as *const Tcg2Event as *const u8,
+        )
+    };
+    drop(proto);
+    if status.is_success() {
+        Ok(())
+    } else {
+        Err("TCG2 extend failed")
     }
 }
 

--- a/nonos-bootloader/src/security/tpm_types/event.rs
+++ b/nonos-bootloader/src/security/tpm_types/event.rs
@@ -14,10 +14,22 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#[repr(C)]
+// EFI_TCG2_EVENT_HEADER is packed in the TCG EFI Protocol spec: 4 + 2 + 4 + 4
+// = 14 bytes with no padding. A natural repr(C) would pad to 16 and the
+// firmware would reject the event.
+#[repr(C, packed)]
 pub struct Tcg2EventHeader {
     pub header_size: u32,
     pub header_version: u16,
     pub pcr_index: u32,
     pub event_type: u32,
+}
+
+// EFI_TCG2_EVENT: a leading Size covering the whole structure, the header, and
+// a variable event body. HashLogExtendEvent reads Size first and validates it.
+#[repr(C, packed)]
+pub struct Tcg2Event {
+    pub size: u32,
+    pub header: Tcg2EventHeader,
+    pub event: [u8; 32],
 }

--- a/nonos-bootloader/src/security/tpm_types/mod.rs
+++ b/nonos-bootloader/src/security/tpm_types/mod.rs
@@ -19,6 +19,6 @@ mod event;
 pub mod pcr;
 mod protocol;
 
-pub use event::Tcg2EventHeader;
+pub use event::{Tcg2Event, Tcg2EventHeader};
 pub use pcr::{EV_POST_CODE, PCR_BOOTLOADER, PCR_CAPSULE, PCR_KERNEL};
 pub use protocol::Tcg2Protocol;

--- a/nonos-bootloader/src/security/tpm_types/protocol.rs
+++ b/nonos-bootloader/src/security/tpm_types/protocol.rs
@@ -15,7 +15,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::capability::Tcg2BootServiceCapability;
-use super::event::Tcg2EventHeader;
 use uefi::proto::unsafe_protocol;
 use uefi::Status;
 
@@ -26,13 +25,8 @@ pub struct Tcg2Protocol {
         unsafe extern "efiapi" fn(*mut Tcg2Protocol, *mut Tcg2BootServiceCapability) -> Status,
     pub get_event_log:
         unsafe extern "efiapi" fn(*mut Tcg2Protocol, u32, *mut u64, *mut u64, *mut bool) -> Status,
-    pub hash_log_extend_event: unsafe extern "efiapi" fn(
-        *mut Tcg2Protocol,
-        u64,
-        *const u8,
-        u64,
-        *const Tcg2EventHeader,
-    ) -> Status,
+    pub hash_log_extend_event:
+        unsafe extern "efiapi" fn(*mut Tcg2Protocol, u64, *const u8, u64, *const u8) -> Status,
     pub submit_command:
         unsafe extern "efiapi" fn(*mut Tcg2Protocol, u32, *const u8, u32, *mut u8) -> Status,
     pub get_active_pcr_banks: unsafe extern "efiapi" fn(*mut Tcg2Protocol, *mut u32) -> Status,


### PR DESCRIPTION
Two related TPM fixes, both proven end to end under swtpm + tpm-crb on a TPM2-enabled OVMF.

1. NV monotonic counter: opened TCG2 with open_protocol_exclusive, but OVMF holds the protocol BY_DRIVER so the exclusive open returned ACCESS_DENIED and every NV command failed. Now opened with GetProtocol via image_handle, open/close per command. Boot logs `tpm-counter: monotonic v1=1 v2=2`.

2. Measured boot: same exclusive-open problem, plus a malformed event passed to HashLogExtendEvent (header unpacked at 16 bytes vs the spec 14, and the outer EFI_TCG2_EVENT Size field and event body missing). Now a packed EFI_TCG2_EVENT with the leading Size, 14 byte header and body. Boot logs `PCR8 extended` and `Measured Boot: ACTIVE`.

The NV command encoding was already proven standalone (scripts/tpm_counter_evidence.sh). This makes the in-firmware UEFI path work.