### PR TITLE
deps: bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
A freshly published advisory, RUSTSEC-2026-0204, flags an invalid pointer dereference in the `fmt::Pointer` impl for `Atomic` and `Shared` in `crossbeam-epoch`. It reaches the tree transitively through `smoltcp`. This turned the supply-chain audit red on every PR opened after the advisory landed, while older runs stayed green.

The patched `0.9.20` clears it. Lockfile only, no manifest change. `cargo audit` exits clean after the bump (the two remaining entries are allowed unmaintained warnings).