### PR TITLE
ci: add the verification pipeline to main

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,232 @@
+# NONOS Operating System
+# Copyright (C) 2026 NONOS Contributors
+#
+# Verification pipeline for source hygiene, runnable proofs, crypto vectors,
+# Kani model checks, and Verus theorems.
+name: verify
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Verification engine clippy
+        run: cargo clippy --manifest-path nonos-verify/Cargo.toml --all-targets -- -D warnings
+      - name: Production source hygiene
+        run: cargo run --manifest-path nonos-verify/Cargo.toml -- hygiene
+
+  runnable-proofs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Host proof suite (store, protocol, security, formatting, fuzz)
+        run: cargo test --release
+        working-directory: userland/fs_proofs
+      - name: Host proof clippy
+        run: cargo clippy --release -- -D warnings
+        working-directory: userland/fs_proofs
+
+  crypto-proofs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Crypto known-answer proofs
+        run: cargo test --release
+        working-directory: userland/crypto_proofs
+      - name: Crypto proof clippy
+        run: cargo clippy --release -- -D warnings
+        working-directory: userland/crypto_proofs
+
+  kani:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: model-checking/kani-github-action@v1
+        with:
+          kani-version: "0.67.0"
+          working-directory: userland/fs_proofs
+
+  verus:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Verus
+        run: |
+          set -euo pipefail
+          VERUS_VERSION="0.2026.06.28.1847ab3"
+          rustup toolchain install 1.96.0-x86_64-unknown-linux-gnu
+          curl -fsSL -o verus.zip \
+            "https://github.com/verus-lang/verus/releases/download/release/${VERUS_VERSION}/verus-${VERUS_VERSION}-x86-linux.zip"
+          unzip -q verus.zip -d "$HOME/verus"
+          echo "$HOME/verus/verus-x86-linux" >> "$GITHUB_PATH"
+      - name: Verify capability theorems
+        run: verus --crate-type=lib src/lib.rs
+        working-directory: verification/verus
+
+  boot-proofs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Boot proofs
+        run: |
+          if [ -d nonos-bootloader/boot_proofs ]; then
+            cargo test --release --manifest-path nonos-bootloader/boot_proofs/Cargo.toml
+          else
+            echo "nonos-bootloader/boot_proofs absent on this ref; skipping"
+          fi
+
+  proof-crates:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate:
+          - kernel_proofs
+          - net_proofs
+          - driver_proofs
+          - usb_proofs
+          - nvme_proofs
+          - usb_msc_proofs
+          - virtio_blk_proofs
+          - virtio_net_proofs
+          - e1000_proofs
+          - rtl8139_proofs
+          - xhci_proofs
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Runnable proofs and clippy
+        run: |
+          if [ -d "userland/${{ matrix.crate }}" ]; then
+            cargo test --release --manifest-path "userland/${{ matrix.crate }}/Cargo.toml"
+            cargo clippy --release --all-targets \
+              --manifest-path "userland/${{ matrix.crate }}/Cargo.toml" -- -D warnings
+          else
+            echo "userland/${{ matrix.crate }} absent on this ref; skipping"
+          fi
+
+  proof-crates-kani:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Kani
+        run: |
+          cargo install --locked kani-verifier --version 0.67.0
+          cargo kani setup
+      - name: Kani model checks
+        run: |
+          set -euo pipefail
+          for crate in kernel_proofs net_proofs driver_proofs usb_proofs nvme_proofs \
+              usb_msc_proofs virtio_blk_proofs virtio_net_proofs e1000_proofs \
+              rtl8139_proofs xhci_proofs; do
+            if [ -d "userland/$crate" ]; then
+              ( cd "userland/$crate" && cargo kani --output-format terse )
+            else
+              echo "userland/$crate absent on this ref; skipping"
+            fi
+          done
+
+  lean:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install elan
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://elan.lean-lang.org/elan-init.sh \
+            | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: Specification theorems
+        run: |
+          if [ -d verification/lean ]; then
+            ( cd verification/lean && lake build )
+          else
+            echo "verification/lean absent on this ref; skipping"
+          fi
+
+  extraction:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install the extraction toolchain
+        run: |
+          set -euo pipefail
+          if [ ! -d verification/extraction ]; then
+            echo "verification/extraction absent on this ref; skipping"
+            exit 0
+          fi
+          rustup toolchain install nightly-2026-06-01 --profile minimal \
+            --component rustc-dev,llvm-tools-preview,rust-src
+          mkdir -p "$HOME/exttools" && cd "$HOME/exttools"
+          curl -fsSL -o charon.tar.gz \
+            "https://github.com/AeneasVerif/charon/releases/download/nightly-2026.07.02/charon-linux-x86_64.tar.gz"
+          tar xzf charon.tar.gz
+          curl -fsSL -o aeneas.tar.gz \
+            "https://github.com/AeneasVerif/aeneas/releases/download/nightly-2026.07.06-45061fa/aeneas-linux-x86_64.tar.gz"
+          tar xzf aeneas.tar.gz
+          echo "$HOME/exttools" >> "$GITHUB_PATH"
+          curl --proto '=https' --tlsv1.2 -sSf https://elan.lean-lang.org/elan-init.sh \
+            | sh -s -- -y --default-toolchain none
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+      - name: Regenerate and check for drift
+        run: |
+          set -euo pipefail
+          if [ ! -d verification/extraction ]; then exit 0; fi
+          cd verification/extraction/caps
+          charon cargo --preset=aeneas \
+            --start-from 'nonos_caps::capabilities::bits::has_capability' \
+            --start-from 'nonos_caps::capabilities::bits::add_capability' \
+            --start-from 'nonos_caps::capabilities::bits::remove_capability' \
+            --dest-file caps.llbc
+          mkdir -p /tmp/regen-caps
+          aeneas -backend lean caps.llbc -dest /tmp/regen-caps
+          diff -u ../lean/NonosExtraction/Caps.lean /tmp/regen-caps/Caps.lean
+          cd ../policy
+          charon cargo --preset=aeneas \
+            --start-from 'nonos_policy::usercopy::policy::check_range' \
+            --start-from 'nonos_policy::to_pte_flags' \
+            --start-from 'nonos_policy::is_wx_violation' \
+            --dest-file policy.llbc
+          mkdir -p /tmp/regen-policy
+          aeneas -backend lean -split-files policy.llbc -dest /tmp/regen-policy
+          for f in Types.lean Funs.lean FunsExternal_Template.lean; do
+            diff -u "../lean/Policy/$f" "/tmp/regen-policy/$f"
+          done
+      - name: Verify the refinement theorems
+        run: |
+          set -euo pipefail
+          if [ ! -d verification/extraction ]; then exit 0; fi
+          cd verification/extraction/lean
+          lake exe cache get
+          lake build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Why this exists
PR #270 (the verification foundation) was squash-merged into `Fs-Hardening`,
not `main`, because `verification-foundation` had been branched off
`Fs-Hardening` and GitHub defaulted the base there. The result is that
`main` never got `verify.yml`, even though every driver and kernel proof PR
targets `main` directly. That merge cannot be undone, so this brings the CI
onto `main` cleanly, based on current `main` rather than the older
foundation branch.

## What it runs
Unconditional (all present on main today, so green now): source hygiene,
the fs and crypto host proofs, the Kani model checks on fs_proofs, and the
Verus theorems.

Guarded (skip on refs without the surface, light up as each PR merges): the
eleven driver and kernel proof crates with clippy and a Kani sweep, the boot
proofs, the Lean specification build, and the Charon plus Aeneas extraction
drift gate that regenerates the Lean from kernel MIR and fails on any
divergence.

## Follow-on to fully green main
- Lean job goes live when Lean-Proofs (#273) merges to main.
- Extraction gate goes live when Extraction-Proofs (#286) merges (it stacks
  on #273).
- The per-crate jobs light up as #276, #278, #279, #282, #283, #284, #287 and
  the rest merge.

Includes the crossbeam-epoch 0.9.20 bump for RUSTSEC-2026-0204 so the
supply-chain gate stays green here too.