### PR TITLE
stark: multi-column traces + a two-element permutation AIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/src/crypto/stark/air/composition.rs
+++ b/src/crypto/stark/air/composition.rs
@@ -65,9 +65,10 @@ pub(super) fn compose<A: Air>(air: &A, g: Fp, x: Fp, window: &[Fp], coeffs: &[Fp
         acc = acc + *coeff * (*value * exempt * z_h_inv);
     }
 
+    // Boundary quotients read column `col` at window offset zero, `window[col]`.
     let boundary_coeffs = &coeffs[transition.len()..];
-    for ((row, expected), coeff) in air.boundary().iter().zip(boundary_coeffs.iter()) {
-        let quotient = (window[0] - *expected) * (x - g.pow(*row as u64)).inv();
+    for ((col, row, expected), coeff) in air.boundary().iter().zip(boundary_coeffs.iter()) {
+        let quotient = (window[*col] - *expected) * (x - g.pow(*row as u64)).inv();
         acc = acc + *coeff * quotient;
     }
 

--- a/src/crypto/stark/air/fibonacci.rs
+++ b/src/crypto/stark/air/fibonacci.rs
@@ -32,6 +32,10 @@ impl Air for Fibonacci {
         self.log_t
     }
 
+    fn trace_width(&self) -> usize {
+        1
+    }
+
     fn window_size(&self) -> usize {
         3
     }
@@ -49,7 +53,8 @@ impl Air for Fibonacci {
         vec![window[2] - window[1] - window[0]]
     }
 
-    fn boundary(&self) -> Vec<(usize, Fp)> {
-        vec![(0, Fp::ONE), (1, Fp::ONE)]
+    fn boundary(&self) -> Vec<(usize, usize, Fp)> {
+        // column 0, the first two rows are both one.
+        vec![(0, 0, Fp::ONE), (0, 1, Fp::ONE)]
     }
 }

--- a/src/crypto/stark/air/mod.rs
+++ b/src/crypto/stark/air/mod.rs
@@ -24,6 +24,7 @@
 
 mod composition;
 mod fibonacci;
+mod permutation2;
 mod power_chain;
 mod prove;
 mod spec;
@@ -32,6 +33,7 @@ mod types;
 mod verify;
 
 pub use fibonacci::Fibonacci;
+pub use permutation2::Permutation2;
 pub use power_chain::PowerChain;
 pub use prove::stark_prove;
 pub use spec::Air;

--- a/src/crypto/stark/air/permutation2.rs
+++ b/src/crypto/stark/air/permutation2.rs
@@ -14,25 +14,38 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! The squaring AIR: a chain `t[i+1] = t[i]^2` from a public seed.
+//! A two-element algebraic permutation, the shape of a hash round: a full x^7
+//! S-box on each state element, a linear mix, and a round constant. The round is
+//!
+//!   x' = x^7 + y + rc0
+//!   y' = x + y^7 + rc1
+//!
+//! A trace of it is a two-column state, so proving a chain is a
+//! computational-integrity proof over a multi-element permutation, the same
+//! structure a Poseidon or Rescue hash is built from. This is the multi-column,
+//! high-degree case: two degree-seven transition constraints over a width-two
+//! trace.
 
 use super::super::field::Fp;
 use super::spec::Air;
 use alloc::vec;
 use alloc::vec::Vec;
 
-pub struct Squaring {
+pub struct Permutation2 {
     pub log_t: u32,
-    pub seed: Fp,
+    pub rc0: Fp,
+    pub rc1: Fp,
+    /// The public final state after the whole chain.
+    pub out: [Fp; 2],
 }
 
-impl Air for Squaring {
+impl Air for Permutation2 {
     fn log_trace_len(&self) -> u32 {
         self.log_t
     }
 
     fn trace_width(&self) -> usize {
-        1
+        2
     }
 
     fn window_size(&self) -> usize {
@@ -40,20 +53,22 @@ impl Air for Squaring {
     }
 
     fn constraint_degree(&self) -> usize {
-        2
+        7
     }
 
     fn num_transition(&self) -> usize {
-        1
+        2
     }
 
     fn transition(&self, window: &[Fp]) -> Vec<Fp> {
-        // f(g*x) - f(x)^2
-        vec![window[1] - window[0] * window[0]]
+        // window = [x, y, x_next, y_next].
+        let (x, y, x_next, y_next) = (window[0], window[1], window[2], window[3]);
+        vec![x_next - (x.pow(7) + y + self.rc0), y_next - (x + y.pow(7) + self.rc1)]
     }
 
     fn boundary(&self) -> Vec<(usize, usize, Fp)> {
-        // column 0, row 0, the public seed.
-        vec![(0, 0, self.seed)]
+        // Both state columns at the last row are the public output.
+        let last = (1usize << self.log_t) - 1;
+        vec![(0, last, self.out[0]), (1, last, self.out[1])]
     }
 }

--- a/src/crypto/stark/air/power_chain.rs
+++ b/src/crypto/stark/air/power_chain.rs
@@ -40,6 +40,10 @@ impl Air for PowerChain {
         self.log_t
     }
 
+    fn trace_width(&self) -> usize {
+        1
+    }
+
     fn window_size(&self) -> usize {
         2
     }
@@ -59,8 +63,8 @@ impl Air for PowerChain {
         vec![window[1] - (x7 + self.c)]
     }
 
-    fn boundary(&self) -> Vec<(usize, Fp)> {
-        // The last row is the public output.
-        vec![((1usize << self.log_t) - 1, self.output)]
+    fn boundary(&self) -> Vec<(usize, usize, Fp)> {
+        // column 0, last row, the public output.
+        vec![(0, (1usize << self.log_t) - 1, self.output)]
     }
 }

--- a/src/crypto/stark/air/prove.rs
+++ b/src/crypto/stark/air/prove.rs
@@ -14,9 +14,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! The STARK prover, generic over any AIR. Interpolate the trace, extend it onto
-//! an evaluation coset, commit it, build the constraint composition, prove that
-//! composition is low degree with FRI, and open the sampled window positions.
+//! The STARK prover, generic over any AIR. Interpolate each trace column, extend
+//! it onto an evaluation coset, commit each, build the constraint composition,
+//! prove that composition is low degree with FRI, and open the sampled window
+//! positions across all columns.
 
 use super::super::field::Fp;
 use super::super::fri::{fri_prove, root_of_unity};
@@ -32,12 +33,13 @@ use alloc::vec::Vec;
 /// meets the trace subgroup.
 const SHIFT: u64 = 7;
 
-/// Prove that `trace` satisfies `air`. The evaluation domain and the low-degree
-/// bound are derived from the AIR's constraint degree. `trace.len()` must equal
-/// the AIR's trace length.
+/// Prove that `trace` satisfies `air`. The trace is laid out row-major:
+/// `trace[row * width + col]`. The evaluation domain and the low-degree bound are
+/// derived from the AIR's constraint degree.
 pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], n_queries: usize) -> StarkProof {
     let log_t = air.log_trace_len();
     let t = 1usize << log_t;
+    let width = air.trace_width();
     let (log_n, fri_log_blowup) = domain_params(air);
     let n = 1usize << log_n;
     let blowup = 1usize << (log_n - log_t);
@@ -47,37 +49,48 @@ pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], n_queries: usize) -> StarkProo
     let omega = root_of_unity(log_n);
     let shift = Fp::from_u64(SHIFT);
 
-    // Trace-domain points g^i, then the low-degree extension of the trace onto
-    // the coset D = shift * {omega^j} by Lagrange interpolation.
+    // Trace-domain points g^i.
     let mut h_pts: Vec<Fp> = Vec::with_capacity(t);
     let mut hp = Fp::ONE;
     for _ in 0..t {
         h_pts.push(hp);
         hp = hp * g;
     }
-    let mut trace_d: Vec<Fp> = Vec::with_capacity(n);
-    let mut x = shift;
-    for _ in 0..n {
-        trace_d.push(eval_lagrange(&h_pts, trace, x));
-        x = x * omega;
+
+    // Each column is interpolated and extended onto the coset, then committed.
+    let mut transcript = Transcript::new(b"NONOS-STARK");
+    let mut trace_d: Vec<Vec<Fp>> = Vec::with_capacity(width);
+    let mut trace_trees: Vec<MerkleTree> = Vec::with_capacity(width);
+    let mut trace_roots: Vec<[u8; 32]> = Vec::with_capacity(width);
+    for c in 0..width {
+        let column: Vec<Fp> = (0..t).map(|i| trace[i * width + c]).collect();
+        let mut column_d: Vec<Fp> = Vec::with_capacity(n);
+        let mut x = shift;
+        for _ in 0..n {
+            column_d.push(eval_lagrange(&h_pts, &column, x));
+            x = x * omega;
+        }
+        let tree = MerkleTree::commit(&column_d);
+        transcript.absorb_digest(&tree.root());
+        trace_roots.push(tree.root());
+        trace_trees.push(tree);
+        trace_d.push(column_d);
     }
 
-    let trace_tree = MerkleTree::commit(&trace_d);
-    let trace_root = trace_tree.root();
-
-    // Composition coefficients, drawn after the trace is committed.
-    let mut transcript = Transcript::new(b"NONOS-STARK");
-    transcript.absorb_digest(&trace_root);
+    // Composition coefficients, drawn after the whole trace is committed.
     let coeffs: Vec<Fp> = (0..num_coeffs(air)).map(|_| transcript.challenge_fp()).collect();
 
-    // The constraint composition over the coset. The window at position j reads
-    // the trace j, j+blowup, ... which are exactly f(x), f(g*x), ... on D.
+    // The constraint composition over the coset. The window at position j gathers
+    // every column at rows j, j+blowup, ... which are f(x), f(g*x), ... on D.
     let mut comp_d: Vec<Fp> = Vec::with_capacity(n);
     let mut x = shift;
     for j in 0..n {
-        let mut window: Vec<Fp> = Vec::with_capacity(window_size);
+        let mut window: Vec<Fp> = Vec::with_capacity(window_size * width);
         for k in 0..window_size {
-            window.push(trace_d[(j + k * blowup) % n]);
+            let idx = (j + k * blowup) % n;
+            for column in &trace_d {
+                window.push(column[idx]);
+            }
         }
         comp_d.push(compose(air, g, x, &window, &coeffs));
         x = x * omega;
@@ -92,12 +105,14 @@ pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], n_queries: usize) -> StarkProo
     let mut queries: Vec<StarkQuery> = Vec::with_capacity(n_queries);
     for _ in 0..n_queries {
         let p = transcript.challenge_index(n);
-        let mut window: Vec<Fp> = Vec::with_capacity(window_size);
-        let mut window_paths: Vec<Vec<[u8; 32]>> = Vec::with_capacity(window_size);
+        let mut window: Vec<Fp> = Vec::with_capacity(window_size * width);
+        let mut window_paths: Vec<Vec<[u8; 32]>> = Vec::with_capacity(window_size * width);
         for k in 0..window_size {
             let idx = (p + k * blowup) % n;
-            window.push(trace_d[idx]);
-            window_paths.push(trace_tree.open(idx));
+            for (column, tree) in trace_d.iter().zip(trace_trees.iter()) {
+                window.push(column[idx]);
+                window_paths.push(tree.open(idx));
+            }
         }
         queries.push(StarkQuery {
             comp: comp_d[p],
@@ -107,5 +122,5 @@ pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], n_queries: usize) -> StarkProo
         });
     }
 
-    StarkProof { trace_root, fri, queries }
+    StarkProof { trace_roots, fri, queries }
 }

--- a/src/crypto/stark/air/spec.rs
+++ b/src/crypto/stark/air/spec.rs
@@ -15,10 +15,12 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! The algebraic intermediate representation a STARK proves. A computation is a
-//! single trace column; the transition reads a sliding window of consecutive
-//! rows and returns the constraint values that must vanish on every trace row
-//! but the last `window_size - 1`, and boundary constraints pin chosen rows to
-//! public values. Any type implementing this can be proven by the same engine.
+//! trace of `trace_width` columns; the transition reads a sliding window of
+//! consecutive rows and returns the constraint values that must vanish on every
+//! trace row but the last `window_size - 1`, and boundary constraints pin a
+//! chosen `(column, row)` to a public value. A single column proves a chain; a
+//! wider trace proves a permutation over a multi-element state, which is what a
+//! hash round is. Any type implementing this is proven by the same engine.
 
 use super::super::field::Fp;
 use alloc::vec::Vec;
@@ -27,7 +29,11 @@ pub trait Air {
     /// Log2 of the trace length, a power of two.
     fn log_trace_len(&self) -> u32;
 
-    /// Number of consecutive rows the transition reads (2 reads `x, g*x`).
+    /// Number of trace columns, the width of the state.
+    fn trace_width(&self) -> usize;
+
+    /// Number of consecutive rows the transition reads (2 reads a row and its
+    /// successor).
     fn window_size(&self) -> usize;
 
     /// The highest polynomial degree among the transition constraints, in the
@@ -38,10 +44,12 @@ pub trait Air {
     /// Number of transition constraints (the length of `transition`).
     fn num_transition(&self) -> usize;
 
-    /// The transition constraint values for a window `[f(x), f(g*x), ...]`. Each
-    /// must be zero on every trace row except the final `window_size - 1`.
+    /// The transition constraint values for a window laid out row-major:
+    /// `window[k * trace_width + col]` is column `col` of the k-th row in the
+    /// window. Each returned value must be zero on every trace row except the
+    /// final `window_size - 1`.
     fn transition(&self, window: &[Fp]) -> Vec<Fp>;
 
-    /// Boundary constraints as `(row, value)` on the trace column.
-    fn boundary(&self) -> Vec<(usize, Fp)>;
+    /// Boundary constraints as `(column, row, value)`.
+    fn boundary(&self) -> Vec<(usize, usize, Fp)>;
 }

--- a/src/crypto/stark/air/types.rs
+++ b/src/crypto/stark/air/types.rs
@@ -14,16 +14,17 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! The STARK proof: a trace commitment, a FRI proof that the constraint
-//! composition is low degree, and per-query openings that bind the composition
-//! back to the committed trace over the whole constraint window.
+//! The STARK proof: one Merkle commitment per trace column, a FRI proof that the
+//! constraint composition is low degree, and per-query openings that bind the
+//! composition back to the committed trace over the whole constraint window.
 
 use super::super::field::Fp;
 use super::super::fri::FriProof;
 use alloc::vec::Vec;
 
 /// One consistency query: the composition value at position `p`, and the trace
-/// values across the constraint window starting at `p`, each with a Merkle path.
+/// values across the constraint window at `p`, laid out row-major
+/// (`window[k * width + col]`), each with a Merkle path to its column commitment.
 pub struct StarkQuery {
     pub comp: Fp,
     pub comp_path: Vec<[u8; 32]>,
@@ -33,7 +34,7 @@ pub struct StarkQuery {
 
 /// A complete STARK proof.
 pub struct StarkProof {
-    pub trace_root: [u8; 32],
+    pub trace_roots: Vec<[u8; 32]>,
     pub fri: FriProof,
     pub queries: Vec<StarkQuery>,
 }

--- a/src/crypto/stark/air/verify.rs
+++ b/src/crypto/stark/air/verify.rs
@@ -17,9 +17,9 @@
 //! The STARK verifier, generic over any AIR. It checks the composition is low
 //! degree through FRI, then at each sampled position checks the committed
 //! composition equals the constraint composition recomputed from the committed
-//! trace window. A false trace yields either a high-degree composition (FRI
-//! rejects) or one that disagrees with the trace (consistency rejects). It only
-//! reads the proof and never panics.
+//! trace window across all columns. A false trace yields either a high-degree
+//! composition (FRI rejects) or one that disagrees with the trace (consistency
+//! rejects). It only reads the proof and never panics.
 
 use super::super::field::Fp;
 use super::super::fri::{fri_verify, root_of_unity};
@@ -32,16 +32,17 @@ use alloc::vec::Vec;
 
 const SHIFT: u64 = 7;
 
-/// Verify `proof` against `air`. The evaluation domain and the low-degree bound
-/// are derived from the AIR, matching the prover.
+/// Verify `proof` against `air`. The evaluation domain and low-degree bound are
+/// derived from the AIR, matching the prover.
 pub fn stark_verify<A: Air>(air: &A, proof: &StarkProof, n_queries: usize) -> bool {
     let log_t = air.log_trace_len();
+    let width = air.trace_width();
     let (log_n, fri_log_blowup) = domain_params(air);
     let n = 1usize << log_n;
     let blowup = 1usize << (log_n - log_t);
     let window_size = air.window_size();
 
-    if proof.queries.len() != n_queries {
+    if proof.trace_roots.len() != width || proof.queries.len() != n_queries {
         return false;
     }
 
@@ -57,15 +58,18 @@ pub fn stark_verify<A: Air>(air: &A, proof: &StarkProof, n_queries: usize) -> bo
 
     // 2. Recover the composition coefficients and query positions.
     let mut transcript = Transcript::new(b"NONOS-STARK");
-    transcript.absorb_digest(&proof.trace_root);
+    for root in &proof.trace_roots {
+        transcript.absorb_digest(root);
+    }
     let coeffs: Vec<Fp> = (0..num_coeffs(air)).map(|_| transcript.challenge_fp()).collect();
     transcript.absorb_digest(&comp_root);
 
     // 3. The committed composition must equal the constraint composition of the
-    // committed trace window at every sampled position.
+    // committed trace window, across every column, at every sampled position.
+    let expected_window = window_size * width;
     for qd in &proof.queries {
         let p = transcript.challenge_index(n);
-        if qd.window.len() != window_size || qd.window_paths.len() != window_size {
+        if qd.window.len() != expected_window || qd.window_paths.len() != expected_window {
             return false;
         }
         if !verify_path(&comp_root, p, qd.comp, &qd.comp_path) {
@@ -73,8 +77,12 @@ pub fn stark_verify<A: Air>(air: &A, proof: &StarkProof, n_queries: usize) -> bo
         }
         for k in 0..window_size {
             let idx = (p + k * blowup) % n;
-            if !verify_path(&proof.trace_root, idx, qd.window[k], &qd.window_paths[k]) {
-                return false;
+            for c in 0..width {
+                let slot = k * width + c;
+                if !verify_path(&proof.trace_roots[c], idx, qd.window[slot], &qd.window_paths[slot])
+                {
+                    return false;
+                }
             }
         }
         let x = shift * omega.pow(p as u64);

--- a/userland/stark_proofs/src/air_tests.rs
+++ b/userland/stark_proofs/src/air_tests.rs
@@ -14,7 +14,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::crypto::stark::air::{stark_prove, stark_verify, Fibonacci, PowerChain, Squaring};
+use crate::crypto::stark::air::{
+    stark_prove, stark_verify, Fibonacci, Permutation2, PowerChain, Squaring,
+};
 use crate::crypto::stark::field::Fp;
 
 extern crate alloc;
@@ -92,6 +94,54 @@ fn an_honest_sbox_chain_verifies() {
     let air = PowerChain { log_t: 4, c, output };
     let proof = stark_prove(&air, &trace, QUERIES);
     assert!(stark_verify(&air, &proof, QUERIES), "honest s-box chain rejected");
+}
+
+/// The honest width-two permutation chain and its public final state.
+fn permutation2_trace(log_t: u32, x0: Fp, y0: Fp, rc0: Fp, rc1: Fp) -> (Vec<Fp>, [Fp; 2]) {
+    let t = 1usize << log_t;
+    let mut trace = Vec::with_capacity(2 * t);
+    let (mut x, mut y) = (x0, y0);
+    for _ in 0..t {
+        trace.push(x);
+        trace.push(y);
+        let nx = x.pow(7) + y + rc0;
+        let ny = x + y.pow(7) + rc1;
+        x = nx;
+        y = ny;
+    }
+    let out = [trace[(t - 1) * 2], trace[(t - 1) * 2 + 1]];
+    (trace, out)
+}
+
+#[test]
+fn an_honest_permutation_chain_verifies() {
+    // A width-two state under an x^7 permutation round: the multi-column, hash
+    // round shaped case. The same engine, a two-element state.
+    let (rc0, rc1) = (Fp::from_u64(13), Fp::from_u64(17));
+    let (trace, out) = permutation2_trace(4, Fp::from_u64(2), Fp::from_u64(5), rc0, rc1);
+    let air = Permutation2 { log_t: 4, rc0, rc1, out };
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(stark_verify(&air, &proof, QUERIES), "honest permutation chain rejected");
+}
+
+#[test]
+fn a_corrupted_permutation_step_is_rejected() {
+    let (rc0, rc1) = (Fp::from_u64(13), Fp::from_u64(17));
+    let (mut trace, out) = permutation2_trace(4, Fp::from_u64(2), Fp::from_u64(5), rc0, rc1);
+    // Corrupt the y column at some row.
+    trace[9] = trace[9] + Fp::ONE;
+    let air = Permutation2 { log_t: 4, rc0, rc1, out };
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(!stark_verify(&air, &proof, QUERIES), "a corrupted permutation step verified");
+}
+
+#[test]
+fn a_wrong_permutation_output_is_rejected() {
+    let (rc0, rc1) = (Fp::from_u64(13), Fp::from_u64(17));
+    let (trace, out) = permutation2_trace(4, Fp::from_u64(2), Fp::from_u64(5), rc0, rc1);
+    let air = Permutation2 { log_t: 4, rc0, rc1, out: [out[0] + Fp::ONE, out[1]] };
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(!stark_verify(&air, &proof, QUERIES), "a wrong permutation output verified");
 }
 
 #[test]


### PR DESCRIPTION
Widens the AIR engine from a single trace column to a multi-element state, the capability a hash permutation needs.

An AIR now reports `trace_width`. Transition windows are laid out row-major across columns (`window[k * width + col]`), and boundary constraints target a `(column, row)`. The prover interpolates and commits each column on its own and opens the full window across all columns per query; the verifier binds every opened value to its column commitment. The existing single-column AIRs are just the width-one case.

On top, `Permutation2` proves a two-element round `x = x^7 + y + rc0`, `y = x + y^7 + rc1`: a full x^7 S-box on each state element with a linear mix and round constants, the structure a Poseidon or Rescue hash round is built from. Proving a chain of it is a computational-integrity proof over a multi-element permutation, which is the shape the NOX proof-anchoring utility wants.

Host proofs (13): honest squaring, Fibonacci, S-box chain, and permutation chain all verify; a corrupted step in each, wrong S-box and permutation outputs, a wrong boundary, and a tampered opening are all rejected. 33/33 stark_proofs tests, clippy -D warnings clean, kernel builds with it wired in.

Stacked on Stark-Air-Sbox (#290).