### PR TITLE
Kernel/crypto trust-boundary hardening + IOMMU S1 (prod-readiness audit)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,7 @@ microkernel-core = [
   "sched",
   "sha3",
   "crypto-ed25519-int",
+  "nonos-arch-iommu",
 ]
 
 # Runtime baseline: core + the three live capsule embeds.

--- a/src/arch/x86_64/acpi/parser/init.rs
+++ b/src/arch/x86_64/acpi/parser/init.rs
@@ -18,7 +18,7 @@ use core::sync::atomic::Ordering;
 
 use super::fadt::parse_fadt;
 use super::madt::parse_madt;
-use super::other::{parse_hpet, parse_mcfg, parse_srat};
+use super::other::{parse_dmar, parse_hpet, parse_mcfg, parse_srat};
 use super::rsdp::find_rsdp;
 use super::state::{TableRegistry, INITIALIZED, STATS, TABLES};
 use super::{parse_rsdt, parse_xsdt};
@@ -50,6 +50,7 @@ pub fn init() -> AcpiResult<()> {
     parse_hpet(&mut registry);
     parse_mcfg(&mut registry);
     parse_srat(&mut registry);
+    parse_dmar(&mut registry);
 
     {
         let mut stats = STATS.write();

--- a/src/arch/x86_64/acpi/parser/other/dmar.rs
+++ b/src/arch/x86_64/acpi/parser/other/dmar.rs
@@ -1,0 +1,73 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use core::mem;
+use core::ptr;
+
+use spin::Mutex;
+
+use super::super::state::TableRegistry;
+use crate::arch::x86_64::acpi::tables::{Dmar, Drhd, SdtHeader, SIG_DMAR};
+
+const DRHD_TYPE: u16 = 0;
+const MAX_REMAP_UNITS: usize = 8;
+
+static REMAP_UNIT_BASES: Mutex<heapless::Vec<u64, MAX_REMAP_UNITS>> = Mutex::new(heapless::Vec::new());
+
+pub fn parse_dmar(registry: &mut TableRegistry) {
+    let addr = match registry.tables.get(&SIG_DMAR) {
+        Some(&a) => a,
+        None => return,
+    };
+    let addr = match super::super::phys::directmap(addr) {
+        Some(v) => v,
+        None => return,
+    };
+
+    let mut found_drhd = false;
+
+    unsafe {
+        let header = ptr::read_volatile(addr as *const SdtHeader);
+        if !header.validate_checksum(addr as *const u8) {
+            return;
+        }
+
+        let mut cursor = addr + mem::size_of::<Dmar>() as u64;
+        let end = addr + header.length as u64;
+
+        while cursor + 4 <= end {
+            let kind = ptr::read_volatile(cursor as *const u16);
+            let length = ptr::read_volatile((cursor + 2) as *const u16);
+            if length < 4 || cursor + length as u64 > end {
+                break;
+            }
+            if kind == DRHD_TYPE && length as usize >= mem::size_of::<Drhd>() {
+                let drhd = ptr::read_volatile(cursor as *const Drhd);
+                if REMAP_UNIT_BASES.lock().push(drhd.register_base_address).is_ok() {
+                    found_drhd = true;
+                }
+            }
+            cursor += length as u64;
+        }
+    }
+
+    if !found_drhd {
+        return;
+    }
+
+    #[cfg(feature = "nonos-arch-iommu")]
+    crate::arch::x86_64::iommu::globals::set_present();
+}

--- a/src/arch/x86_64/acpi/tables/dmar_types.rs
+++ b/src/arch/x86_64/acpi/tables/dmar_types.rs
@@ -14,14 +14,24 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-mod dmar;
-mod hpet;
-mod mcfg;
-mod srat;
-mod srat_memory;
+use super::sdt::SdtHeader;
 
-pub use dmar::parse_dmar;
-pub use hpet::parse_hpet;
-pub use mcfg::parse_mcfg;
-pub use srat::parse_srat;
-pub use srat_memory::{parse_memory_affinity, parse_x2apic_affinity};
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct Dmar {
+    pub header: SdtHeader,
+    pub host_address_width: u8,
+    pub flags: u8,
+    pub reserved: [u8; 10],
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct Drhd {
+    pub kind: u16,
+    pub length: u16,
+    pub flags: u8,
+    pub reserved: u8,
+    pub segment: u16,
+    pub register_base_address: u64,
+}

--- a/src/arch/x86_64/acpi/tables/mod.rs
+++ b/src/arch/x86_64/acpi/tables/mod.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+mod dmar_types;
 pub mod fadt;
 pub mod hpet;
 pub mod madt;
@@ -33,6 +34,7 @@ mod srat_other;
 mod srat_processor;
 mod srat_types;
 
+pub use dmar_types::*;
 pub use fadt::*;
 pub use hpet::*;
 pub use madt::*;
@@ -58,6 +60,7 @@ pub const SIG_FADT: u32 = u32::from_le_bytes(*b"FACP");
 pub const SIG_MADT: u32 = u32::from_le_bytes(*b"APIC");
 pub const SIG_HPET: u32 = u32::from_le_bytes(*b"HPET");
 pub const SIG_MCFG: u32 = u32::from_le_bytes(*b"MCFG");
+pub const SIG_DMAR: u32 = u32::from_le_bytes(*b"DMAR");
 pub const SIG_SRAT: u32 = u32::from_le_bytes(*b"SRAT");
 pub const SIG_SLIT: u32 = u32::from_le_bytes(*b"SLIT");
 pub const SIG_DSDT: u32 = u32::from_le_bytes(*b"DSDT");

--- a/src/arch/x86_64/iommu/globals/mod.rs
+++ b/src/arch/x86_64/iommu/globals/mod.rs
@@ -16,7 +16,9 @@
 
 mod allocate_domain_id;
 mod is_present;
+mod set_present;
 pub(super) mod state;
 
 pub use allocate_domain_id::allocate_domain_id;
 pub use is_present::is_present;
+pub use set_present::set_present;

--- a/src/arch/x86_64/iommu/globals/set_present.rs
+++ b/src/arch/x86_64/iommu/globals/set_present.rs
@@ -14,14 +14,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-mod dmar;
-mod hpet;
-mod mcfg;
-mod srat;
-mod srat_memory;
+use core::sync::atomic::Ordering;
 
-pub use dmar::parse_dmar;
-pub use hpet::parse_hpet;
-pub use mcfg::parse_mcfg;
-pub use srat::parse_srat;
-pub use srat_memory::{parse_memory_affinity, parse_x2apic_affinity};
+use super::state::DMAR_PRESENT;
+
+pub fn set_present() {
+    DMAR_PRESENT.store(true, Ordering::Release);
+}

--- a/src/crypto/core/api/init.rs
+++ b/src/crypto/core/api/init.rs
@@ -18,13 +18,18 @@ use crate::crypto::kernel_keys;
 use crate::crypto::util::rng;
 
 pub fn init_crypto_subsystem() -> Result<(), &'static str> {
-    let _ = rng::init_rng();
+    if rng::init_rng().is_err() {
+        return Err("crypto: init_rng failed, entropy unavailable");
+    }
     kernel_keys::init();
     Ok(())
 }
 
 pub fn init() {
-    let _ = rng::init_rng();
+    if rng::init_rng().is_err() {
+        crate::sys::serial::println(b"[FATAL] crypto: init_rng failed, entropy unavailable");
+        crate::arch::halt_loop();
+    }
     kernel_keys::init();
 }
 

--- a/src/crypto/util/rng/api.rs
+++ b/src/crypto/util/rng/api.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use super::global::{fill_random_bytes, random_u64, random_u64_secure};
+use super::global::{fill_random_bytes, random_u64_secure};
 
 #[inline]
 pub fn fill_bytes(buffer: &mut [u8]) {
@@ -23,5 +23,8 @@ pub fn fill_bytes(buffer: &mut [u8]) {
 
 #[inline]
 pub fn secure_random_u64() -> u64 {
-    random_u64_secure().unwrap_or_else(|_| random_u64())
+    match random_u64_secure() {
+        Ok(v) => v,
+        Err(e) => panic!("[RNG] secure entropy unavailable; refusing predictable output ({})", e.as_str()),
+    }
 }

--- a/src/elf/loader/core/relocate.rs
+++ b/src/elf/loader/core/relocate.rs
@@ -27,6 +27,7 @@ const DT_RELASZ: u64 = 8;
 const R_X86_64_RELATIVE: u64 = 8;
 const DYN_ENTRY: usize = 16;
 const RELA_ENTRY: usize = 24;
+const RELA_WRITE_SIZE: u64 = 8;
 
 fn rd_u64(bytes: &[u8], off: usize) -> u64 {
     u64::from_le_bytes([
@@ -79,6 +80,9 @@ pub(in crate::elf::loader::core) fn apply_relative_relocations(
         if r_info & 0xffff_ffff != R_X86_64_RELATIVE {
             continue;
         }
+        if !reloc_in_writable_load(elf_data, header, ph_count, r_offset)? {
+            return Err(ElfError::RelocationFailed);
+        }
         let va = VirtAddr::new(base_addr.as_u64().wrapping_add(r_offset));
         let value = base_addr.as_u64().wrapping_add(r_addend);
         let pa = translate_in_asid(target_asid, va).ok_or(ElfError::DynamicSectionError)?;
@@ -87,6 +91,30 @@ pub(in crate::elf::loader::core) fn apply_relative_relocations(
         }
     }
     Ok(())
+}
+
+fn reloc_in_writable_load(
+    elf_data: &[u8],
+    header: &ElfHeader,
+    ph_count: usize,
+    r_offset: u64,
+) -> Result<bool, ElfError> {
+    let Some(end) = r_offset.checked_add(RELA_WRITE_SIZE) else {
+        return Ok(false);
+    };
+    for index in 0..ph_count {
+        let ph = parse_program_header_at(elf_data, header, index)?;
+        if ph.p_type != phdr_type::PT_LOAD || !ph.is_writable() {
+            continue;
+        }
+        let Some(seg_end) = ph.p_vaddr.checked_add(ph.p_memsz) else {
+            continue;
+        };
+        if r_offset >= ph.p_vaddr && end <= seg_end {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn vaddr_to_file_offset(

--- a/src/kernel_core/surface_registry/release/release_owned_by_pid.rs
+++ b/src/kernel_core/surface_registry/release/release_owned_by_pid.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::kernel_core::surface_registry::table::SLOTS;
+use crate::kernel_core::surface_registry::table::{bump_generation, SLOTS};
 use crate::kernel_core::surface_registry::types::{encode_handle, SLOT_CAP};
 
 pub fn release_owned_by_pid(pid: u32) -> u32 {
@@ -32,6 +32,7 @@ pub fn release_owned_by_pid(pid: u32) -> u32 {
             handles[count] = encode_handle(idx as u32, slot.epoch);
             count += 1;
             *entry = None;
+            bump_generation(idx);
         }
     }
     for handle in handles.iter().take(count) {

--- a/src/kernel_core/surface_registry/release/release_surface.rs
+++ b/src/kernel_core/surface_registry/release/release_surface.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::kernel_core::surface_registry::table::SLOTS;
+use crate::kernel_core::surface_registry::table::{bump_generation, SLOTS};
 use crate::kernel_core::surface_registry::types::{decode_handle, RegistryError, SurfaceHandle};
 
 pub fn release_surface(handle: SurfaceHandle) -> Result<u32, RegistryError> {
@@ -31,6 +31,7 @@ pub fn release_surface(handle: SurfaceHandle) -> Result<u32, RegistryError> {
     };
     if new_count == 0 {
         *entry = None;
+        bump_generation(idx as usize);
     }
     Ok(new_count)
 }

--- a/src/kernel_core/surface_registry/share/attach_surface.rs
+++ b/src/kernel_core/surface_registry/share/attach_surface.rs
@@ -44,6 +44,8 @@ pub fn attach_surface(
         let slot =
             slots.get(idx as usize).and_then(|s| s.as_ref()).ok_or(RegistryError::BadHandle)?;
         if slot.epoch != epoch {
+            #[cfg(feature = "dbg-ring")]
+            crate::log::dbg_ring::dbg_emit_2u64(0x5546_0001, handle, slot.epoch as u64);
             return Err(RegistryError::BadHandle);
         }
         if slot.owner_pid == receiver_pid && slot.owner_base_va != 0 {
@@ -62,6 +64,8 @@ pub fn attach_surface(
         let slot =
             slots.get_mut(idx as usize).and_then(|s| s.as_mut()).ok_or(RegistryError::BadHandle)?;
         if slot.epoch != epoch {
+            #[cfg(feature = "dbg-ring")]
+            crate::log::dbg_ring::dbg_emit_2u64(0x5546_0001, handle, slot.epoch as u64);
             return Err(RegistryError::BadHandle);
         }
         slot.refcount = slot.refcount.checked_add(1).ok_or(RegistryError::InvalidArg)?;

--- a/src/kernel_core/surface_registry/table.rs
+++ b/src/kernel_core/surface_registry/table.rs
@@ -15,6 +15,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicU32, Ordering};
 use spin::Mutex;
 
 use crate::memory::addr::PhysAddr;
@@ -43,6 +44,16 @@ pub(super) struct Slot {
 
 pub(super) static SLOTS: Mutex<[Option<Slot>; SLOT_CAP]> = Mutex::new([const { None }; SLOT_CAP]);
 
+pub(super) static SLOT_GENERATIONS: [AtomicU32; SLOT_CAP] =
+    [const { AtomicU32::new(1) }; SLOT_CAP];
+
+pub(super) fn bump_generation(idx: usize) {
+    let next = SLOT_GENERATIONS[idx].fetch_add(1, Ordering::AcqRel).wrapping_add(1);
+    if next == 0 {
+        SLOT_GENERATIONS[idx].store(1, Ordering::Release);
+    }
+}
+
 pub fn register_surface(
     owner_pid: u32,
     desc: &SurfaceDescriptor,
@@ -61,7 +72,7 @@ pub fn register_surface(
     let mut slots = SLOTS.lock();
     for (i, entry) in slots.iter_mut().enumerate() {
         if entry.is_none() {
-            let epoch = (i as u32).wrapping_add(1);
+            let epoch = SLOT_GENERATIONS[i].load(Ordering::Acquire);
             *entry = Some(Slot {
                 owner_pid,
                 epoch,
@@ -75,6 +86,8 @@ pub fn register_surface(
                 owner_base_va: desc.base_va,
                 frames,
             });
+            #[cfg(feature = "dbg-ring")]
+            crate::log::dbg_ring::dbg_emit_2u64(0x5546_0002, i as u64, epoch as u64);
             return Ok((i as u64, encode_handle(i as u32, epoch)));
         }
     }

--- a/src/memory/heap/manager/verify.rs
+++ b/src/memory/heap/manager/verify.rs
@@ -28,30 +28,32 @@ pub fn verify_heap_integrity() -> bool {
         return false;
     }
     let _sampled = KERNEL_HEAP.tracking_overflowed.load(core::sync::atomic::Ordering::Relaxed);
-    let allocated_ptrs = KERNEL_HEAP.allocated_ptrs.lock();
-    for &ptr_addr in allocated_ptrs.iter() {
-        if ptr_addr < layout::KHEAP_BASE as usize
-            || ptr_addr >= (layout::KHEAP_BASE + layout::KHEAP_SIZE) as usize
-        {
-            return false;
+    crate::arch::x86_64::idt::without_interrupts(|| {
+        let allocated_ptrs = KERNEL_HEAP.allocated_ptrs.lock();
+        for &ptr_addr in allocated_ptrs.iter() {
+            if ptr_addr < layout::KHEAP_BASE as usize
+                || ptr_addr >= (layout::KHEAP_BASE + layout::KHEAP_SIZE) as usize
+            {
+                return false;
+            }
+            unsafe {
+                let header_size = mem::size_of::<AllocationHeader>();
+                let header_ptr = (ptr_addr - header_size) as *const AllocationHeader;
+                let header = ptr::read_volatile(header_ptr);
+                if !header.is_valid() {
+                    return false;
+                }
+                let canary_ptr = (ptr_addr + header.canary_offset) as *const u64;
+                let canary = ptr::read_volatile(canary_ptr);
+                if canary != KERNEL_HEAP.canary_value {
+                    return false;
+                }
+                let current_time = get_timestamp();
+                if current_time < header.allocated_at {
+                    return false;
+                }
+            }
         }
-        unsafe {
-            let header_size = mem::size_of::<AllocationHeader>();
-            let header_ptr = (ptr_addr - header_size) as *const AllocationHeader;
-            let header = ptr::read_volatile(header_ptr);
-            if !header.is_valid() {
-                return false;
-            }
-            let canary_ptr = (ptr_addr + header.canary_offset) as *const u64;
-            let canary = ptr::read_volatile(canary_ptr);
-            if canary != KERNEL_HEAP.canary_value {
-                return false;
-            }
-            let current_time = get_timestamp();
-            if current_time < header.allocated_at {
-                return false;
-            }
-        }
-    }
-    true
+        true
+    })
 }

--- a/src/memory/heap/manager/verify.rs
+++ b/src/memory/heap/manager/verify.rs
@@ -27,6 +27,7 @@ pub fn verify_heap_integrity() -> bool {
     if heap_size == 0 {
         return false;
     }
+    let _sampled = KERNEL_HEAP.tracking_overflowed.load(core::sync::atomic::Ordering::Relaxed);
     let allocated_ptrs = KERNEL_HEAP.allocated_ptrs.lock();
     for &ptr_addr in allocated_ptrs.iter() {
         if ptr_addr < layout::KHEAP_BASE as usize

--- a/src/memory/heap/types/alloc_impl.rs
+++ b/src/memory/heap/types/alloc_impl.rs
@@ -62,6 +62,12 @@ pub(super) unsafe fn alloc_impl(allocator: &SecureHeapAllocator, layout: Layout)
 
         super::super::manager::HEAP_STATS.record_allocation(layout.size());
 
+        crate::arch::x86_64::idt::without_interrupts(|| {
+            if allocator.allocated_ptrs.lock().insert(data_ptr as usize).is_err() {
+                allocator.tracking_overflowed.store(true, Ordering::Relaxed);
+            }
+        });
+
         if super::super::manager::HEAP_ZERO_ON_ALLOC.load(Ordering::Relaxed) {
             ptr::write_bytes(data_ptr, 0, layout.size());
         }

--- a/src/memory/heap/types/allocator.rs
+++ b/src/memory/heap/types/allocator.rs
@@ -15,14 +15,17 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::super::constants::CANARY_VALUE;
-use alloc::collections::BTreeSet;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use heapless::FnvIndexSet;
 use linked_list_allocator::LockedHeap;
 use spin::Mutex;
 
+pub const TRACK_CAPACITY: usize = 8192;
+
 pub struct SecureHeapAllocator {
     pub inner: LockedHeap,
-    pub allocated_ptrs: Mutex<BTreeSet<usize>>,
+    pub allocated_ptrs: Mutex<FnvIndexSet<usize, TRACK_CAPACITY>>,
+    pub tracking_overflowed: AtomicBool,
     pub canary_value: u64,
     pub initialized: AtomicBool,
     pub heap_size: AtomicUsize,
@@ -32,7 +35,8 @@ impl SecureHeapAllocator {
     pub const fn new() -> Self {
         Self {
             inner: LockedHeap::empty(),
-            allocated_ptrs: Mutex::new(BTreeSet::new()),
+            allocated_ptrs: Mutex::new(FnvIndexSet::new()),
+            tracking_overflowed: AtomicBool::new(false),
             canary_value: CANARY_VALUE,
             initialized: AtomicBool::new(false),
             heap_size: AtomicUsize::new(0),

--- a/src/memory/heap/types/dealloc_impl.rs
+++ b/src/memory/heap/types/dealloc_impl.rs
@@ -58,6 +58,10 @@ pub(super) unsafe fn dealloc_impl(allocator: &SecureHeapAllocator, ptr: *mut u8,
             return;
         }
 
+        crate::arch::x86_64::idt::without_interrupts(|| {
+            allocator.allocated_ptrs.lock().remove(&(ptr as usize));
+        });
+
         if super::super::manager::HEAP_ZERO_ON_FREE.load(Ordering::Relaxed) {
             ptr::write_bytes(ptr, 0, layout.size());
         }

--- a/src/security/crypto/mod.rs
+++ b/src/security/crypto/mod.rs
@@ -36,7 +36,7 @@ pub use constant_time::{
 
 pub use random::{
     fill_random, fill_random_bytes, init as random_init, secure_random_u32, secure_random_u64,
-    secure_random_u8,
+    secure_random_u8, try_fill_random,
 };
 
 pub use trusted_keys::{

--- a/src/security/crypto/random.rs
+++ b/src/security/crypto/random.rs
@@ -40,10 +40,9 @@ pub fn init() -> Result<(), &'static str> {
 }
 
 /* DEV NOTES eK@nonos.systems
-   Secure random generation with multiple entropy source fallbacks: RDRAND, RDSEED, VirtIO RNG.
-   Uses TSC-based PRNG as last resort fallback to prevent system panic if no hardware RNG is
-   available. The TSC fallback provides reasonable entropy for non-cryptographic uses but callers
-   requiring cryptographic randomness should use try_secure_random_u64() and handle errors.
+   Secure random generation from hardware entropy sources: RDRAND, RDSEED, VirtIO RNG.
+   Returns cryptographic entropy or panics if secure entropy is unavailable (fail-closed).
+   For error handling, use try_secure_random_u64() instead.
 */
 pub fn secure_random_u64() -> u64 {
     match try_secure_random_u64() {

--- a/src/security/crypto/random.rs
+++ b/src/security/crypto/random.rs
@@ -51,9 +51,8 @@ pub fn secure_random_u64() -> u64 {
             consume_entropy(64);
             v
         }
-        Err(_) => {
-            crate::log::warn!("[RNG] No hardware entropy source, using TSC-based fallback");
-            tsc_fallback_random()
+        Err(e) => {
+            panic!("[RNG] secure entropy unavailable; refusing predictable output ({})", e)
         }
     }
 }
@@ -80,6 +79,7 @@ pub fn try_secure_random_u64() -> Result<u64, &'static str> {
     Err("No hardware entropy source available")
 }
 
+#[allow(dead_code)]
 fn tsc_fallback_random() -> u64 {
     use core::sync::atomic::{AtomicU64, Ordering};
     static STATE: AtomicU64 = AtomicU64::new(0x853c49e6748fea9b);
@@ -132,6 +132,19 @@ pub fn fill_random(buf: &mut [u8]) {
         buf[off..off + take].copy_from_slice(&chunk[..take]);
         off += take;
     }
+}
+
+pub fn try_fill_random(buf: &mut [u8]) -> Result<(), &'static str> {
+    let mut off = 0;
+    while off < buf.len() {
+        let v = try_secure_random_u64()?;
+        consume_entropy(64);
+        let chunk = v.to_le_bytes();
+        let take = core::cmp::min(buf.len() - off, chunk.len());
+        buf[off..off + take].copy_from_slice(&chunk[..take]);
+        off += take;
+    }
+    Ok(())
 }
 
 pub fn secure_random_u32() -> u32 {

--- a/src/syscall/dispatch/crypto/random.rs
+++ b/src/syscall/dispatch/crypto/random.rs
@@ -40,10 +40,10 @@ pub fn handle_crypto_random(buf: u64, len: u64) -> SyscallResult {
         Ok(n) if n == len as usize => deliver(buf, &buffer, len),
         Ok(_) => errno(5),
         Err(e) if is_caller_error(&e) => map_entropy_error(e),
-        Err(_) => {
-            crate::security::crypto::random::fill_random(&mut buffer);
-            deliver(buf, &buffer, len)
-        }
+        Err(_) => match crate::security::crypto::random::try_fill_random(&mut buffer) {
+            Ok(()) => deliver(buf, &buffer, len),
+            Err(_) => errno(5),
+        },
     }
 }
 


### PR DESCRIPTION
## Summary

Security remediation from the 2026-07-03 production-readiness audit. Fixes six confirmed trust-boundary / correctness findings in the kernel and crypto subsystems, plus stage 1 of the IOMMU bring-up. Every fix is surgical and fails closed.

| Finding | Fix |
|---|---|
| **P1-a** — ELF relocation writes were bounded only by "mapped somewhere in the ASID", giving a malicious capsule an arbitrary-kernel-write primitive | Bound each relocation write to a writable `PT_LOAD` segment of the loading image; reject out-of-range/overflow fail-closed (`elf/loader/core/relocate.rs`) |
| **P1-b** — `security/crypto` CSPRNG silently fell back to a fixed-seed TSC PRNG when hardware entropy was unavailable, feeding predictable bytes to keys/nonces | Secure path now panics (fail-closed); syscall path returns an error instead of predictable bytes; the TSC fallback is retained but has no live caller |
| **P1-b-ext** (discovered during this work) — a second RNG tree had the same footgun | Fail-closed the exported duplicate `crypto::core::api::init` (was swallowing the RNG-init error before generating the kernel root key) and made `crypto::util::rng::secure_random_u64` fail closed instead of silently degrading |
| **P1-c** — surface handles were deterministic (`idx+1`), so a reaped slot re-minted an identical handle → use-after-free painted to screen | Persistent per-slot generation counter, bumped on free; existing epoch check now rejects stale handles (`kernel_core/surface_registry`) |
| **P1-d** — `verify_heap_integrity` walked a set that was never populated, so it always returned "verified" | Populate the tracking set via a fixed-capacity `heapless::FnvIndexSet` (no allocator re-entrancy) under `without_interrupts`; made the read side IRQ-safe |
| **P0-2 (S1)** — IOMMU/VT-d fully inert (`DMAR_PRESENT` hard-false, feature in no profile) | Parse the ACPI DMAR table, arm `DMAR_PRESENT` only after a checksum+DRHD-validated parse, and enable `nonos-arch-iommu` in `microkernel-core`. **Stage 1 only** — see disclosures |

## Verification

- `make nonos-mk-check` passes on every commit.
- Full production build clean (`nonos-mk-*-prod`, `NONOS_DEV=1`): core + production + IOMMU feature + signed capsule embed.
- Clean live desktop boot under QEMU/hvf: capsules attested and spawned at CPL=3, `[INIT] Capsules spawned`, zero panics / `[FATAL]` / `HEAP-GUARD` across the full bring-up. The two always-on hot paths (P1-d allocator tracking, P1-b crypto init) are runtime-exercised with no deadlock or fatal halt.
- Desktop renders correctly (wallpaper, live menubar, app dock) — no GUI regression.
- Each commit was independently code-reviewed; two required and received follow-up fixes (P1-d read-side IRQ-safety; a stale P1-b comment). A whole-branch review returned merge-ready after the items below.

## Disclosures

- **IOMMU is Stage 1 only.** Translation is still inert — the DMA broker continues to return raw host-physical addresses; presence is merely armed. Real translation and per-device isolation (S2–S5) are a separate arc (design: `docs/superpowers/specs/2026-07-05-iommu-vtd-translation-s2-s5-design.md`). Isolation-enforcement proof requires KVM (not provable on the macOS TCG/hvf host) and is deferred.
- **P1-d** heap-integrity verification is a bounded 8192-live-allocation sample (overflows during normal desktop operation) — a strict improvement over the prior vacuous check, not full coverage.
- **P1-b** completeness relies on the boot-time fail-closed `init_rng()` gate (`kernel_core/init/entry.rs`); residual TSC fallbacks in `crypto/util/rng/global/generate.rs` and the unused `init_rng_simple()` are dead-but-present and slated for a defense-in-depth follow-up.
- **Boot smoketest harnesses** are currently un-runnable due to a pre-existing `tests/` submodule ↔ Makefile target-name skew (`nonos-mk-<x>-test` vs `-prod`) — not introduced here; runtime verification above was a manual desktop boot rather than harness markers.

## Not in this PR

The audit's **P0-1** (TLS certificate CA-constraint / MITM) is intentionally **not** included here — it is owned by `feat/browser-p0-hardening`, which fixes the same finding with stronger verification (validated against a real bbc.com chain). This branch touches no browser code, so there is no overlap or conflict with that branch.
