### PR TITLE
deps: patch crossbeam-epoch for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
RUSTSEC-2026-0204 published on 2026-07-06 flags crossbeam-epoch 0.9.18
(invalid pointer dereference in the fmt::Pointer impl). The supply-chain gate
now fails on every branch that runs after the advisory landed, independent of
the branch's own changes. This takes the patched 0.9.20, one line in the
lockfile. Open verification branches carry the same one-line bump so their
gates stay green until this merges and they rebase.