### PR TITLE
Bootloader: show TPM measured boot + NV counter status on the boot screen

### DIFF
--- a/nonos-bootloader/src/boot/security/run.rs
+++ b/nonos-bootloader/src/boot/security/run.rs
@@ -33,11 +33,12 @@ pub fn run_security_checks(st: &mut SystemTable<Boot>, gop: bool) -> SecurityCon
     init_security_primitives();
     let hw_caps = verify_hardware_requirements(st, gop);
     verify_platform(&hw_caps, gop);
-    let security = init_subsystems(st, gop);
+    let mut security = init_subsystems(st, gop);
     enforce_policy(&security, st, gop);
     verify_chain(&security, st);
     match tpm_counter_selftest(st.boot_services()) {
         Ok((first, second)) => {
+            security.tpm_counter_ok = true;
             log_info("tpm-counter", &format!("monotonic v1={} v2={}", first, second))
         }
         Err(rc) if rc == RC_NO_TPM => log_info("tpm-counter", "no TPM present, selftest skipped"),

--- a/nonos-bootloader/src/bootmenu/mod.rs
+++ b/nonos-bootloader/src/bootmenu/mod.rs
@@ -23,6 +23,7 @@ mod list;
 mod nav;
 mod render;
 mod run;
+mod security_status;
 mod theme;
 
 pub use run::run;

--- a/nonos-bootloader/src/bootmenu/security_status.rs
+++ b/nonos-bootloader/src/bootmenu/security_status.rs
@@ -14,25 +14,28 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use super::footer::draw_footer;
-use super::header::draw_header;
-use super::list::draw_list;
-use super::security_status::draw_security_status;
-use crate::display::fx::fill_atmosphere;
-use crate::display::gop::get_dimensions;
+use super::theme::STATUS;
+use crate::display::font::{draw_string, CHAR_WIDTH};
 use crate::security::SecurityContext;
 
-pub(super) fn render(sel: usize, remaining_s: u32, sec: &SecurityContext) {
-    let (w, h) = get_dimensions();
-    fill_atmosphere();
-
-    // Vertically center the title + list + status as one block.
-    let title_y = h.saturating_sub(360) / 2 + 24;
-    let list_top = title_y + 116;
-    let status_y = list_top + 6 * 50 + 30;
-
-    draw_header(w, title_y);
-    draw_list(w, list_top, sel);
-    draw_footer(w, status_y, remaining_s);
-    draw_security_status(w, status_y + 44, sec);
+pub(super) fn draw_security_status(w: u32, y: u32, sec: &SecurityContext) {
+    let mut buf = [0u8; 64];
+    let mut n = 0usize;
+    let head: &[u8] = if sec.measured_boot_active {
+        b"TPM MEASURED BOOT ACTIVE   NV COUNTER "
+    } else {
+        b"TPM MEASURED BOOT INACTIVE   NV COUNTER "
+    };
+    for &b in head {
+        buf[n] = b;
+        n += 1;
+    }
+    let counter: &[u8] = if sec.tpm_counter_ok { b"OK" } else { b"--" };
+    for &b in counter {
+        buf[n] = b;
+        n += 1;
+    }
+    let msg = &buf[..n];
+    let mw = msg.len() as u32 * CHAR_WIDTH;
+    draw_string(w.saturating_sub(mw) / 2, y, msg, STATUS);
 }

--- a/nonos-bootloader/src/security/types/context.rs
+++ b/nonos-bootloader/src/security/types/context.rs
@@ -25,6 +25,7 @@ pub struct SecurityContext {
     pub production_keys_loaded: bool,
     pub key_count: usize,
     pub measured_boot_active: bool,
+    pub tpm_counter_ok: bool,
 }
 
 impl SecurityContext {
@@ -39,6 +40,7 @@ impl SecurityContext {
             production_keys_loaded: false,
             key_count: 0,
             measured_boot_active: false,
+            tpm_counter_ok: false,
         }
     }
 }


### PR DESCRIPTION
Follow-up to the merged TPM work (#248). The measured-boot result and NV monotonic counter selftest were serial-only; the boot menu now renders TPM MEASURED BOOT ACTIVE and NV COUNTER OK from the security context, so the hardware root of trust is visible on screen (and screenshot-able). Proven live under swtpm + tpm-crb.