### PR TITLE
Bootloader: the boot menu chooses the security policy

### DIFF
--- a/nonos-bootloader/src/boot/mod.rs
+++ b/nonos-bootloader/src/boot/mod.rs
@@ -33,7 +33,7 @@ pub use elf::run_elf_parse;
 pub use hardware::run_hardware_discovery;
 pub use kernel::run_kernel_load;
 pub use prepare::{run_handoff_prepare, HandoffParams};
-pub use security::run_security_checks;
+pub use security::{enforce_policy, run_security_checks};
 pub use shell::exit_to_shell;
 pub use uefi::{run_boot_screen_init, run_uefi_init};
 pub use util::{fatal_reset, micro_delay, mini_delay, print_u64};

--- a/nonos-bootloader/src/boot/security/mod.rs
+++ b/nonos-bootloader/src/boot/security/mod.rs
@@ -20,4 +20,5 @@ mod platform;
 mod policy;
 mod run;
 
+pub use policy::enforce_policy;
 pub use run::run_security_checks;

--- a/nonos-bootloader/src/boot/security/policy.rs
+++ b/nonos-bootloader/src/boot/security/policy.rs
@@ -18,14 +18,20 @@ use uefi::prelude::*;
 
 use crate::display::{log_ok, show_error_screen, update_stage, StageStatus, STAGE_SECURITY};
 use crate::log::logger::{log_error, log_warn};
+use crate::menu::SecurityMode;
 use crate::security::{
     enforce_security_policy, verify_secure_boot_chain, SecurityContext, SecurityPolicy,
 };
 
 use super::super::util::fatal_reset;
 
-pub fn enforce_policy(security: &SecurityContext, st: &mut SystemTable<Boot>, gop: bool) {
-    let enforcement = enforce_security_policy(security, st);
+pub fn enforce_policy(
+    security: &SecurityContext,
+    st: &mut SystemTable<Boot>,
+    gop: bool,
+    mode: SecurityMode,
+) {
+    let enforcement = enforce_security_policy(security, st, mode);
     if !enforcement.allow_boot {
         log_error("security", enforcement.reason);
         update_stage(STAGE_SECURITY, StageStatus::Failed);

--- a/nonos-bootloader/src/boot/security/run.rs
+++ b/nonos-bootloader/src/boot/security/run.rs
@@ -25,8 +25,11 @@ use super::super::uefi::TOTAL_BOOT_STAGES;
 use super::hardware::verify_hardware_requirements;
 use super::init::init_security_primitives;
 use super::platform::{init_subsystems, verify_platform};
-use super::policy::{enforce_policy, verify_chain};
+use super::policy::verify_chain;
 
+// Gathers the security posture (keys, measured boot, TPM, secure-boot chain)
+// so the menu can display it. Policy enforcement is deferred until after the
+// menu, in enforce_selected_policy, so the chosen mode can raise the floor.
 pub fn run_security_checks(st: &mut SystemTable<Boot>, gop: bool) -> SecurityContext {
     update_stage(STAGE_SECURITY, StageStatus::Running);
     draw_boot_progress(2, TOTAL_BOOT_STAGES);
@@ -34,7 +37,6 @@ pub fn run_security_checks(st: &mut SystemTable<Boot>, gop: bool) -> SecurityCon
     let hw_caps = verify_hardware_requirements(st, gop);
     verify_platform(&hw_caps, gop);
     let mut security = init_subsystems(st, gop);
-    enforce_policy(&security, st, gop);
     verify_chain(&security, st);
     match tpm_counter_selftest(st.boot_services()) {
         Ok((first, second)) => {

--- a/nonos-bootloader/src/bootmenu/run.rs
+++ b/nonos-bootloader/src/bootmenu/run.rs
@@ -23,24 +23,35 @@ use super::render::render;
 use crate::display::gop::is_initialized;
 use crate::hardware::HardwareInfo;
 use crate::menu::MenuAction;
-use crate::security::SecurityContext;
+use crate::security::{SecurityContext, SecurityPolicy};
 
 const TIMEOUT_S: u32 = 10;
 const TICK_US: usize = 50_000;
 const TICKS_PER_S: u32 = 20;
 
+// A hands-off boot lands on the compile-time floor (index 1 = Standard), which
+// is always satisfiable. Hardened (index 0) stays a deliberate escalation that
+// the operator must select, since it requires Secure Boot and a TPM.
+fn default_index() -> usize {
+    match SecurityPolicy::from_build() {
+        SecurityPolicy::Hardened => 0,
+        _ => 1,
+    }
+}
+
 pub fn run(st: &mut SystemTable<Boot>, sec: &SecurityContext, _hw: &HardwareInfo) -> MenuAction {
     if !is_initialized() {
         return MenuAction::Timeout;
     }
-    let mut sel = 0usize;
+    let default = default_index();
+    let mut sel = default;
     let mut ticks = 0u32;
     let mut shown_prev = u32::MAX;
     let mut counting = true;
     loop {
         let remaining = if counting { TIMEOUT_S.saturating_sub(ticks / TICKS_PER_S) } else { 0 };
         if counting && remaining == 0 {
-            return ENTRIES[0];
+            return ENTRIES[default];
         }
         if remaining != shown_prev {
             render(sel, remaining, sec);

--- a/nonos-bootloader/src/entry/boot.rs
+++ b/nonos-bootloader/src/entry/boot.rs
@@ -19,7 +19,8 @@ use super::init::init_boot_services;
 use super::mode::select_security_mode;
 use super::pipeline::run_verified_boot;
 use nonos_boot::boot::{
-    initialize_zk_replay_protection, run_hardware_discovery, run_security_checks, run_uefi_init,
+    enforce_policy, initialize_zk_replay_protection, run_hardware_discovery, run_security_checks,
+    run_uefi_init,
 };
 use nonos_boot::display::{draw_status_line, init_boot_screen};
 use uefi::prelude::*;
@@ -35,6 +36,7 @@ pub fn boot_entry(_handle: Handle, mut st: SystemTable<Boot>) -> Status {
         Ok(mode) => mode,
         Err(status) => return status,
     };
+    enforce_policy(&security, &mut st, gop, security_mode);
     if gop {
         init_boot_screen();
         draw_status_line(security.secure_boot_enabled, security.measured_boot_active, false);

--- a/nonos-bootloader/src/security/enforce/core.rs
+++ b/nonos-bootloader/src/security/enforce/core.rs
@@ -24,16 +24,35 @@ use super::policy::{EnforcementResult, SecurityPolicy};
 use super::requirements::{enforce_crypto_health, enforce_keys_loaded};
 use crate::display::display_enforcement_result;
 use crate::log::logger::log_info;
+use crate::menu::SecurityMode;
 use crate::security::types::SecurityContext;
+
+fn policy_for_mode(mode: SecurityMode) -> SecurityPolicy {
+    match mode {
+        SecurityMode::Development => SecurityPolicy::Development,
+        SecurityMode::Standard | SecurityMode::SafeMode | SecurityMode::Recovery => {
+            SecurityPolicy::Standard
+        }
+        SecurityMode::Hardened | SecurityMode::NetworkIsolated => SecurityPolicy::Hardened,
+    }
+}
 
 pub fn enforce_security_policy(
     ctx: &SecurityContext,
     system_table: &mut SystemTable<Boot>,
+    mode: SecurityMode,
 ) -> EnforcementResult {
-    let policy = SecurityPolicy::from_build();
+    // The compile-time policy is a floor that the menu can only raise, never
+    // lower, so a console operator cannot downgrade a hardened image.
+    let floor = SecurityPolicy::from_build();
+    let requested = policy_for_mode(mode);
+    let policy = floor.stricter(requested);
     let mut result = EnforcementResult::new(policy);
 
-    log_info("enforce", &format!("policy: {:?}", policy));
+    log_info(
+        "enforce",
+        &format!("policy: {:?} (build floor {:?}, menu {:?})", policy, floor, requested),
+    );
 
     enforce_crypto_health(ctx, &mut result);
     enforce_keys_loaded(ctx, &mut result);

--- a/nonos-bootloader/src/security/enforce/policy/types.rs
+++ b/nonos-bootloader/src/security/enforce/policy/types.rs
@@ -50,4 +50,20 @@ impl SecurityPolicy {
             );
         }
     }
+
+    pub fn level(self) -> u8 {
+        match self {
+            SecurityPolicy::Development => 0,
+            SecurityPolicy::Standard => 1,
+            SecurityPolicy::Hardened => 2,
+        }
+    }
+
+    pub fn stricter(self, other: SecurityPolicy) -> SecurityPolicy {
+        if other.level() > self.level() {
+            other
+        } else {
+            self
+        }
+    }
 }


### PR DESCRIPTION
Enforcement previously used only the compile-time policy, so the menu's Hardened/Standard selection did nothing. The menu now drives the runtime policy, bounded so it can only raise it above the compile-time floor (a console operator cannot downgrade a hardened image).

- Each menu mode maps to a policy: Hardened and Air-Gapped to Hardened; Standard, Safe and Recovery to Standard; Development only via the explicit dev override.
- Effective policy = stricter(build floor, menu choice).
- Enforcement moves to after the menu so the choice is known.
- A hands-off boot defaults to the build floor (always satisfiable); Hardened is a deliberate selection that mandates Secure Boot + TPM and halts without them.

Proven under swtpm: default boot logs `policy: Standard (build floor Standard, menu Standard)` and boots; selecting Hardened on a Standard build raises enforcement to Hardened and halts when Secure Boot is absent.