### PR TITLE
stark: FRI low-degree test with a Fiat-Shamir transcript

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/crypto/stark/fri/domain.rs
+++ b/src/crypto/stark/fri/domain.rs
@@ -1,0 +1,32 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The evaluation domain: a multiplicative subgroup of size a power of two.
+
+use super::super::field::{Fp, P};
+
+/// A multiplicative generator of the Goldilocks field. Every nonzero element is
+/// a power of it, so `GENERATOR^((P-1)/2^k)` has order exactly `2^k`.
+const GENERATOR: u64 = 7;
+
+/// A primitive `2^log_n`-th root of unity. The returned `omega` generates the
+/// size-`2^log_n` subgroup used as the FRI evaluation domain: `omega^(2^log_n)`
+/// is one and `omega^(2^(log_n-1))` is minus one, so the domain is closed under
+/// negation, which is what the folding step requires. Valid for `log_n <= 32`,
+/// the two-adicity of this field.
+pub fn root_of_unity(log_n: u32) -> Fp {
+    Fp::from_u64(GENERATOR).pow((P - 1) >> log_n)
+}

--- a/src/crypto/stark/fri/fold.rs
+++ b/src/crypto/stark/fri/fold.rs
@@ -14,24 +14,26 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! The FRI folding step. A codeword of `f` over a domain `D` folds with a
-//! challenge into a codeword of a half-degree polynomial over `D` squared.
+//! The FRI folding step. A codeword of `f` on a domain `D = shift * {omega^i}`
+//! folds with a challenge into a codeword of a half-degree polynomial on the
+//! squared domain. The domain may be a coset (`shift != 1`), which is what the
+//! STARK needs so the low-degree test runs off the trace domain.
 
 use super::super::field::Fp;
 use alloc::vec::Vec;
 
-/// Fold `evals`, the values of `f` on the size-`n` domain `{omega^i}`, into the
-/// values of `f_beta` on the size-`n/2` domain `{omega^(2i)}`. Writing
-/// `f(x) = E(x^2) + x*O(x^2)`, the even and odd parts are recovered from the
-/// pair `(f(x), f(-x))` and recombined as `E + beta*O`. `inv2` is the inverse of
-/// two, passed in so it is computed once by the caller.
-pub(super) fn fold_layer(evals: &[Fp], beta: Fp, omega: Fp, inv2: Fp) -> Vec<Fp> {
+/// Fold `evals`, the values of `f` on the size-`n` domain `{shift*omega^i}`, into
+/// the values of `f_beta` on the size-`n/2` squared domain. Writing
+/// `f(x) = E(x^2) + x*O(x^2)`, the even and odd parts are recovered from the pair
+/// `(f(x), f(-x))` and recombined as `E + beta*O`. `inv2` is the inverse of two,
+/// passed in so it is computed once by the caller.
+pub(super) fn fold_layer(evals: &[Fp], beta: Fp, shift: Fp, omega: Fp, inv2: Fp) -> Vec<Fp> {
     let half = evals.len() / 2;
     let (lo, hi) = evals.split_at(half);
     let mut out = Vec::with_capacity(half);
-    // x walks the first half of the domain: omega^0, omega^1, ... The point
-    // paired with x is -x = omega^(i + n/2), which sits at `hi[i]`.
-    let mut x = Fp::ONE;
+    // x walks the first half of the domain: shift, shift*omega, ... The point
+    // paired with x is -x = shift*omega^(i + n/2), which sits at `hi[i]`.
+    let mut x = shift;
     for (a, b) in lo.iter().zip(hi.iter()) {
         let even = (*a + *b) * inv2;
         let odd = (*a - *b) * inv2 * x.inv();

--- a/src/crypto/stark/fri/fold.rs
+++ b/src/crypto/stark/fri/fold.rs
@@ -1,0 +1,42 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The FRI folding step. A codeword of `f` over a domain `D` folds with a
+//! challenge into a codeword of a half-degree polynomial over `D` squared.
+
+use super::super::field::Fp;
+use alloc::vec::Vec;
+
+/// Fold `evals`, the values of `f` on the size-`n` domain `{omega^i}`, into the
+/// values of `f_beta` on the size-`n/2` domain `{omega^(2i)}`. Writing
+/// `f(x) = E(x^2) + x*O(x^2)`, the even and odd parts are recovered from the
+/// pair `(f(x), f(-x))` and recombined as `E + beta*O`. `inv2` is the inverse of
+/// two, passed in so it is computed once by the caller.
+pub(super) fn fold_layer(evals: &[Fp], beta: Fp, omega: Fp, inv2: Fp) -> Vec<Fp> {
+    let half = evals.len() / 2;
+    let (lo, hi) = evals.split_at(half);
+    let mut out = Vec::with_capacity(half);
+    // x walks the first half of the domain: omega^0, omega^1, ... The point
+    // paired with x is -x = omega^(i + n/2), which sits at `hi[i]`.
+    let mut x = Fp::ONE;
+    for (a, b) in lo.iter().zip(hi.iter()) {
+        let even = (*a + *b) * inv2;
+        let odd = (*a - *b) * inv2 * x.inv();
+        out.push(even + beta * odd);
+        x = x * omega;
+    }
+    out
+}

--- a/src/crypto/stark/fri/mod.rs
+++ b/src/crypto/stark/fri/mod.rs
@@ -1,0 +1,30 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The FRI low-degree test: a transparent, post-quantum argument that a
+//! committed codeword is close to a low-degree polynomial. It is the engine a
+//! STARK uses to check the trace and its constraints without a trusted setup.
+
+mod domain;
+mod fold;
+mod prove;
+mod types;
+mod verify;
+
+pub use domain::root_of_unity;
+pub use prove::fri_prove;
+pub use types::{FriProof, LayerOpening, QueryProof};
+pub use verify::fri_verify;

--- a/src/crypto/stark/fri/prove.rs
+++ b/src/crypto/stark/fri/prove.rs
@@ -1,0 +1,86 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The FRI prover: commit each layer, fold under a Fiat-Shamir challenge, then
+//! open the sampled query positions.
+
+use super::super::field::Fp;
+use super::super::merkle::MerkleTree;
+use super::super::transcript::Transcript;
+use super::domain::root_of_unity;
+use super::fold::fold_layer;
+use super::types::{FriProof, LayerOpening, QueryProof};
+use alloc::vec::Vec;
+
+/// Prove that `codeword`, the evaluations of a polynomial over the size-`2^k`
+/// subgroup domain, has degree below `2^k / 2^log_blowup`. Folds `k - log_blowup`
+/// times down to a constant layer of `2^log_blowup` values, then answers
+/// `n_queries` sampled positions. `codeword.len()` must be a power of two.
+pub fn fri_prove(codeword: &[Fp], log_blowup: u32, n_queries: usize) -> FriProof {
+    let n = codeword.len();
+    let log_n = n.trailing_zeros();
+    let n_folds = (log_n - log_blowup) as usize;
+    let base_omega = root_of_unity(log_n);
+    let inv2 = Fp::from_u64(2).inv();
+
+    let mut transcript = Transcript::new(b"NONOS-STARK-FRI");
+    let mut layers: Vec<Vec<Fp>> = Vec::with_capacity(n_folds);
+    let mut trees: Vec<MerkleTree> = Vec::with_capacity(n_folds);
+    let mut roots: Vec<[u8; 32]> = Vec::with_capacity(n_folds);
+
+    let mut current = codeword.to_vec();
+    let mut omega = base_omega;
+    for _ in 0..n_folds {
+        let tree = MerkleTree::commit(&current);
+        let root = tree.root();
+        transcript.absorb_digest(&root);
+        let beta = transcript.challenge_fp();
+        let next = fold_layer(&current, beta, omega, inv2);
+        layers.push(current);
+        trees.push(tree);
+        roots.push(root);
+        current = next;
+        omega = omega.square();
+    }
+
+    // The final layer is small and constant for a genuine low-degree input; it
+    // is sent in full and bound into the transcript before the queries.
+    let final_layer = current;
+    for value in &final_layer {
+        transcript.absorb_fp(*value);
+    }
+
+    let mut queries: Vec<QueryProof> = Vec::with_capacity(n_queries);
+    for _ in 0..n_queries {
+        let q = transcript.challenge_index(n);
+        let mut opened: Vec<LayerOpening> = Vec::with_capacity(n_folds);
+        for m in 0..n_folds {
+            let half = n >> (m + 1);
+            let i = q % half;
+            let layer = &layers[m];
+            let tree = &trees[m];
+            opened.push(LayerOpening {
+                a: layer[i],
+                a_path: tree.open(i),
+                b: layer[i + half],
+                b_path: tree.open(i + half),
+            });
+        }
+        queries.push(QueryProof { layers: opened });
+    }
+
+    FriProof { roots, final_layer, queries }
+}

--- a/src/crypto/stark/fri/prove.rs
+++ b/src/crypto/stark/fri/prove.rs
@@ -28,8 +28,9 @@ use alloc::vec::Vec;
 /// Prove that `codeword`, the evaluations of a polynomial over the size-`2^k`
 /// subgroup domain, has degree below `2^k / 2^log_blowup`. Folds `k - log_blowup`
 /// times down to a constant layer of `2^log_blowup` values, then answers
-/// `n_queries` sampled positions. `codeword.len()` must be a power of two.
-pub fn fri_prove(codeword: &[Fp], log_blowup: u32, n_queries: usize) -> FriProof {
+/// `n_queries` sampled positions. The domain is `shift * {omega^i}`; pass
+/// `shift = Fp::ONE` for the raw subgroup. `codeword.len()` must be a power of two.
+pub fn fri_prove(codeword: &[Fp], shift: Fp, log_blowup: u32, n_queries: usize) -> FriProof {
     let n = codeword.len();
     let log_n = n.trailing_zeros();
     let n_folds = (log_n - log_blowup) as usize;
@@ -43,17 +44,19 @@ pub fn fri_prove(codeword: &[Fp], log_blowup: u32, n_queries: usize) -> FriProof
 
     let mut current = codeword.to_vec();
     let mut omega = base_omega;
+    let mut coset = shift;
     for _ in 0..n_folds {
         let tree = MerkleTree::commit(&current);
         let root = tree.root();
         transcript.absorb_digest(&root);
         let beta = transcript.challenge_fp();
-        let next = fold_layer(&current, beta, omega, inv2);
+        let next = fold_layer(&current, beta, coset, omega, inv2);
         layers.push(current);
         trees.push(tree);
         roots.push(root);
         current = next;
         omega = omega.square();
+        coset = coset.square();
     }
 
     // The final layer is small and constant for a genuine low-degree input; it

--- a/src/crypto/stark/fri/types.rs
+++ b/src/crypto/stark/fri/types.rs
@@ -1,0 +1,42 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The FRI proof: commitment roots, the small final layer sent in full, and the
+//! opened query positions that bind consecutive layers together.
+
+use super::super::field::Fp;
+use alloc::vec::Vec;
+
+/// One layer's contribution to a query: the value at the queried position `i`
+/// and at its negation `i + n/2`, each with a Merkle path to that layer's root.
+pub struct LayerOpening {
+    pub a: Fp,
+    pub a_path: Vec<[u8; 32]>,
+    pub b: Fp,
+    pub b_path: Vec<[u8; 32]>,
+}
+
+/// The openings a single query induces across every folded layer.
+pub struct QueryProof {
+    pub layers: Vec<LayerOpening>,
+}
+
+/// A complete FRI low-degree proof.
+pub struct FriProof {
+    pub roots: Vec<[u8; 32]>,
+    pub final_layer: Vec<Fp>,
+    pub queries: Vec<QueryProof>,
+}

--- a/src/crypto/stark/fri/verify.rs
+++ b/src/crypto/stark/fri/verify.rs
@@ -29,7 +29,13 @@ use alloc::vec::Vec;
 /// Verify a FRI proof for a size-`2^log_n` domain and blowup `2^log_blowup`.
 /// Returns `true` only if every structural, Merkle, folding, and low-degree
 /// check passes for all `n_queries` sampled positions.
-pub fn fri_verify(proof: &FriProof, log_n: u32, log_blowup: u32, n_queries: usize) -> bool {
+pub fn fri_verify(
+    proof: &FriProof,
+    shift: Fp,
+    log_n: u32,
+    log_blowup: u32,
+    n_queries: usize,
+) -> bool {
     let n = 1usize << log_n;
     let blowup = 1usize << log_blowup;
     let n_folds = (log_n - log_blowup) as usize;
@@ -79,8 +85,9 @@ pub fn fri_verify(proof: &FriProof, log_n: u32, log_blowup: u32, n_queries: usiz
                 return false;
             }
 
-            // Recompute the fold at the queried point x = omega_m^i.
-            let x = base_omega.pow((i as u64) << m);
+            // Recompute the fold at the queried point of layer m, which is
+            // `(shift * omega^i)^(2^m)` on the squared coset.
+            let x = (shift * base_omega.pow(i as u64)).pow(1u64 << m);
             let even = (op.a + op.b) * inv2;
             let odd = (op.a - op.b) * inv2 * x.inv();
             let folded = even + *beta * odd;

--- a/src/crypto/stark/fri/verify.rs
+++ b/src/crypto/stark/fri/verify.rs
@@ -1,0 +1,103 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The FRI verifier. It never trusts the prover: it recomputes the transcript,
+//! checks the final layer is constant, and for each sampled query re-derives the
+//! fold and checks it against the next committed layer, every value bound by a
+//! Merkle path. It only reads the proof and never panics.
+
+use super::super::field::Fp;
+use super::super::merkle::verify_path;
+use super::super::transcript::Transcript;
+use super::domain::root_of_unity;
+use super::types::FriProof;
+use alloc::vec::Vec;
+
+/// Verify a FRI proof for a size-`2^log_n` domain and blowup `2^log_blowup`.
+/// Returns `true` only if every structural, Merkle, folding, and low-degree
+/// check passes for all `n_queries` sampled positions.
+pub fn fri_verify(proof: &FriProof, log_n: u32, log_blowup: u32, n_queries: usize) -> bool {
+    let n = 1usize << log_n;
+    let blowup = 1usize << log_blowup;
+    let n_folds = (log_n - log_blowup) as usize;
+
+    if proof.roots.len() != n_folds
+        || proof.final_layer.len() != blowup
+        || proof.queries.len() != n_queries
+    {
+        return false;
+    }
+
+    let base_omega = root_of_unity(log_n);
+    let inv2 = Fp::from_u64(2).inv();
+
+    // Rebuild the transcript exactly as the prover did: absorb each root and
+    // draw its fold challenge, then absorb the final layer.
+    let mut transcript = Transcript::new(b"NONOS-STARK-FRI");
+    let mut betas: Vec<Fp> = Vec::with_capacity(n_folds);
+    for root in &proof.roots {
+        transcript.absorb_digest(root);
+        betas.push(transcript.challenge_fp());
+    }
+
+    // The low-degree conclusion: the final layer must be a single constant.
+    let final_value = proof.final_layer[0];
+    for value in &proof.final_layer {
+        if *value != final_value {
+            return false;
+        }
+        transcript.absorb_fp(*value);
+    }
+
+    for qp in &proof.queries {
+        if qp.layers.len() != n_folds {
+            return false;
+        }
+        let q = transcript.challenge_index(n);
+        for (m, beta) in betas.iter().enumerate() {
+            let half = n >> (m + 1);
+            let i = q % half;
+            let op = &qp.layers[m];
+
+            // Bind both opened points to this layer's commitment.
+            if !verify_path(&proof.roots[m], i, op.a, &op.a_path)
+                || !verify_path(&proof.roots[m], i + half, op.b, &op.b_path)
+            {
+                return false;
+            }
+
+            // Recompute the fold at the queried point x = omega_m^i.
+            let x = base_omega.pow((i as u64) << m);
+            let even = (op.a + op.b) * inv2;
+            let odd = (op.a - op.b) * inv2 * x.inv();
+            let folded = even + *beta * odd;
+
+            // The fold must equal the value at the same index one layer up.
+            if m + 1 < n_folds {
+                let half_next = n >> (m + 2);
+                let next = &qp.layers[m + 1];
+                let expected = if i < half_next { next.a } else { next.b };
+                if folded != expected {
+                    return false;
+                }
+            } else if folded != final_value {
+                return false;
+            }
+        }
+    }
+
+    true
+}

--- a/src/crypto/stark/mod.rs
+++ b/src/crypto/stark/mod.rs
@@ -5,8 +5,11 @@
 
 //! Transparent, post-quantum STARK verification primitives. Hash-based and
 //! curve-free, so verification relies only on the strength of the hash. Built
-//! bottom up: the Goldilocks field, then a Merkle commitment over it.
+//! bottom up: the Goldilocks field, a Merkle commitment over it, polynomials,
+//! a Fiat-Shamir transcript, and the FRI low-degree test on top.
 
 pub mod field;
+pub mod fri;
 pub mod merkle;
 pub mod poly;
+pub mod transcript;

--- a/src/crypto/stark/transcript.rs
+++ b/src/crypto/stark/transcript.rs
@@ -1,0 +1,70 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! A Fiat-Shamir transcript over BLAKE3. Each absorb folds its input into a
+//! running 32-byte state under a domain tag; each challenge folds a tag in and
+//! reads the fresh state. A prover and verifier that absorb the same sequence
+//! draw the same challenges, which is what turns the interactive FRI protocol
+//! into a non-interactive one, sound in the random-oracle model.
+
+use super::field::Fp;
+use crate::crypto::hash::blake3_hash;
+use alloc::vec::Vec;
+
+pub struct Transcript {
+    state: [u8; 32],
+}
+
+impl Transcript {
+    pub fn new(label: &[u8]) -> Transcript {
+        Transcript { state: blake3_hash(label) }
+    }
+
+    fn mix(&mut self, tag: u8, data: &[u8]) {
+        let mut buf = Vec::with_capacity(1 + 32 + data.len());
+        buf.push(tag);
+        buf.extend_from_slice(&self.state);
+        buf.extend_from_slice(data);
+        self.state = blake3_hash(&buf);
+    }
+
+    /// Absorb a commitment root.
+    pub fn absorb_digest(&mut self, digest: &[u8; 32]) {
+        self.mix(0x01, digest);
+    }
+
+    /// Absorb a field element.
+    pub fn absorb_fp(&mut self, value: Fp) {
+        self.mix(0x02, &value.value().to_le_bytes());
+    }
+
+    fn squeeze_u64(&mut self, tag: u8) -> u64 {
+        self.mix(tag, &[]);
+        let s = &self.state;
+        u64::from_le_bytes([s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7]])
+    }
+
+    /// Draw a field-element challenge.
+    pub fn challenge_fp(&mut self) -> Fp {
+        Fp::from_u64(self.squeeze_u64(0x03))
+    }
+
+    /// Draw a query index in `[0, bound)`. `bound` is a power of two in FRI, so
+    /// masking is unbiased.
+    pub fn challenge_index(&mut self, bound: usize) -> usize {
+        (self.squeeze_u64(0x04) as usize) & (bound - 1)
+    }
+}

--- a/userland/stark_proofs/src/fri_tests.rs
+++ b/userland/stark_proofs/src/fri_tests.rs
@@ -35,13 +35,13 @@ fn xorshift(state: &mut u64) -> u64 {
 }
 
 /// Evaluate a random polynomial of degree below `d` over the size-`2^log_n`
-/// subgroup domain, giving a genuine low-degree codeword.
-fn low_degree_codeword(log_n: u32, d: usize, seed: u64) -> Vec<Fp> {
+/// domain `shift * {omega^i}`, giving a genuine low-degree codeword.
+fn low_degree_codeword(log_n: u32, d: usize, shift: Fp, seed: u64) -> Vec<Fp> {
     let n = 1usize << log_n;
     let omega = root_of_unity(log_n);
     let mut s = seed | 1;
     let coeffs: Vec<Fp> = (0..d).map(|_| Fp::from_u64(xorshift(&mut s))).collect();
-    let mut x = Fp::ONE;
+    let mut x = shift;
     let mut codeword = Vec::with_capacity(n);
     for _ in 0..n {
         codeword.push(eval(&coeffs, x));
@@ -72,18 +72,35 @@ fn the_domain_generator_has_the_right_order() {
 #[test]
 fn an_honest_low_degree_codeword_verifies() {
     let (log_n, log_blowup, degree, queries) = (5u32, 2u32, 8usize, 40usize);
-    let codeword = low_degree_codeword(log_n, degree, 0xABCD);
-    let proof = fri_prove(&codeword, log_blowup, queries);
-    assert!(fri_verify(&proof, log_n, log_blowup, queries), "an honest proof was rejected");
+    let codeword = low_degree_codeword(log_n, degree, Fp::ONE, 0xABCD);
+    let proof = fri_prove(&codeword, Fp::ONE, log_blowup, queries);
+    assert!(
+        fri_verify(&proof, Fp::ONE, log_n, log_blowup, queries),
+        "an honest proof was rejected"
+    );
+}
+
+#[test]
+fn an_honest_codeword_on_a_coset_verifies() {
+    // The STARK runs FRI on an LDE coset, not the raw subgroup. Folding must hold
+    // there too: evaluate a low-degree polynomial on shift * {omega^i} and prove.
+    let (log_n, log_blowup, degree, queries) = (6u32, 2u32, 8usize, 40usize);
+    let shift = Fp::from_u64(7);
+    let codeword = low_degree_codeword(log_n, degree, shift, 0xC05E7);
+    let proof = fri_prove(&codeword, shift, log_blowup, queries);
+    assert!(
+        fri_verify(&proof, shift, log_n, log_blowup, queries),
+        "an honest coset proof rejected"
+    );
 }
 
 #[test]
 fn honest_proofs_verify_across_sizes() {
     for (log_n, log_blowup, degree) in [(4u32, 1u32, 4usize), (6, 2, 8), (8, 3, 16)] {
-        let codeword = low_degree_codeword(log_n, degree, 0x1000 + log_n as u64);
-        let proof = fri_prove(&codeword, log_blowup, 32);
+        let codeword = low_degree_codeword(log_n, degree, Fp::ONE, 0x1000 + log_n as u64);
+        let proof = fri_prove(&codeword, Fp::ONE, log_blowup, 32);
         assert!(
-            fri_verify(&proof, log_n, log_blowup, 32),
+            fri_verify(&proof, Fp::ONE, log_n, log_blowup, 32),
             "honest proof at log_n {log_n} rejected"
         );
     }
@@ -95,8 +112,8 @@ fn a_high_degree_codeword_is_rejected() {
     // layer is not constant, so the low-degree check rejects it.
     let (log_n, log_blowup, queries) = (5u32, 2u32, 40usize);
     let codeword = random_codeword(log_n, 0x99);
-    let proof = fri_prove(&codeword, log_blowup, queries);
-    assert!(!fri_verify(&proof, log_n, log_blowup, queries), "a random codeword verified");
+    let proof = fri_prove(&codeword, Fp::ONE, log_blowup, queries);
+    assert!(!fri_verify(&proof, Fp::ONE, log_n, log_blowup, queries), "a random codeword verified");
 }
 
 #[test]
@@ -106,20 +123,26 @@ fn a_forged_constant_final_layer_is_rejected() {
     // longer land at the re-derived positions and the Merkle checks fail.
     let (log_n, log_blowup, queries) = (5u32, 2u32, 40usize);
     let codeword = random_codeword(log_n, 0x1357);
-    let mut proof = fri_prove(&codeword, log_blowup, queries);
+    let mut proof = fri_prove(&codeword, Fp::ONE, log_blowup, queries);
     let constant = proof.final_layer[0];
     for value in proof.final_layer.iter_mut() {
         *value = constant;
     }
-    assert!(!fri_verify(&proof, log_n, log_blowup, queries), "a forged constant final verified");
+    assert!(
+        !fri_verify(&proof, Fp::ONE, log_n, log_blowup, queries),
+        "a forged constant final verified"
+    );
 }
 
 #[test]
 fn a_tampered_opening_is_rejected() {
     // Corrupt one opened value. Its Merkle path no longer recomputes the root.
     let (log_n, log_blowup, queries) = (5u32, 2u32, 40usize);
-    let codeword = low_degree_codeword(log_n, 8, 0x2468);
-    let mut proof = fri_prove(&codeword, log_blowup, queries);
+    let codeword = low_degree_codeword(log_n, 8, Fp::ONE, 0x2468);
+    let mut proof = fri_prove(&codeword, Fp::ONE, log_blowup, queries);
     proof.queries[0].layers[0].a = proof.queries[0].layers[0].a + Fp::ONE;
-    assert!(!fri_verify(&proof, log_n, log_blowup, queries), "a tampered opening verified");
+    assert!(
+        !fri_verify(&proof, Fp::ONE, log_n, log_blowup, queries),
+        "a tampered opening verified"
+    );
 }

--- a/userland/stark_proofs/src/fri_tests.rs
+++ b/userland/stark_proofs/src/fri_tests.rs
@@ -1,0 +1,125 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::crypto::stark::field::Fp;
+use crate::crypto::stark::fri::{fri_prove, fri_verify, root_of_unity};
+use crate::crypto::stark::poly::eval;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+// FRI is the low-degree test at the heart of a STARK: it convinces a verifier
+// that a committed codeword is close to a low-degree polynomial, with no trusted
+// setup and hash-only cryptography. Completeness (honest low-degree codewords
+// pass) and soundness (high-degree codewords and forged proofs fail) are both
+// checked here against the real prover and verifier.
+
+fn xorshift(state: &mut u64) -> u64 {
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+    *state
+}
+
+/// Evaluate a random polynomial of degree below `d` over the size-`2^log_n`
+/// subgroup domain, giving a genuine low-degree codeword.
+fn low_degree_codeword(log_n: u32, d: usize, seed: u64) -> Vec<Fp> {
+    let n = 1usize << log_n;
+    let omega = root_of_unity(log_n);
+    let mut s = seed | 1;
+    let coeffs: Vec<Fp> = (0..d).map(|_| Fp::from_u64(xorshift(&mut s))).collect();
+    let mut x = Fp::ONE;
+    let mut codeword = Vec::with_capacity(n);
+    for _ in 0..n {
+        codeword.push(eval(&coeffs, x));
+        x = x * omega;
+    }
+    codeword
+}
+
+fn random_codeword(log_n: u32, seed: u64) -> Vec<Fp> {
+    let n = 1usize << log_n;
+    let mut s = seed | 1;
+    (0..n).map(|_| Fp::from_u64(xorshift(&mut s))).collect()
+}
+
+#[test]
+fn the_domain_generator_has_the_right_order() {
+    // omega must have order exactly 2^log_n: omega^n == 1 and omega^(n/2) == -1,
+    // which is what makes the domain closed under negation for folding.
+    let minus_one = Fp::ZERO - Fp::ONE;
+    for log_n in [2u32, 3, 5, 8, 10, 16] {
+        let n = 1u64 << log_n;
+        let omega = root_of_unity(log_n);
+        assert_eq!(omega.pow(n), Fp::ONE, "omega^n must be one");
+        assert_eq!(omega.pow(n / 2), minus_one, "omega^(n/2) must be minus one");
+    }
+}
+
+#[test]
+fn an_honest_low_degree_codeword_verifies() {
+    let (log_n, log_blowup, degree, queries) = (5u32, 2u32, 8usize, 40usize);
+    let codeword = low_degree_codeword(log_n, degree, 0xABCD);
+    let proof = fri_prove(&codeword, log_blowup, queries);
+    assert!(fri_verify(&proof, log_n, log_blowup, queries), "an honest proof was rejected");
+}
+
+#[test]
+fn honest_proofs_verify_across_sizes() {
+    for (log_n, log_blowup, degree) in [(4u32, 1u32, 4usize), (6, 2, 8), (8, 3, 16)] {
+        let codeword = low_degree_codeword(log_n, degree, 0x1000 + log_n as u64);
+        let proof = fri_prove(&codeword, log_blowup, 32);
+        assert!(
+            fri_verify(&proof, log_n, log_blowup, 32),
+            "honest proof at log_n {log_n} rejected"
+        );
+    }
+}
+
+#[test]
+fn a_high_degree_codeword_is_rejected() {
+    // A random codeword is far from any low-degree polynomial; its folded final
+    // layer is not constant, so the low-degree check rejects it.
+    let (log_n, log_blowup, queries) = (5u32, 2u32, 40usize);
+    let codeword = random_codeword(log_n, 0x99);
+    let proof = fri_prove(&codeword, log_blowup, queries);
+    assert!(!fri_verify(&proof, log_n, log_blowup, queries), "a random codeword verified");
+}
+
+#[test]
+fn a_forged_constant_final_layer_is_rejected() {
+    // Forge the final layer to a constant so the low-degree check passes. This
+    // changes the Fiat-Shamir transcript, so the pre-committed query openings no
+    // longer land at the re-derived positions and the Merkle checks fail.
+    let (log_n, log_blowup, queries) = (5u32, 2u32, 40usize);
+    let codeword = random_codeword(log_n, 0x1357);
+    let mut proof = fri_prove(&codeword, log_blowup, queries);
+    let constant = proof.final_layer[0];
+    for value in proof.final_layer.iter_mut() {
+        *value = constant;
+    }
+    assert!(!fri_verify(&proof, log_n, log_blowup, queries), "a forged constant final verified");
+}
+
+#[test]
+fn a_tampered_opening_is_rejected() {
+    // Corrupt one opened value. Its Merkle path no longer recomputes the root.
+    let (log_n, log_blowup, queries) = (5u32, 2u32, 40usize);
+    let codeword = low_degree_codeword(log_n, 8, 0x2468);
+    let mut proof = fri_prove(&codeword, log_blowup, queries);
+    proof.queries[0].layers[0].a = proof.queries[0].layers[0].a + Fp::ONE;
+    assert!(!fri_verify(&proof, log_n, log_blowup, queries), "a tampered opening verified");
+}

--- a/userland/stark_proofs/src/lib.rs
+++ b/userland/stark_proofs/src/lib.rs
@@ -9,6 +9,8 @@ pub mod crypto;
 #[cfg(test)]
 mod field_tests;
 #[cfg(test)]
+mod fri_tests;
+#[cfg(test)]
 mod merkle_tests;
 #[cfg(test)]
 mod poly_tests;

--- a/userland/stark_proofs/src/merkle_tests.rs
+++ b/userland/stark_proofs/src/merkle_tests.rs
@@ -92,6 +92,32 @@ fn a_tampered_path_or_root_is_rejected() {
 }
 
 #[test]
+fn a_path_of_the_wrong_length_is_rejected() {
+    // The verifier binds the path length to the leaf's depth through its final
+    // `idx == 0` check. A truncated path forges a shallower position; an
+    // over-long path overshoots the root. Both must fail, or a prover could open
+    // to a position it never committed.
+    let ls = leaves(64, 99);
+    let tree = MerkleTree::commit(&ls);
+    let root = tree.root();
+    for i in [0usize, 1, 9, 40, 63] {
+        let leaf = ls[i];
+        let path = tree.open(i);
+        assert!(verify_path(&root, i, leaf, &path));
+
+        // Drop the topmost sibling: the recomputation stops below the root.
+        let mut short = path.clone();
+        short.pop();
+        assert!(!verify_path(&root, i, leaf, &short), "a truncated path verified");
+
+        // Append a sibling: the recomputation runs one level past the root.
+        let mut long = path.clone();
+        long.push([0xABu8; 32]);
+        assert!(!verify_path(&root, i, leaf, &long), "an over-long path verified");
+    }
+}
+
+#[test]
 fn distinct_leaf_sets_give_distinct_roots() {
     // Binding: changing any leaf changes the root (collision would break BLAKE3).
     let a = MerkleTree::commit(&leaves(64, 1)).root();


### PR DESCRIPTION
Builds the FRI low-degree test on top of the field, Merkle, and polynomial layers. This is the engine a STARK uses to check a trace without a trusted setup, hash-only so verification stays post-quantum.

The prover commits each folded layer under a BLAKE3 transcript, folds down to a constant, and answers sampled query positions with Merkle openings that bind one layer to the next. The verifier recomputes the transcript, requires the final layer to be constant, and re-derives every fold while reading only the proof, so it never trusts the prover and never panics.

Host proofs against the real prover and verifier:
- completeness: honest low-degree codewords verify across domain sizes
- a high-degree codeword is rejected by the low-degree check
- a forged constant final layer is rejected by the Fiat-Shamir binding
- a tampered opening is rejected by the Merkle binding
- the domain generator has order exactly 2^k
- a Merkle opening of the wrong path length is rejected

Green locally: 19/19 stark_proofs tests, clippy -D warnings clean, and the kernel builds with the module wired in. One concern per file, mod.rs re-exports only.

Stacked on Stark-Proofs (#277).