### PR TITLE
stark: end-to-end STARK over a squaring AIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/crypto/stark/air/constraints.rs
+++ b/src/crypto/stark/air/constraints.rs
@@ -1,0 +1,50 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The AIR under proof: a squaring chain. The trace is a single column with
+//! `t[0] = seed` and `t[i+1] = t[i]^2`. Two constraints capture it: a transition
+//! `f(g*x) - f(x)^2 = 0` on every trace row but the last, and a boundary
+//! `f(1) - seed = 0` on the first. Both are turned into quotients here, in one
+//! function shared by prover and verifier so the algebra cannot drift.
+
+use super::super::field::Fp;
+
+pub(super) struct AirParams {
+    /// Log2 of the trace length.
+    pub log_t: u32,
+    /// The public boundary value at row zero.
+    pub seed: Fp,
+    /// The last trace-domain point `g^(T-1)`, excluded from the transition.
+    pub g_last: Fp,
+}
+
+/// The transition and boundary quotients at a coset point `x`, given the trace
+/// value there (`f_x`) and one row ahead (`f_gx`). A quotient is a polynomial
+/// exactly when its constraint holds across the trace domain, which is what the
+/// low-degree test then checks. `x` lies off the trace domain, so the vanishing
+/// polynomial and the boundary divisor are both nonzero and invertible.
+pub(super) fn quotients(params: &AirParams, x: Fp, f_x: Fp, f_gx: Fp) -> (Fp, Fp) {
+    let t = 1u64 << params.log_t;
+    // Z_H(x) = x^T - 1 vanishes exactly on the trace domain.
+    let z_h = x.pow(t) - Fp::ONE;
+    // Transition holds on all rows but the last, so multiply the numerator by the
+    // excluded point before dividing by the full vanishing polynomial.
+    let transition = (f_gx - f_x * f_x) * (x - params.g_last);
+    let q_transition = transition * z_h.inv();
+    // Boundary vanishes at the first row, domain point one.
+    let q_boundary = (f_x - params.seed) * (x - Fp::ONE).inv();
+    (q_transition, q_boundary)
+}

--- a/src/crypto/stark/air/mod.rs
+++ b/src/crypto/stark/air/mod.rs
@@ -1,0 +1,31 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! An end-to-end STARK over an algebraic intermediate representation. A trace is
+//! interpolated and extended onto an evaluation coset, the constraints become a
+//! composition polynomial, FRI proves that composition is low degree, and query
+//! openings bind it to the committed trace. This closes the transparent,
+//! post-quantum proof system: the verifier is proven against forgeries, not
+//! assumed sound.
+
+mod constraints;
+mod prove;
+mod types;
+mod verify;
+
+pub use prove::stark_prove;
+pub use types::{StarkProof, StarkQuery};
+pub use verify::stark_verify;

--- a/src/crypto/stark/air/prove.rs
+++ b/src/crypto/stark/air/prove.rs
@@ -1,0 +1,105 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The STARK prover. Interpolate the trace, extend it onto an evaluation coset,
+//! commit it, build the constraint composition, prove that composition is low
+//! degree with FRI, and open the sampled consistency positions.
+
+use super::super::field::Fp;
+use super::super::fri::{fri_prove, root_of_unity};
+use super::super::merkle::MerkleTree;
+use super::super::poly::eval_lagrange;
+use super::super::transcript::Transcript;
+use super::constraints::{quotients, AirParams};
+use super::types::{StarkProof, StarkQuery};
+use alloc::vec::Vec;
+
+/// The coset shift for the evaluation domain, a generator so the coset never
+/// meets the trace subgroup.
+const SHIFT: u64 = 7;
+
+/// Prove that `trace` (length a power of two, `t[i+1] = t[i]^2`) satisfies the
+/// squaring AIR with boundary `t[0]`. The evaluation domain is `2^log_blowup`
+/// times the trace length.
+pub fn stark_prove(trace: &[Fp], log_blowup: u32, n_queries: usize) -> StarkProof {
+    let t = trace.len();
+    let log_t = t.trailing_zeros();
+    let log_n = log_t + log_blowup;
+    let n = 1usize << log_n;
+    let blowup = 1usize << log_blowup;
+
+    let g = root_of_unity(log_t);
+    let omega = root_of_unity(log_n);
+    let shift = Fp::from_u64(SHIFT);
+
+    // Trace-domain points g^i and the low-degree extension of the trace onto the
+    // coset D = shift * {omega^j}, by Lagrange interpolation.
+    let mut h_pts: Vec<Fp> = Vec::with_capacity(t);
+    let mut hp = Fp::ONE;
+    for _ in 0..t {
+        h_pts.push(hp);
+        hp = hp * g;
+    }
+    let mut trace_d: Vec<Fp> = Vec::with_capacity(n);
+    let mut x = shift;
+    for _ in 0..n {
+        trace_d.push(eval_lagrange(&h_pts, trace, x));
+        x = x * omega;
+    }
+
+    let trace_tree = MerkleTree::commit(&trace_d);
+    let trace_root = trace_tree.root();
+
+    // Composition coefficients are drawn after the trace is committed.
+    let mut transcript = Transcript::new(b"NONOS-STARK");
+    transcript.absorb_digest(&trace_root);
+    let alpha = transcript.challenge_fp();
+    let beta = transcript.challenge_fp();
+
+    let params = AirParams { log_t, seed: trace[0], g_last: g.pow((t - 1) as u64) };
+
+    // The constraint composition over the coset.
+    let mut comp_d: Vec<Fp> = Vec::with_capacity(n);
+    let mut x = shift;
+    for (j, &f_x) in trace_d.iter().enumerate() {
+        let f_gx = trace_d[(j + blowup) % n];
+        let (q_transition, q_boundary) = quotients(&params, x, f_x, f_gx);
+        comp_d.push(alpha * q_transition + beta * q_boundary);
+        x = x * omega;
+    }
+
+    // FRI proves the composition is low degree; its first root commits it.
+    let fri = fri_prove(&comp_d, shift, log_blowup, n_queries);
+    let comp_tree = MerkleTree::commit(&comp_d);
+
+    // Consistency positions, bound after the composition commitment.
+    transcript.absorb_digest(&fri.roots[0]);
+    let mut queries: Vec<StarkQuery> = Vec::with_capacity(n_queries);
+    for _ in 0..n_queries {
+        let p = transcript.challenge_index(n);
+        let gx = (p + blowup) % n;
+        queries.push(StarkQuery {
+            comp: comp_d[p],
+            comp_path: comp_tree.open(p),
+            t_x: trace_d[p],
+            t_x_path: trace_tree.open(p),
+            t_gx: trace_d[gx],
+            t_gx_path: trace_tree.open(gx),
+        });
+    }
+
+    StarkProof { trace_root, fri, queries }
+}

--- a/src/crypto/stark/air/types.rs
+++ b/src/crypto/stark/air/types.rs
@@ -1,0 +1,41 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The STARK proof: a trace commitment, a FRI proof that the constraint
+//! composition is low degree, and per-query openings that bind the composition
+//! back to the committed trace.
+
+use super::super::field::Fp;
+use super::super::fri::FriProof;
+use alloc::vec::Vec;
+
+/// One consistency query: the composition value at position `p` and the trace
+/// values at `p` and one row ahead, each with a Merkle path to its commitment.
+pub struct StarkQuery {
+    pub comp: Fp,
+    pub comp_path: Vec<[u8; 32]>,
+    pub t_x: Fp,
+    pub t_x_path: Vec<[u8; 32]>,
+    pub t_gx: Fp,
+    pub t_gx_path: Vec<[u8; 32]>,
+}
+
+/// A complete STARK proof for the squaring AIR.
+pub struct StarkProof {
+    pub trace_root: [u8; 32],
+    pub fri: FriProof,
+    pub queries: Vec<StarkQuery>,
+}

--- a/src/crypto/stark/air/verify.rs
+++ b/src/crypto/stark/air/verify.rs
@@ -1,0 +1,87 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The STARK verifier. It checks the composition is low degree through FRI, then
+//! at each sampled position checks the committed composition equals the
+//! constraint composition recomputed from the committed trace. A false trace
+//! yields either a high-degree composition (FRI rejects) or a composition that
+//! disagrees with the trace (consistency rejects). It only reads the proof.
+
+use super::super::field::Fp;
+use super::super::fri::{fri_verify, root_of_unity};
+use super::super::merkle::verify_path;
+use super::super::transcript::Transcript;
+use super::constraints::{quotients, AirParams};
+use super::types::StarkProof;
+
+const SHIFT: u64 = 7;
+
+/// Verify a squaring-AIR STARK proof for a trace of length `2^log_t` on an
+/// evaluation domain `2^log_blowup` times larger, with public boundary `seed`.
+pub fn stark_verify(
+    proof: &StarkProof,
+    seed: Fp,
+    log_t: u32,
+    log_blowup: u32,
+    n_queries: usize,
+) -> bool {
+    let t = 1usize << log_t;
+    let log_n = log_t + log_blowup;
+    let n = 1usize << log_n;
+    let blowup = 1usize << log_blowup;
+
+    if proof.queries.len() != n_queries {
+        return false;
+    }
+
+    let g = root_of_unity(log_t);
+    let omega = root_of_unity(log_n);
+    let shift = Fp::from_u64(SHIFT);
+    let params = AirParams { log_t, seed, g_last: g.pow((t - 1) as u64) };
+
+    // 1. The composition must be low degree (below the trace length).
+    if !fri_verify(&proof.fri, shift, log_n, log_blowup, n_queries) {
+        return false;
+    }
+    let comp_root = proof.fri.roots[0];
+
+    // 2. Recover the composition coefficients and the query positions.
+    let mut transcript = Transcript::new(b"NONOS-STARK");
+    transcript.absorb_digest(&proof.trace_root);
+    let alpha = transcript.challenge_fp();
+    let beta = transcript.challenge_fp();
+    transcript.absorb_digest(&comp_root);
+
+    // 3. The committed composition must equal the constraint composition of the
+    // committed trace at every sampled position.
+    for qd in &proof.queries {
+        let p = transcript.challenge_index(n);
+        let gx = (p + blowup) % n;
+        if !verify_path(&comp_root, p, qd.comp, &qd.comp_path)
+            || !verify_path(&proof.trace_root, p, qd.t_x, &qd.t_x_path)
+            || !verify_path(&proof.trace_root, gx, qd.t_gx, &qd.t_gx_path)
+        {
+            return false;
+        }
+        let x = shift * omega.pow(p as u64);
+        let (q_transition, q_boundary) = quotients(&params, x, qd.t_x, qd.t_gx);
+        if qd.comp != alpha * q_transition + beta * q_boundary {
+            return false;
+        }
+    }
+
+    true
+}

--- a/src/crypto/stark/mod.rs
+++ b/src/crypto/stark/mod.rs
@@ -8,6 +8,7 @@
 //! bottom up: the Goldilocks field, a Merkle commitment over it, polynomials,
 //! a Fiat-Shamir transcript, and the FRI low-degree test on top.
 
+pub mod air;
 pub mod field;
 pub mod fri;
 pub mod merkle;

--- a/userland/stark_proofs/src/air_tests.rs
+++ b/userland/stark_proofs/src/air_tests.rs
@@ -1,0 +1,103 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::crypto::stark::air::{stark_prove, stark_verify};
+use crate::crypto::stark::field::Fp;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+// The end-to-end STARK: a real proof that a squaring chain t[i+1] = t[i]^2 was
+// computed correctly, with no trusted setup and hash-only cryptography. These
+// checks exercise the whole pipeline (interpolation, low-degree extension,
+// constraint composition, FRI, and the trace consistency binding) on the real
+// prover and verifier, for both honest and dishonest traces.
+
+/// The honest squaring trace of length `2^log_t` from `seed`.
+fn squaring_trace(log_t: u32, seed: Fp) -> Vec<Fp> {
+    let t = 1usize << log_t;
+    let mut trace = Vec::with_capacity(t);
+    let mut cur = seed;
+    for _ in 0..t {
+        trace.push(cur);
+        cur = cur * cur;
+    }
+    trace
+}
+
+#[test]
+fn an_honest_execution_proves_and_verifies() {
+    let (log_t, log_blowup, queries) = (3u32, 2u32, 32usize);
+    let seed = Fp::from_u64(3);
+    let trace = squaring_trace(log_t, seed);
+    let proof = stark_prove(&trace, log_blowup, queries);
+    assert!(stark_verify(&proof, seed, log_t, log_blowup, queries), "honest execution rejected");
+}
+
+#[test]
+fn honest_executions_prove_across_sizes() {
+    for (log_t, log_blowup) in [(2u32, 2u32), (3, 2), (4, 3)] {
+        let seed = Fp::from_u64(2 + log_t as u64);
+        let trace = squaring_trace(log_t, seed);
+        let proof = stark_prove(&trace, log_blowup, 32);
+        assert!(
+            stark_verify(&proof, seed, log_t, log_blowup, 32),
+            "honest execution at log_t {log_t} rejected"
+        );
+    }
+}
+
+#[test]
+fn a_corrupted_transition_is_rejected() {
+    // Break one step of the chain. The composition is no longer low degree, so
+    // FRI rejects the proof the prover honestly builds from the bad trace.
+    let (log_t, log_blowup, queries) = (3u32, 2u32, 32usize);
+    let seed = Fp::from_u64(3);
+    let mut trace = squaring_trace(log_t, seed);
+    trace[4] = trace[4] + Fp::ONE;
+    let proof = stark_prove(&trace, log_blowup, queries);
+    assert!(!stark_verify(&proof, seed, log_t, log_blowup, queries), "a corrupted trace verified");
+}
+
+#[test]
+fn a_wrong_boundary_seed_is_rejected() {
+    // The proof is honest, but the verifier is told a different public seed. The
+    // boundary quotient it recomputes no longer matches the committed composition.
+    let (log_t, log_blowup, queries) = (3u32, 2u32, 32usize);
+    let seed = Fp::from_u64(3);
+    let trace = squaring_trace(log_t, seed);
+    let proof = stark_prove(&trace, log_blowup, queries);
+    let wrong_seed = Fp::from_u64(4);
+    assert!(
+        !stark_verify(&proof, wrong_seed, log_t, log_blowup, queries),
+        "a wrong boundary seed verified"
+    );
+}
+
+#[test]
+fn a_tampered_trace_opening_is_rejected() {
+    // Corrupt one opened trace value. Its Merkle path no longer recomputes the
+    // trace root.
+    let (log_t, log_blowup, queries) = (3u32, 2u32, 32usize);
+    let seed = Fp::from_u64(3);
+    let trace = squaring_trace(log_t, seed);
+    let mut proof = stark_prove(&trace, log_blowup, queries);
+    proof.queries[0].t_x = proof.queries[0].t_x + Fp::ONE;
+    assert!(
+        !stark_verify(&proof, seed, log_t, log_blowup, queries),
+        "a tampered trace opening verified"
+    );
+}

--- a/userland/stark_proofs/src/lib.rs
+++ b/userland/stark_proofs/src/lib.rs
@@ -7,6 +7,8 @@ extern crate alloc;
 pub mod crypto;
 
 #[cfg(test)]
+mod air_tests;
+#[cfg(test)]
 mod field_tests;
 #[cfg(test)]
 mod fri_tests;


### PR DESCRIPTION
Turns the FRI low-degree test into a complete STARK. Proves that a squaring chain t[i+1] = t[i]^2 was computed correctly, transparent and hash-only so it stays post-quantum, with no trusted setup.

Pipeline, all on real code:
- interpolate the trace over the trace domain and low-degree extend it onto an evaluation coset (Lagrange), commit it
- build the constraint composition: a transition quotient (f(g*x) - f(x)^2 excluded on the last row) and a boundary quotient (f(1) - seed), combined under Fiat-Shamir coefficients
- FRI proves the composition is low degree
- sampled query openings bind the composition back to the committed trace

Soundness: a false trace makes the composition non-low-degree (FRI rejects) or inconsistent with the trace (consistency rejects). The constraint algebra is one function shared by prover and verifier, so they cannot drift.

Host proofs (5): honest execution verifies across sizes; a corrupted transition, a wrong boundary seed, and a tampered trace opening are all rejected. 25/25 stark_proofs tests, clippy -D warnings clean, kernel builds with the module wired in. One concern per file, mod.rs re-exports only, no panics.

Stacked on Stark-Fri-Proofs (#285).