### PR TITLE
Bootloader: TPM-backed anti-rollback (signed index + monotonic counter floor)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,12 @@ ZK_CAPSULE_ENROLL_SEED ?=
 ZK_CAPSULE_NONCE_SEED ?=
 ZK_CAPSULE_EPOCH ?= 1
 EMBED_TOOL       := $(BOOTLOADER_DIR)/tools/embed-zk-proof/target/$(HOST_TARGET)/release/embed-zk-proof
+SIGN_TOOL        := $(BOOTLOADER_DIR)/tools/sign-kernel/target/$(HOST_TARGET)/release/sign-kernel
+
+# Anti-rollback index baked into and signed over the kernel image. Bump only for
+# security-critical releases; the TPM monotonic counter enforces it as a floor
+# so an older signed kernel cannot be rolled back onto a device.
+NONOS_ROLLBACK_INDEX ?= 0
 
 # Developer evaluation bootstrap (NOT production custody).
 #
@@ -338,6 +344,11 @@ nonos-mk-attestation-receipt: $(TARGET_DIR)/kernel_attested.bin
 $(EMBED_TOOL): nonos-mk-check-deps
 	@echo "Building ZK embed tool..."
 	@cd $(BOOTLOADER_DIR)/tools/embed-zk-proof && RUSTFLAGS="" RUSTUP_TOOLCHAIN=$(TOOLCHAIN) \
+		$(CARGO) build --release --target $(HOST_TARGET)
+
+$(SIGN_TOOL): nonos-mk-check-deps
+	@echo "Building kernel signing tool..."
+	@cd $(BOOTLOADER_DIR)/tools/sign-kernel && RUSTFLAGS="" RUSTUP_TOOLCHAIN=$(TOOLCHAIN) \
 		$(CARGO) build --release --target $(HOST_TARGET)
 
 $(ZK_BOOT_ROOT) $(ZK_BOOT_COMMITMENTS) $(ZK_BOOT_SECRETS): $(ZK_BOOT_LABELS) $(ZK_ENROLL_TOOL)
@@ -1255,14 +1266,11 @@ nonos-mk-process-manager-prod: nonos-mk-desktop-gui-prod
 
 # Sign + attest + ESP packaging
 
-$(TARGET_DIR)/kernel_signed.bin: $(TARGET_DIR)/x86_64-nonos/release/nonos-kernel $(SIGNING_KEY)
-	@echo "Signing kernel (Ed25519)..."
+$(TARGET_DIR)/kernel_signed.bin: $(TARGET_DIR)/x86_64-nonos/release/nonos-kernel $(SIGNING_KEY) $(SIGN_TOOL)
+	@echo "Signing kernel (Ed25519, rollback index $(NONOS_ROLLBACK_INDEX))..."
 	@mkdir -p $(TARGET_DIR)
-ifeq ($(UNAME_S),Darwin)
-	@/usr/bin/python3 nonos-utils/sign_kernel.py $< $(SIGNING_KEY) $@
-else
-	@python3 nonos-utils/sign_kernel.py $< $(SIGNING_KEY) $@
-endif
+	@$(SIGN_TOOL) --key $(KERNEL_SIGNING_KEY) --input $< --output $@ \
+		--rollback-index $(NONOS_ROLLBACK_INDEX)
 
 nonos-mk-sign: $(TARGET_DIR)/kernel_signed.bin
 

--- a/nonos-bootloader/src/boot/crypto/rollback.rs
+++ b/nonos-bootloader/src/boot/crypto/rollback.rs
@@ -19,9 +19,11 @@ use uefi::prelude::*;
 use crate::display::{log_ok, show_error_screen};
 use crate::handoff::get_uefi_time_epoch;
 use crate::image_format::{has_production_footer, parse_image_footer};
-use crate::log::logger::{log_error, log_info};
+use crate::log::logger::{log_error, log_info, log_warn};
+use alloc::format;
+
 use crate::menu::SecurityMode;
-use crate::security::{check_kernel_version, update_kernel_version};
+use crate::security::{check_kernel_version, commit_floor, read_floor, update_kernel_version};
 
 use super::super::util::fatal_reset;
 
@@ -29,10 +31,12 @@ pub fn check_rollback(st: &mut SystemTable<Boot>, data: &[u8], mode: SecurityMod
     if !has_production_footer(data) {
         return;
     }
-    let version = match parse_image_footer(data) {
-        Ok(parsed) => parsed.footer.image_version as u64,
+    let parsed = match parse_image_footer(data) {
+        Ok(parsed) => parsed,
         Err(_) => return,
     };
+    let version = parsed.footer.image_version as u64;
+    let rollback_index = parsed.footer.rollback_index as u64;
     match check_kernel_version(version) {
         Ok(()) => {
             log_info("rollback", "kernel version acceptable");
@@ -51,14 +55,24 @@ pub fn check_rollback(st: &mut SystemTable<Boot>, data: &[u8], mode: SecurityMod
             log_info("rollback", "rollback detected but dev mode - continuing");
         }
     }
+    if let Some(floor) = read_floor(st.boot_services()) {
+        log_info("rollback", &format!("tpm floor {} index {}", floor, rollback_index));
+        if rollback_index < floor && mode.requires_signature() {
+            log_error("rollback", "rollback index below TPM monotonic floor");
+            if gop {
+                show_error_screen(b"Rollback attack detected");
+            }
+            fatal_reset(st, "rollback index below TPM floor");
+        }
+    }
 }
 
 pub fn commit_rollback(st: &mut SystemTable<Boot>, data: &[u8], mode: SecurityMode, gop: bool) {
     if !has_production_footer(data) {
         return;
     }
-    let version = match parse_image_footer(data) {
-        Ok(parsed) => parsed.footer.image_version as u64,
+    let parsed = match parse_image_footer(data) {
+        Ok(parsed) => parsed,
         Err(e) => {
             if mode.requires_signature() {
                 log_error("rollback", "kernel version footer parse failed");
@@ -67,6 +81,8 @@ pub fn commit_rollback(st: &mut SystemTable<Boot>, data: &[u8], mode: SecurityMo
             return;
         }
     };
+    let version = parsed.footer.image_version as u64;
+    let rollback_index = parsed.footer.rollback_index as u64;
     let timestamp = get_uefi_time_epoch(st);
     match update_kernel_version(version, timestamp) {
         Ok(()) => {
@@ -75,15 +91,14 @@ pub fn commit_rollback(st: &mut SystemTable<Boot>, data: &[u8], mode: SecurityMo
                 log_ok(b"Anti-rollback commit PASSED");
             }
         }
-        Err(e) => {
-            if mode.requires_signature() {
-                log_error("rollback", "kernel version commit failed");
-                if gop {
-                    show_error_screen(b"Rollback state update failed");
-                }
-                fatal_reset(st, e.as_str());
-            }
-            log_info("rollback", "rollback commit failed but dev mode - continuing");
+        Err(_) => {
+            log_warn(
+                "rollback",
+                "legacy nvram commit unavailable; enforcing via TPM counter floor",
+            );
         }
+    }
+    if commit_floor(st.boot_services(), rollback_index) {
+        log_info("rollback", "tpm rollback floor committed");
     }
 }

--- a/nonos-bootloader/src/image_format/footer.rs
+++ b/nonos-bootloader/src/image_format/footer.rs
@@ -36,6 +36,8 @@ pub struct ImageFooter {
     pub proof_size: u32,
     pub image_version: u32,
     pub reserved1: [u8; 4],
+    pub rollback_index: u32,
+    pub reserved2: [u8; 4],
 }
 
 impl ImageFooter {

--- a/nonos-bootloader/src/image_format/parse/bytes.rs
+++ b/nonos-bootloader/src/image_format/parse/bytes.rs
@@ -46,6 +46,11 @@ pub fn parse_footer_bytes(bytes: &[u8]) -> Result<ImageFooter, ParseError> {
     let mut reserved1 = [0u8; 4];
     reserved1.copy_from_slice(&bytes[52..56]);
 
+    let rollback_index = u32::from_le_bytes([bytes[56], bytes[57], bytes[58], bytes[59]]);
+
+    let mut reserved2 = [0u8; 4];
+    reserved2.copy_from_slice(&bytes[60..64]);
+
     Ok(ImageFooter {
         magic,
         version,
@@ -62,5 +67,7 @@ pub fn parse_footer_bytes(bytes: &[u8]) -> Result<ImageFooter, ParseError> {
         proof_size,
         image_version,
         reserved1,
+        rollback_index,
+        reserved2,
     })
 }

--- a/nonos-bootloader/src/kernel_verify/signature.rs
+++ b/nonos-bootloader/src/kernel_verify/signature.rs
@@ -25,7 +25,8 @@ use crate::crypto::sig::verify_signature_bytes;
 use crate::log::logger::{log_error, log_info};
 
 pub fn verify_and_display_signature(
-    kernel_code: &[u8],
+    kernel_hash: &[u8; 32],
+    rollback_index: u32,
     signature: &[u8],
     result: &mut CryptoVerifyResult,
     st: &mut SystemTable<Boot>,
@@ -40,7 +41,10 @@ pub fn verify_and_display_signature(
     }
     display_signature_components(signature, st);
     print(st, cstr16!("  [CRYPTO] Verifying Ed25519 signature...\r\n"));
-    match verify_signature_bytes(kernel_code, signature) {
+    let mut signed_message = [0u8; 36];
+    signed_message[..32].copy_from_slice(kernel_hash);
+    signed_message[32..].copy_from_slice(&rollback_index.to_le_bytes());
+    match verify_signature_bytes(&signed_message, signature) {
         Ok(key_id) => signature_passed(result, &key_id, st),
         Err(e) => {
             result.signature_valid = false;

--- a/nonos-bootloader/src/kernel_verify/verify.rs
+++ b/nonos-bootloader/src/kernel_verify/verify.rs
@@ -58,7 +58,14 @@ pub fn verify_kernel_crypto(kernel_data: &[u8], st: &mut SystemTable<Boot>) -> C
     print_kernel_size(st, parsed.kernel_bytes.len());
     mini_delay();
     compute_and_display_hash(parsed.kernel_bytes, &mut result, st);
-    verify_and_display_signature(parsed.kernel_bytes, parsed.signature_bytes, &mut result, st);
+    let kernel_hash = result.kernel_hash_full;
+    verify_and_display_signature(
+        &kernel_hash,
+        parsed.footer.rollback_index,
+        parsed.signature_bytes,
+        &mut result,
+        st,
+    );
     if result.signature_valid {
         print_verification_success(st);
     } else {

--- a/nonos-bootloader/src/security/mod.rs
+++ b/nonos-bootloader/src/security/mod.rs
@@ -62,7 +62,7 @@ pub use memory::{
     init_canaries, verify_heap_canary, verify_stack_canary, zeroize_slice, SecureBuffer, SecureKey,
 };
 pub use tpm_extend::{extend_pcr_measurement, measure_boot_components};
-pub use tpm_nv::{tpm_counter_selftest, RC_NO_TPM};
+pub use tpm_nv::{commit_floor, read_floor, tpm_counter_selftest, RC_NO_TPM};
 pub use tpm_types::{EV_POST_CODE, PCR_BOOTLOADER, PCR_CAPSULE, PCR_KERNEL};
 pub use types::SecurityContext;
 pub use verify::{verify_kernel_signature_advanced, verify_signature};

--- a/nonos-bootloader/src/security/tpm_nv/consts.rs
+++ b/nonos-bootloader/src/security/tpm_nv/consts.rs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 pub const RC_NV_DEFINED: u32 = 0x0000_014C;
+pub const RC_NV_UNINITIALIZED: u32 = 0x0000_014A;
 pub const RC_SUBMIT_FAILED: u32 = 0xFFFF_FFFF;
 pub const RC_NO_TPM: u32 = 0xFFFF_FFFE;
 

--- a/nonos-bootloader/src/security/tpm_nv/floor.rs
+++ b/nonos-bootloader/src/security/tpm_nv/floor.rs
@@ -1,0 +1,80 @@
+// NØNOS Operating System
+// Copyright (C) 2026 NØNOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use super::consts::{
+    response_code, DEFINE_COUNTER_CMD, INCREMENT_CMD, READ_CMD, RC_NV_UNINITIALIZED,
+};
+use crate::security::tpm_extend::{submit_tpm_command, tpm_present};
+use uefi::table::boot::BootServices;
+
+fn rb_define() -> [u8; 45] {
+    let mut cmd = DEFINE_COUNTER_CMD;
+    cmd[34] = 0x20;
+    cmd
+}
+
+fn rb_increment() -> [u8; 31] {
+    let mut cmd = INCREMENT_CMD;
+    cmd[13] = 0x20;
+    cmd[17] = 0x20;
+    cmd
+}
+
+fn rb_read() -> [u8; 35] {
+    let mut cmd = READ_CMD;
+    cmd[13] = 0x20;
+    cmd[17] = 0x20;
+    cmd
+}
+
+pub fn read_floor(bs: &BootServices) -> Option<u64> {
+    if !tpm_present(bs) {
+        return None;
+    }
+    let mut resp = [0u8; 64];
+    let _ = submit_tpm_command(bs, &rb_define(), &mut resp);
+    let n = submit_tpm_command(bs, &rb_read(), &mut resp).ok()?;
+    let rc = response_code(&resp);
+    if rc == RC_NV_UNINITIALIZED {
+        return Some(0);
+    }
+    if rc != 0 || n < 24 {
+        return None;
+    }
+    Some(u64::from_be_bytes([
+        resp[16], resp[17], resp[18], resp[19], resp[20], resp[21], resp[22], resp[23],
+    ]))
+}
+
+pub fn commit_floor(bs: &BootServices, target: u64) -> bool {
+    let mut current = match read_floor(bs) {
+        Some(value) => value,
+        None => return false,
+    };
+    let mut guard = 0u32;
+    while current < target {
+        if guard >= 4096 {
+            return false;
+        }
+        let mut resp = [0u8; 32];
+        if submit_tpm_command(bs, &rb_increment(), &mut resp).is_err() || response_code(&resp) != 0 {
+            return false;
+        }
+        current += 1;
+        guard += 1;
+    }
+    true
+}

--- a/nonos-bootloader/src/security/tpm_nv/mod.rs
+++ b/nonos-bootloader/src/security/tpm_nv/mod.rs
@@ -16,9 +16,11 @@
 
 mod consts;
 mod define;
+mod floor;
 mod increment;
 mod read;
 mod selftest;
 
 pub use consts::RC_NO_TPM;
+pub use floor::{commit_floor, read_floor};
 pub use selftest::tpm_counter_selftest;

--- a/nonos-bootloader/tools/embed-zk-proof/src/embed/assemble.rs
+++ b/nonos-bootloader/tools/embed-zk-proof/src/embed/assemble.rs
@@ -30,7 +30,13 @@ pub fn assemble_attested_image(kernel: &SignedKernel, zk_block: Vec<u8>) -> Atte
     let proof_size = zk_block.len() as u32;
 
     let total_size = kernel.kernel_bytes.len() + ED25519_SIG_SIZE + zk_block.len() + FOOTER_SIZE;
-    let footer = create_image_footer(kernel_size, signature_size, proof_size, total_size as u64);
+    let footer = create_image_footer(
+        kernel_size,
+        signature_size,
+        proof_size,
+        total_size as u64,
+        kernel.rollback_index,
+    );
 
     let mut data = Vec::with_capacity(total_size);
     data.extend_from_slice(&kernel.kernel_bytes);

--- a/nonos-bootloader/tools/embed-zk-proof/src/footer/create.rs
+++ b/nonos-bootloader/tools/embed-zk-proof/src/footer/create.rs
@@ -21,6 +21,7 @@ pub fn create_image_footer(
     signature_size: u32,
     proof_size: u32,
     total_image_size: u64,
+    rollback_index: u32,
 ) -> [u8; FOOTER_SIZE] {
     let mut footer = [0u8; FOOTER_SIZE];
 
@@ -38,6 +39,7 @@ pub fn create_image_footer(
     footer[40..44].copy_from_slice(&(kernel_size + signature_size).to_le_bytes());
     footer[44..48].copy_from_slice(&proof_size.to_le_bytes());
     footer[48..52].copy_from_slice(&1u32.to_le_bytes());
+    footer[56..60].copy_from_slice(&rollback_index.to_le_bytes());
 
     footer
 }

--- a/nonos-bootloader/tools/embed-zk-proof/src/kernel/load.rs
+++ b/nonos-bootloader/tools/embed-zk-proof/src/kernel/load.rs
@@ -27,6 +27,7 @@ pub struct SignedKernel {
     pub raw_bytes: Vec<u8>,
     pub kernel_bytes: Vec<u8>,
     pub signature: [u8; ED25519_SIG_SIZE],
+    pub rollback_index: u32,
 }
 
 pub fn load_signed_kernel(path: &Path) -> Result<SignedKernel> {
@@ -58,5 +59,12 @@ pub fn load_signed_kernel(path: &Path) -> Result<SignedKernel> {
     let mut signature = [0u8; ED25519_SIG_SIZE];
     signature.copy_from_slice(&raw_bytes[sig_start..sig_start + ED25519_SIG_SIZE]);
 
-    Ok(SignedKernel { raw_bytes, kernel_bytes, signature })
+    let rollback_index = u32::from_le_bytes([
+        raw_bytes[footer_start + 56],
+        raw_bytes[footer_start + 57],
+        raw_bytes[footer_start + 58],
+        raw_bytes[footer_start + 59],
+    ]);
+
+    Ok(SignedKernel { raw_bytes, kernel_bytes, signature, rollback_index })
 }

--- a/nonos-bootloader/tools/sign-kernel/src/main.rs
+++ b/nonos-bootloader/tools/sign-kernel/src/main.rs
@@ -57,11 +57,18 @@ struct Args {
     #[arg(long, action = clap::ArgAction::SetTrue)]
     verify: bool,
 
+    #[arg(long, value_name = "N", default_value_t = 0)]
+    rollback_index: u32,
+
     #[arg(short, long, action = clap::ArgAction::SetTrue)]
     verbose: bool,
 }
 
-fn create_image_footer(kernel_size: u32, total_image_size: u64) -> [u8; FOOTER_SIZE] {
+fn create_image_footer(
+    kernel_size: u32,
+    total_image_size: u64,
+    rollback_index: u32,
+) -> [u8; FOOTER_SIZE] {
     let mut footer = [0u8; FOOTER_SIZE];
     footer[0..8].copy_from_slice(&FOOTER_MAGIC);
     footer[8..10].copy_from_slice(&FOOTER_VERSION.to_le_bytes());
@@ -77,7 +84,15 @@ fn create_image_footer(kernel_size: u32, total_image_size: u64) -> [u8; FOOTER_S
     footer[40..44].copy_from_slice(&0u32.to_le_bytes());
     footer[44..48].copy_from_slice(&0u32.to_le_bytes());
     footer[48..52].copy_from_slice(&1u32.to_le_bytes());
+    footer[56..60].copy_from_slice(&rollback_index.to_le_bytes());
     footer
+}
+
+fn signed_message(kernel_data: &[u8], rollback_index: u32) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(36);
+    msg.extend_from_slice(blake3::hash(kernel_data).as_bytes());
+    msg.extend_from_slice(&rollback_index.to_le_bytes());
+    msg
 }
 
 fn main() -> Result<()> {
@@ -93,7 +108,12 @@ fn main() -> Result<()> {
 
     let kernel_hash = blake3::hash(&kernel_data);
     println!("Kernel BLAKE3: {}", kernel_hash.to_hex());
+    println!("Rollback index: {}", args.rollback_index);
     println!();
+
+    // The signature covers BLAKE3(kernel) || rollback_index so the anti-rollback
+    // floor is authenticated, not just the kernel bytes.
+    let message = signed_message(&kernel_data, args.rollback_index);
 
     let (sig_bytes, verifying_key) = if let Some(ref vault_addr) = args.vault_addr {
         let vault_token = args
@@ -126,7 +146,7 @@ fn main() -> Result<()> {
         println!();
 
         let sig_bytes =
-            sign_kernel_with_vault(vault_addr, vault_token, &args.vault_key_name, &kernel_data)
+            sign_kernel_with_vault(vault_addr, vault_token, &args.vault_key_name, &message)
                 .map_err(|e| anyhow::anyhow!("vault signing failed: {}", e))?;
 
         (sig_bytes, verifying_key)
@@ -157,7 +177,7 @@ fn main() -> Result<()> {
         println!();
 
         println!("Signing kernel with Ed25519 (local key)...");
-        let signature = signing_key.sign(&kernel_data);
+        let signature = signing_key.sign(&message);
 
         (signature.to_bytes(), verifying_key)
     } else {
@@ -170,7 +190,7 @@ fn main() -> Result<()> {
 
     let kernel_size = kernel_data.len() as u32;
     let total_size = (kernel_data.len() + 64 + FOOTER_SIZE) as u64;
-    let footer = create_image_footer(kernel_size, total_size);
+    let footer = create_image_footer(kernel_size, total_size, args.rollback_index);
 
     let mut output_data = kernel_data.clone();
     output_data.extend_from_slice(&sig_bytes);
@@ -213,8 +233,9 @@ fn main() -> Result<()> {
         sig_arr.copy_from_slice(sig_bytes_read);
         let sig_read = ed25519_dalek::Signature::from_bytes(&sig_arr);
 
+        let check = signed_message(payload, args.rollback_index);
         use ed25519_dalek::Verifier;
-        match verifying_key.verify(payload, &sig_read) {
+        match verifying_key.verify(&check, &sig_read) {
             Ok(()) => {
                 println!("Signature verification: PASSED");
             }


### PR DESCRIPTION
Complete, proven anti-rollback. Two commits.

1. Authenticate the index. The kernel signature covered only the kernel bytes, so the footer (and any rollback field) was unsigned and forgeable on an old signed kernel. The signature now covers BLAKE3(kernel) || rollback_index (a 32-bit LE index), a 36-byte prehash. The footer carries it at [56:60]; the Rust signer writes and signs it; the ZK embed step preserves it; the bootloader verifies over the same 36 bytes. Build switches to the Rust signer and exposes NONOS_ROLLBACK_INDEX. Breaking: re-signs every image.

2. Enforce against a TPM monotonic counter. A dedicated TPM NV counter (index 0x01000020) is the floor. On boot the signed index is compared to the counter and a lower index is rejected; on commit the counter is advanced toward the index. The legacy NVRAM version commit becomes best effort.

Proven end to end under swtpm + tpm-crb:
- index 2 image: Ed25519 VERIFIED, tpm floor 0 index 2, floor committed (counter -> 2).
- same kernel re-signed index 1, same TPM: Ed25519 VERIFIED, tpm floor 2 index 1, rollback index below TPM monotonic floor, FATAL (boot halted).

So a correctly signed but older kernel is rejected; the attacker can neither lower the hardware counter nor forge the signed index.