### PR TITLE
stark: extend traces by NTT for O(n log n) proving

### DIFF
--- a/src/crypto/stark/air/prove.rs
+++ b/src/crypto/stark/air/prove.rs
@@ -22,9 +22,9 @@
 use super::super::field::Fp;
 use super::super::fri::{fri_prove, root_of_unity};
 use super::super::merkle::MerkleTree;
-use super::super::poly::eval_lagrange;
+use super::super::poly::lde;
 use super::super::transcript::Transcript;
-use super::composition::{compose, domain_params, eval_periodic, num_coeffs};
+use super::composition::{compose, domain_params, num_coeffs};
 use super::spec::Air;
 use super::types::{StarkProof, StarkQuery};
 use alloc::vec::Vec;
@@ -49,27 +49,14 @@ pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], n_queries: usize) -> StarkProo
     let omega = root_of_unity(log_n);
     let shift = Fp::from_u64(SHIFT);
 
-    // Trace-domain points g^i.
-    let mut h_pts: Vec<Fp> = Vec::with_capacity(t);
-    let mut hp = Fp::ONE;
-    for _ in 0..t {
-        h_pts.push(hp);
-        hp = hp * g;
-    }
-
-    // Each column is interpolated and extended onto the coset, then committed.
+    // Each column is extended onto the coset by transform, then committed.
     let mut transcript = Transcript::new(b"NONOS-STARK");
     let mut trace_d: Vec<Vec<Fp>> = Vec::with_capacity(width);
     let mut trace_trees: Vec<MerkleTree> = Vec::with_capacity(width);
     let mut trace_roots: Vec<[u8; 32]> = Vec::with_capacity(width);
     for c in 0..width {
         let column: Vec<Fp> = (0..t).map(|i| trace[i * width + c]).collect();
-        let mut column_d: Vec<Fp> = Vec::with_capacity(n);
-        let mut x = shift;
-        for _ in 0..n {
-            column_d.push(eval_lagrange(&h_pts, &column, x));
-            x = x * omega;
-        }
+        let column_d = lde(&column, g, shift, omega, n);
         let tree = MerkleTree::commit(&column_d);
         transcript.absorb_digest(&tree.root());
         trace_roots.push(tree.root());
@@ -80,8 +67,9 @@ pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], n_queries: usize) -> StarkProo
     // Composition coefficients, drawn after the whole trace is committed.
     let coeffs: Vec<Fp> = (0..num_coeffs(air)).map(|_| transcript.challenge_fp()).collect();
 
-    // Public periodic columns (round constants) interpolated over the trace domain.
-    let periodic_cols = air.periodic_columns();
+    // Public periodic columns (round constants), each extended onto the coset once.
+    let periodic_d: Vec<Vec<Fp>> =
+        air.periodic_columns().iter().map(|col| lde(col, g, shift, omega, n)).collect();
 
     // The constraint composition over the coset. The window at position j gathers
     // every column at rows j, j+blowup, ... which are f(x), f(g*x), ... on D.
@@ -95,7 +83,7 @@ pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], n_queries: usize) -> StarkProo
                 window.push(column[idx]);
             }
         }
-        let periodic = eval_periodic(&periodic_cols, &h_pts, x);
+        let periodic: Vec<Fp> = periodic_d.iter().map(|pd| pd[j]).collect();
         comp_d.push(compose(air, g, x, &window, &periodic, &coeffs));
         x = x * omega;
     }

--- a/src/crypto/stark/poly/lde.rs
+++ b/src/crypto/stark/poly/lde.rs
@@ -1,0 +1,43 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The low-degree extension by transform: interpolate values on the trace
+//! subgroup, then evaluate the same polynomial on a larger coset. This is the
+//! per-column extension the prover runs, in O(n log n).
+
+use super::super::field::Fp;
+use super::ntt::{intt, ntt};
+use alloc::vec::Vec;
+
+/// Extend `values`, the evaluations of a polynomial on the size-`values.len()`
+/// subgroup `{trace_gen^i}`, onto the coset `shift * {coset_gen^i}` of size
+/// `target_len`. `trace_gen` and `coset_gen` are primitive roots of unity of the
+/// respective orders. The result equals evaluating the interpolating polynomial
+/// at each coset point, computed by transform rather than point by point.
+pub fn lde(values: &[Fp], trace_gen: Fp, shift: Fp, coset_gen: Fp, target_len: usize) -> Vec<Fp> {
+    // Interpolate to coefficients over the trace subgroup.
+    let mut coeffs = intt(values, trace_gen);
+    // Extend the coefficient list to the target degree with zeros.
+    coeffs.resize(target_len, Fp::ZERO);
+    // Fold the coset shift into the coefficients: evaluating `sum c_i (shift*x)^i`
+    // is evaluating `sum (c_i shift^i) x^i`, so scale then transform.
+    let mut s = Fp::ONE;
+    for c in coeffs.iter_mut() {
+        *c = *c * s;
+        s = s * shift;
+    }
+    ntt(&coeffs, coset_gen)
+}

--- a/src/crypto/stark/poly/mod.rs
+++ b/src/crypto/stark/poly/mod.rs
@@ -1,9 +1,14 @@
 // NONOS Operating System (AGPL-3.0-or-later)
-//! Polynomials over the field: evaluation in coefficient form and Lagrange
-//! evaluation of the low-degree extension.
+//! Polynomials over the field: evaluation in coefficient form, Lagrange
+//! evaluation of the low-degree extension, and the number-theoretic transform
+//! with the coset low-degree extension built on it.
 
 mod eval;
 mod lagrange;
+mod lde;
+mod ntt;
 
 pub use eval::eval;
 pub use lagrange::eval_lagrange;
+pub use lde::lde;
+pub use ntt::{intt, ntt};

--- a/src/crypto/stark/poly/ntt.rs
+++ b/src/crypto/stark/poly/ntt.rs
@@ -1,0 +1,85 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The number-theoretic transform: evaluate a polynomial on a multiplicative
+//! subgroup, and its inverse, in O(n log n) instead of O(n^2). This is what lets
+//! the prover extend a trace to a large domain at scale. `omega` must be a
+//! primitive `n`-th root of unity, where `n` is the length, a power of two.
+
+use super::super::field::Fp;
+use alloc::vec::Vec;
+
+/// Reorder `a` into bit-reversed index order in place.
+fn bit_reverse(a: &mut [Fp]) {
+    let n = a.len();
+    let mut j = 0usize;
+    for i in 1..n {
+        let mut bit = n >> 1;
+        while j & bit != 0 {
+            j ^= bit;
+            bit >>= 1;
+        }
+        j ^= bit;
+        if i < j {
+            a.swap(i, j);
+        }
+    }
+}
+
+/// Evaluate `coeffs` (low degree first) on `{omega^0, ..., omega^{n-1}}` by the
+/// iterative radix-2 transform. Returns the `n` evaluations in natural order.
+pub fn ntt(coeffs: &[Fp], omega: Fp) -> Vec<Fp> {
+    let n = coeffs.len();
+    let mut a = coeffs.to_vec();
+    if n <= 1 {
+        return a;
+    }
+    bit_reverse(&mut a);
+
+    let mut len = 2usize;
+    while len <= n {
+        // A primitive len-th root of unity.
+        let w_len = omega.pow((n / len) as u64);
+        let mut start = 0usize;
+        while start < n {
+            let mut w = Fp::ONE;
+            for j in 0..len / 2 {
+                let u = a[start + j];
+                let v = a[start + j + len / 2] * w;
+                a[start + j] = u + v;
+                a[start + j + len / 2] = u - v;
+                w = w * w_len;
+            }
+            start += len;
+        }
+        len <<= 1;
+    }
+    a
+}
+
+/// Interpolate `evals` on `{omega^0, ..., omega^{n-1}}` back to coefficients: the
+/// transform with the inverse root, scaled by `1/n`.
+pub fn intt(evals: &[Fp], omega: Fp) -> Vec<Fp> {
+    let n = evals.len();
+    let mut a = ntt(evals, omega.inv());
+    if n > 1 {
+        let n_inv = Fp::from_u64(n as u64).inv();
+        for x in a.iter_mut() {
+            *x = *x * n_inv;
+        }
+    }
+    a
+}

--- a/userland/stark_proofs/src/lib.rs
+++ b/userland/stark_proofs/src/lib.rs
@@ -15,4 +15,6 @@ mod fri_tests;
 #[cfg(test)]
 mod merkle_tests;
 #[cfg(test)]
+mod ntt_tests;
+#[cfg(test)]
 mod poly_tests;

--- a/userland/stark_proofs/src/ntt_tests.rs
+++ b/userland/stark_proofs/src/ntt_tests.rs
@@ -1,0 +1,92 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::crypto::stark::field::Fp;
+use crate::crypto::stark::fri::root_of_unity;
+use crate::crypto::stark::poly::{eval, eval_lagrange, intt, lde, ntt};
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+// The transform is the prover's scaling path. It must agree exactly with the
+// direct methods it replaces: evaluation on the subgroup, and the Lagrange
+// low-degree extension onto the coset. These checks pin that equality.
+
+fn xorshift(state: &mut u64) -> u64 {
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+    *state
+}
+
+fn random(n: usize, seed: u64) -> Vec<Fp> {
+    let mut s = seed | 1;
+    (0..n).map(|_| Fp::from_u64(xorshift(&mut s))).collect()
+}
+
+#[test]
+fn ntt_matches_pointwise_evaluation() {
+    for log_n in [1u32, 2, 3, 5, 8] {
+        let n = 1usize << log_n;
+        let omega = root_of_unity(log_n);
+        let coeffs = random(n, 0x1234 + log_n as u64);
+        let evals = ntt(&coeffs, omega);
+        let mut x = Fp::ONE;
+        for (j, &e) in evals.iter().enumerate() {
+            assert_eq!(e, eval(&coeffs, x), "ntt disagrees with evaluation at {j}");
+            x = x * omega;
+        }
+    }
+}
+
+#[test]
+fn intt_inverts_ntt() {
+    for log_n in [1u32, 3, 5, 8] {
+        let n = 1usize << log_n;
+        let omega = root_of_unity(log_n);
+        let coeffs = random(n, 0xabcd + log_n as u64);
+        assert_eq!(intt(&ntt(&coeffs, omega), omega), coeffs, "intt did not invert ntt");
+    }
+}
+
+#[test]
+fn lde_matches_the_lagrange_extension() {
+    // Extend a size-16 trace onto a size-64 coset and compare against the direct
+    // Lagrange evaluation at every coset point.
+    let (log_t, log_n) = (4u32, 6u32);
+    let (t, n) = (1usize << log_t, 1usize << log_n);
+    let g = root_of_unity(log_t);
+    let omega = root_of_unity(log_n);
+    let shift = Fp::from_u64(7);
+
+    let values = random(t, 0x9e37);
+    let fast = lde(&values, g, shift, omega, n);
+
+    let h_pts: Vec<Fp> = {
+        let mut v = Vec::with_capacity(t);
+        let mut p = Fp::ONE;
+        for _ in 0..t {
+            v.push(p);
+            p = p * g;
+        }
+        v
+    };
+    let mut x = shift;
+    for (j, &f) in fast.iter().enumerate() {
+        assert_eq!(f, eval_lagrange(&h_pts, &values, x), "lde disagrees with lagrange at {j}");
+        x = x * omega;
+    }
+}


### PR DESCRIPTION
The prover extended each trace column onto the evaluation coset with a Lagrange evaluation at every point: O(n^2), which caps the trace at small sizes and is the main thing stopping the STARK from proving real computations.

Adds the number-theoretic transform: the iterative radix-2 NTT and its inverse over the Goldilocks field, and a coset low-degree extension built on them that interpolates a column over the trace subgroup and evaluates it over the larger coset in O(n log n). The prover uses it for both the trace columns and the periodic round-constant columns.

Correctness is pinned by cross-checking against the direct methods it replaces, so the proofs are bit-identical and every existing test still passes:
- the NTT equals pointwise polynomial evaluation on the subgroup,
- the inverse transform inverts it,
- the coset extension equals the Lagrange extension at every coset point.

41/41 stark_proofs tests, clippy -D warnings clean, kernel builds with it wired in.

Stacked on Stark-Air-Poseidon (#296).