### PR TITLE
stark: constraint-degree domain sizing + an x^7 S-box AIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/crypto/stark/air/composition.rs
+++ b/src/crypto/stark/air/composition.rs
@@ -29,6 +29,22 @@ pub(super) fn num_coeffs<A: Air>(air: &A) -> usize {
     air.num_transition() + air.boundary().len()
 }
 
+/// The evaluation-domain sizing derived from the AIR: `(log_n, fri_log_blowup)`.
+///
+/// The composition degree is below `constraint_degree * trace_len`, so the FRI
+/// degree bound `B` is that rounded up to a power of two, and the evaluation
+/// domain is `2 * B` (a rate of one half for the low-degree test). Both prover
+/// and verifier call this, so they agree on the domain without passing sizes.
+pub(super) fn domain_params<A: Air>(air: &A) -> (u32, u32) {
+    let t = 1usize << air.log_trace_len();
+    let degree = air.constraint_degree().max(1);
+    let bound = (degree * t).next_power_of_two();
+    let n = 2 * bound;
+    let log_n = n.trailing_zeros();
+    let fri_log_blowup = log_n - bound.trailing_zeros();
+    (log_n, fri_log_blowup)
+}
+
 /// The composition value at coset point `x`, given the trace window
 /// `[f(x), f(g*x), ...]` and the transcript coefficients. `g` is the trace-domain
 /// generator. `x` lies off the trace domain, so every divisor is invertible.

--- a/src/crypto/stark/air/fibonacci.rs
+++ b/src/crypto/stark/air/fibonacci.rs
@@ -36,6 +36,10 @@ impl Air for Fibonacci {
         3
     }
 
+    fn constraint_degree(&self) -> usize {
+        1
+    }
+
     fn num_transition(&self) -> usize {
         1
     }

--- a/src/crypto/stark/air/mod.rs
+++ b/src/crypto/stark/air/mod.rs
@@ -24,6 +24,7 @@
 
 mod composition;
 mod fibonacci;
+mod power_chain;
 mod prove;
 mod spec;
 mod squaring;
@@ -31,6 +32,7 @@ mod types;
 mod verify;
 
 pub use fibonacci::Fibonacci;
+pub use power_chain::PowerChain;
 pub use prove::stark_prove;
 pub use spec::Air;
 pub use squaring::Squaring;

--- a/src/crypto/stark/air/power_chain.rs
+++ b/src/crypto/stark/air/power_chain.rs
@@ -14,19 +14,28 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! The squaring AIR: a chain `t[i+1] = t[i]^2` from a public seed.
+//! An iterated S-box chain: `t[i+1] = t[i]^7 + c`. Raising to the seventh power
+//! is a permutation of this field (7 is coprime to the group order), the same
+//! low-degree S-box the Goldilocks hash permutations use. Proving a chain of it
+//! is a computational-integrity proof of a hash-style, verifiable-delay
+//! computation: the prover shows a public output is the result of applying the
+//! permutation `T` times to some starting value, without revealing that value.
+//! The degree-7 transition is what exercises the engine's high-degree path.
 
 use super::super::field::Fp;
 use super::spec::Air;
 use alloc::vec;
 use alloc::vec::Vec;
 
-pub struct Squaring {
+pub struct PowerChain {
     pub log_t: u32,
-    pub seed: Fp,
+    /// The round constant added after each S-box.
+    pub c: Fp,
+    /// The public final value the chain must reach.
+    pub output: Fp,
 }
 
-impl Air for Squaring {
+impl Air for PowerChain {
     fn log_trace_len(&self) -> u32 {
         self.log_t
     }
@@ -36,7 +45,7 @@ impl Air for Squaring {
     }
 
     fn constraint_degree(&self) -> usize {
-        2
+        7
     }
 
     fn num_transition(&self) -> usize {
@@ -44,11 +53,14 @@ impl Air for Squaring {
     }
 
     fn transition(&self, window: &[Fp]) -> Vec<Fp> {
-        // f(g*x) - f(x)^2
-        vec![window[1] - window[0] * window[0]]
+        // f(g*x) - (f(x)^7 + c)
+        let x = window[0];
+        let x7 = x.pow(7);
+        vec![window[1] - (x7 + self.c)]
     }
 
     fn boundary(&self) -> Vec<(usize, Fp)> {
-        vec![(0, self.seed)]
+        // The last row is the public output.
+        vec![((1usize << self.log_t) - 1, self.output)]
     }
 }

--- a/src/crypto/stark/air/prove.rs
+++ b/src/crypto/stark/air/prove.rs
@@ -23,7 +23,7 @@ use super::super::fri::{fri_prove, root_of_unity};
 use super::super::merkle::MerkleTree;
 use super::super::poly::eval_lagrange;
 use super::super::transcript::Transcript;
-use super::composition::{compose, num_coeffs};
+use super::composition::{compose, domain_params, num_coeffs};
 use super::spec::Air;
 use super::types::{StarkProof, StarkQuery};
 use alloc::vec::Vec;
@@ -32,14 +32,15 @@ use alloc::vec::Vec;
 /// meets the trace subgroup.
 const SHIFT: u64 = 7;
 
-/// Prove that `trace` satisfies `air` on an evaluation domain `2^log_blowup`
-/// times the trace length. `trace.len()` must equal the AIR's trace length.
-pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], log_blowup: u32, n_queries: usize) -> StarkProof {
+/// Prove that `trace` satisfies `air`. The evaluation domain and the low-degree
+/// bound are derived from the AIR's constraint degree. `trace.len()` must equal
+/// the AIR's trace length.
+pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], n_queries: usize) -> StarkProof {
     let log_t = air.log_trace_len();
     let t = 1usize << log_t;
-    let log_n = log_t + log_blowup;
+    let (log_n, fri_log_blowup) = domain_params(air);
     let n = 1usize << log_n;
-    let blowup = 1usize << log_blowup;
+    let blowup = 1usize << (log_n - log_t);
     let window_size = air.window_size();
 
     let g = root_of_unity(log_t);
@@ -83,7 +84,7 @@ pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], log_blowup: u32, n_queries: us
     }
 
     // FRI proves the composition is low degree; its first root commits it.
-    let fri = fri_prove(&comp_d, shift, log_blowup, n_queries);
+    let fri = fri_prove(&comp_d, shift, fri_log_blowup, n_queries);
     let comp_tree = MerkleTree::commit(&comp_d);
 
     // Consistency positions, bound after the composition commitment.

--- a/src/crypto/stark/air/spec.rs
+++ b/src/crypto/stark/air/spec.rs
@@ -30,6 +30,11 @@ pub trait Air {
     /// Number of consecutive rows the transition reads (2 reads `x, g*x`).
     fn window_size(&self) -> usize;
 
+    /// The highest polynomial degree among the transition constraints, in the
+    /// trace values. Squaring is 2, a linear recurrence 1, an `x^7` S-box 7. The
+    /// engine sizes the evaluation domain and the low-degree test from this.
+    fn constraint_degree(&self) -> usize;
+
     /// Number of transition constraints (the length of `transition`).
     fn num_transition(&self) -> usize;
 

--- a/src/crypto/stark/air/verify.rs
+++ b/src/crypto/stark/air/verify.rs
@@ -25,25 +25,20 @@ use super::super::field::Fp;
 use super::super::fri::{fri_verify, root_of_unity};
 use super::super::merkle::verify_path;
 use super::super::transcript::Transcript;
-use super::composition::{compose, num_coeffs};
+use super::composition::{compose, domain_params, num_coeffs};
 use super::spec::Air;
 use super::types::StarkProof;
 use alloc::vec::Vec;
 
 const SHIFT: u64 = 7;
 
-/// Verify `proof` against `air` on an evaluation domain `2^log_blowup` times the
-/// trace length.
-pub fn stark_verify<A: Air>(
-    air: &A,
-    proof: &StarkProof,
-    log_blowup: u32,
-    n_queries: usize,
-) -> bool {
+/// Verify `proof` against `air`. The evaluation domain and the low-degree bound
+/// are derived from the AIR, matching the prover.
+pub fn stark_verify<A: Air>(air: &A, proof: &StarkProof, n_queries: usize) -> bool {
     let log_t = air.log_trace_len();
-    let log_n = log_t + log_blowup;
+    let (log_n, fri_log_blowup) = domain_params(air);
     let n = 1usize << log_n;
-    let blowup = 1usize << log_blowup;
+    let blowup = 1usize << (log_n - log_t);
     let window_size = air.window_size();
 
     if proof.queries.len() != n_queries {
@@ -54,8 +49,8 @@ pub fn stark_verify<A: Air>(
     let omega = root_of_unity(log_n);
     let shift = Fp::from_u64(SHIFT);
 
-    // 1. The composition must be low degree (below the trace length).
-    if !fri_verify(&proof.fri, shift, log_n, log_blowup, n_queries) {
+    // 1. The composition must be low degree (below the derived bound).
+    if !fri_verify(&proof.fri, shift, log_n, fri_log_blowup, n_queries) {
         return false;
     }
     let comp_root = proof.fri.roots[0];

--- a/userland/stark_proofs/src/air_tests.rs
+++ b/userland/stark_proofs/src/air_tests.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::crypto::stark::air::{stark_prove, stark_verify, Fibonacci, Squaring};
+use crate::crypto::stark::air::{stark_prove, stark_verify, Fibonacci, PowerChain, Squaring};
 use crate::crypto::stark::field::Fp;
 
 extern crate alloc;
@@ -22,10 +22,13 @@ use alloc::vec::Vec;
 
 // The end-to-end STARK: a real proof that a computation ran correctly, with no
 // trusted setup and hash-only cryptography. The engine is generic over the AIR,
-// so the same prover and verifier handle two structurally different problems, a
-// squaring chain and a Fibonacci recurrence. These checks exercise the whole
-// pipeline (interpolation, low-degree extension, constraint composition, FRI,
-// and the trace consistency binding) on the real code, honest and dishonest.
+// so one prover and verifier handle three structurally different problems: a
+// squaring chain, a Fibonacci recurrence, and an iterated x^7 S-box chain (the
+// hash-style, high-degree case). The evaluation domain is derived from each
+// AIR's constraint degree. These checks run the whole pipeline on real code,
+// honest and dishonest.
+
+const QUERIES: usize = 32;
 
 fn squaring_trace(log_t: u32, seed: Fp) -> Vec<Fp> {
     let t = 1usize << log_t;
@@ -51,22 +54,44 @@ fn fibonacci_trace(log_t: u32) -> Vec<Fp> {
     trace
 }
 
+/// The honest S-box chain t[i+1] = t[i]^7 + c from a starting value, and its
+/// public final output.
+fn power_chain_trace(log_t: u32, start: Fp, c: Fp) -> (Vec<Fp>, Fp) {
+    let t = 1usize << log_t;
+    let mut trace = Vec::with_capacity(t);
+    let mut cur = start;
+    for _ in 0..t {
+        trace.push(cur);
+        cur = cur.pow(7) + c;
+    }
+    let output = trace[t - 1];
+    (trace, output)
+}
+
 #[test]
 fn an_honest_squaring_execution_verifies() {
-    let (log_t, log_blowup, queries) = (3u32, 2u32, 32usize);
     let seed = Fp::from_u64(3);
-    let air = Squaring { log_t, seed };
-    let proof = stark_prove(&air, &squaring_trace(log_t, seed), log_blowup, queries);
-    assert!(stark_verify(&air, &proof, log_blowup, queries), "honest squaring rejected");
+    let air = Squaring { log_t: 3, seed };
+    let proof = stark_prove(&air, &squaring_trace(3, seed), QUERIES);
+    assert!(stark_verify(&air, &proof, QUERIES), "honest squaring rejected");
 }
 
 #[test]
 fn an_honest_fibonacci_execution_verifies() {
-    // The same engine, a different computation. This is the generality check.
-    let (log_t, log_blowup, queries) = (4u32, 2u32, 32usize);
-    let air = Fibonacci { log_t };
-    let proof = stark_prove(&air, &fibonacci_trace(log_t), log_blowup, queries);
-    assert!(stark_verify(&air, &proof, log_blowup, queries), "honest fibonacci rejected");
+    let air = Fibonacci { log_t: 4 };
+    let proof = stark_prove(&air, &fibonacci_trace(4), QUERIES);
+    assert!(stark_verify(&air, &proof, QUERIES), "honest fibonacci rejected");
+}
+
+#[test]
+fn an_honest_sbox_chain_verifies() {
+    // The hash-style, degree-7 case: prove a public output is the result of
+    // applying the x^7 permutation T times to a starting value.
+    let (c, start) = (Fp::from_u64(11), Fp::from_u64(2));
+    let (trace, output) = power_chain_trace(4, start, c);
+    let air = PowerChain { log_t: 4, c, output };
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(stark_verify(&air, &proof, QUERIES), "honest s-box chain rejected");
 }
 
 #[test]
@@ -74,54 +99,63 @@ fn honest_executions_prove_across_sizes() {
     for log_t in [2u32, 3, 4] {
         let seed = Fp::from_u64(2 + log_t as u64);
         let air = Squaring { log_t, seed };
-        let proof = stark_prove(&air, &squaring_trace(log_t, seed), 3, 32);
-        assert!(stark_verify(&air, &proof, 3, 32), "squaring at log_t {log_t} rejected");
+        let proof = stark_prove(&air, &squaring_trace(log_t, seed), QUERIES);
+        assert!(stark_verify(&air, &proof, QUERIES), "squaring at log_t {log_t} rejected");
     }
 }
 
 #[test]
 fn a_corrupted_squaring_transition_is_rejected() {
-    // Break one step of the chain. The composition is no longer low degree, so
-    // FRI rejects the proof honestly built from the bad trace.
-    let (log_t, log_blowup, queries) = (3u32, 2u32, 32usize);
     let seed = Fp::from_u64(3);
-    let air = Squaring { log_t, seed };
-    let mut trace = squaring_trace(log_t, seed);
+    let air = Squaring { log_t: 3, seed };
+    let mut trace = squaring_trace(3, seed);
     trace[4] = trace[4] + Fp::ONE;
-    let proof = stark_prove(&air, &trace, log_blowup, queries);
-    assert!(!stark_verify(&air, &proof, log_blowup, queries), "a corrupted squaring verified");
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(!stark_verify(&air, &proof, QUERIES), "a corrupted squaring verified");
 }
 
 #[test]
 fn a_corrupted_fibonacci_transition_is_rejected() {
-    let (log_t, log_blowup, queries) = (4u32, 2u32, 32usize);
-    let air = Fibonacci { log_t };
-    let mut trace = fibonacci_trace(log_t);
+    let air = Fibonacci { log_t: 4 };
+    let mut trace = fibonacci_trace(4);
     trace[5] = trace[5] + Fp::ONE;
-    let proof = stark_prove(&air, &trace, log_blowup, queries);
-    assert!(!stark_verify(&air, &proof, log_blowup, queries), "a corrupted fibonacci verified");
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(!stark_verify(&air, &proof, QUERIES), "a corrupted fibonacci verified");
+}
+
+#[test]
+fn a_corrupted_sbox_step_is_rejected() {
+    let (c, start) = (Fp::from_u64(11), Fp::from_u64(2));
+    let (mut trace, output) = power_chain_trace(4, start, c);
+    trace[6] = trace[6] + Fp::ONE;
+    let air = PowerChain { log_t: 4, c, output };
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(!stark_verify(&air, &proof, QUERIES), "a corrupted s-box step verified");
+}
+
+#[test]
+fn a_wrong_sbox_output_is_rejected() {
+    // The chain is honest, but the claimed public output is wrong.
+    let (c, start) = (Fp::from_u64(11), Fp::from_u64(2));
+    let (trace, output) = power_chain_trace(4, start, c);
+    let air = PowerChain { log_t: 4, c, output: output + Fp::ONE };
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(!stark_verify(&air, &proof, QUERIES), "a wrong s-box output verified");
 }
 
 #[test]
 fn a_wrong_boundary_seed_is_rejected() {
-    // The proof is honest, but the verifier is told a different public seed. The
-    // boundary quotient it recomputes no longer matches the committed composition.
-    let (log_t, log_blowup, queries) = (3u32, 2u32, 32usize);
     let seed = Fp::from_u64(3);
-    let proof =
-        stark_prove(&Squaring { log_t, seed }, &squaring_trace(log_t, seed), log_blowup, queries);
-    let wrong = Squaring { log_t, seed: Fp::from_u64(4) };
-    assert!(!stark_verify(&wrong, &proof, log_blowup, queries), "a wrong boundary seed verified");
+    let proof = stark_prove(&Squaring { log_t: 3, seed }, &squaring_trace(3, seed), QUERIES);
+    let wrong = Squaring { log_t: 3, seed: Fp::from_u64(4) };
+    assert!(!stark_verify(&wrong, &proof, QUERIES), "a wrong boundary seed verified");
 }
 
 #[test]
 fn a_tampered_trace_opening_is_rejected() {
-    // Corrupt one opened trace value. Its Merkle path no longer recomputes the
-    // trace root.
-    let (log_t, log_blowup, queries) = (3u32, 2u32, 32usize);
     let seed = Fp::from_u64(3);
-    let air = Squaring { log_t, seed };
-    let mut proof = stark_prove(&air, &squaring_trace(log_t, seed), log_blowup, queries);
+    let air = Squaring { log_t: 3, seed };
+    let mut proof = stark_prove(&air, &squaring_trace(3, seed), QUERIES);
     proof.queries[0].window[0] = proof.queries[0].window[0] + Fp::ONE;
-    assert!(!stark_verify(&air, &proof, log_blowup, queries), "a tampered trace opening verified");
+    assert!(!stark_verify(&air, &proof, QUERIES), "a tampered trace opening verified");
 }


### PR DESCRIPTION
Extends the AIR engine to high-degree constraints and adds a cryptographic instance.

The engine sized its low-degree bound to the trace length, which only works for degree-two constraints. Now an AIR reports its `constraint_degree`, and the engine derives the evaluation domain: the composition degree is below `constraint_degree * trace_len`, so the FRI bound is that rounded up to a power of two and the domain is twice it (rate one half). Prover and verifier both derive this, so the `log_blowup` argument is gone from the API.

On top of that, `PowerChain` proves an iterated `t[i+1] = t[i]^7 + c`. Raising to the seventh power is a permutation of the Goldilocks field (7 is coprime to the group order), the same low-degree S-box the Goldilocks hash permutations are built from. A chain of it is a computational-integrity proof of a hash-style, verifiable-delay computation: a public output is the result of applying the permutation T times to a starting value the proof does not reveal. Its degree-seven transition is what exercises the high-degree path.

Host proofs (10): honest squaring, Fibonacci, and S-box chains all verify; a corrupted step in each, a wrong S-box output, a wrong boundary, and a tampered opening are all rejected. 30/30 stark_proofs tests, clippy -D warnings clean, kernel builds with it wired in.

Stacked on Stark-Air-Framework (#289).