### PR TITLE
stark: DEEP out-of-domain sampling

### DIFF
--- a/src/crypto/stark/air/composition.rs
+++ b/src/crypto/stark/air/composition.rs
@@ -22,20 +22,11 @@
 //! on the two sides by construction.
 
 use super::super::field::Fp;
-use super::super::poly::eval_lagrange;
 use super::spec::Air;
-use alloc::vec::Vec;
 
 /// Total number of random coefficients an AIR's composition consumes.
 pub(super) fn num_coeffs<A: Air>(air: &A) -> usize {
     air.num_transition() + air.boundary().len()
-}
-
-/// Evaluate each periodic column at point `x` by interpolating it over the trace
-/// domain `h_pts`. The columns are public, so prover and verifier compute this
-/// identically.
-pub(super) fn eval_periodic(columns: &[Vec<Fp>], h_pts: &[Fp], x: Fp) -> Vec<Fp> {
-    columns.iter().map(|col| eval_lagrange(h_pts, col, x)).collect()
 }
 
 /// The evaluation-domain sizing derived from the AIR: `(log_n, fri_log_blowup)`.

--- a/src/crypto/stark/air/prove.rs
+++ b/src/crypto/stark/air/prove.rs
@@ -14,15 +14,17 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! The STARK prover, generic over any AIR. Interpolate each trace column, extend
-//! it onto an evaluation coset, commit each, build the constraint composition,
-//! prove that composition is low degree with FRI, and open the sampled window
-//! positions across all columns.
+//! The DEEP STARK prover, generic over any AIR. Commit the extended trace and
+//! the constraint composition, evaluate the trace at an out-of-domain point
+//! drawn from the transcript, and prove with FRI that the DEEP quotients, which
+//! tie every committed value to those out-of-domain evaluations, are one low
+//! degree polynomial. The out-of-domain binding is what lets each query open a
+//! single row instead of a whole constraint window.
 
 use super::super::field::Fp;
 use super::super::fri::{fri_prove, root_of_unity};
 use super::super::merkle::MerkleTree;
-use super::super::poly::lde;
+use super::super::poly::{eval, intt, lde};
 use super::super::transcript::Transcript;
 use super::composition::{compose, domain_params, num_coeffs};
 use super::spec::Air;
@@ -33,9 +35,22 @@ use alloc::vec::Vec;
 /// meets the trace subgroup.
 const SHIFT: u64 = 7;
 
+/// Draw the out-of-domain point: a challenge that lies neither on the
+/// evaluation coset nor on the trace domain, so every DEEP denominator and
+/// every periodic-column denominator is invertible. Both sides run this
+/// identically, so they agree on the point.
+pub(super) fn draw_ood_point(transcript: &mut Transcript, shift: Fp, n: usize, t: usize) -> Fp {
+    let shift_n = shift.pow(n as u64);
+    let mut z = transcript.challenge_fp();
+    while z.pow(n as u64) == shift_n || z.pow(t as u64) == Fp::ONE {
+        z = transcript.challenge_fp();
+    }
+    z
+}
+
 /// Prove that `trace` satisfies `air`. The trace is laid out row-major:
-/// `trace[row * width + col]`. The evaluation domain and the low-degree bound are
-/// derived from the AIR's constraint degree.
+/// `trace[row * width + col]`. The evaluation domain and the low-degree bound
+/// are derived from the AIR's constraint degree.
 pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], n_queries: usize) -> StarkProof {
     let log_t = air.log_trace_len();
     let t = 1usize << log_t;
@@ -49,9 +64,11 @@ pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], n_queries: usize) -> StarkProo
     let omega = root_of_unity(log_n);
     let shift = Fp::from_u64(SHIFT);
 
-    // Each column is extended onto the coset by transform, then committed.
+    // Each column is extended onto the coset by transform and committed; its
+    // coefficients are kept for the out-of-domain evaluations.
     let mut transcript = Transcript::new(b"NONOS-STARK");
     let mut trace_d: Vec<Vec<Fp>> = Vec::with_capacity(width);
+    let mut trace_coeffs: Vec<Vec<Fp>> = Vec::with_capacity(width);
     let mut trace_trees: Vec<MerkleTree> = Vec::with_capacity(width);
     let mut trace_roots: Vec<[u8; 32]> = Vec::with_capacity(width);
     for c in 0..width {
@@ -60,6 +77,7 @@ pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], n_queries: usize) -> StarkProo
         let tree = MerkleTree::commit(&column_d);
         transcript.absorb_digest(&tree.root());
         trace_roots.push(tree.root());
+        trace_coeffs.push(intt(&column, g));
         trace_trees.push(tree);
         trace_d.push(column_d);
     }
@@ -67,12 +85,12 @@ pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], n_queries: usize) -> StarkProo
     // Composition coefficients, drawn after the whole trace is committed.
     let coeffs: Vec<Fp> = (0..num_coeffs(air)).map(|_| transcript.challenge_fp()).collect();
 
-    // Public periodic columns (round constants), each extended onto the coset once.
+    // Public periodic columns (round constants), each extended onto the coset.
+    let periodic_cols = air.periodic_columns();
     let periodic_d: Vec<Vec<Fp>> =
-        air.periodic_columns().iter().map(|col| lde(col, g, shift, omega, n)).collect();
+        periodic_cols.iter().map(|col| lde(col, g, shift, omega, n)).collect();
 
-    // The constraint composition over the coset. The window at position j gathers
-    // every column at rows j, j+blowup, ... which are f(x), f(g*x), ... on D.
+    // The constraint composition over the coset, committed on its own.
     let mut comp_d: Vec<Fp> = Vec::with_capacity(n);
     let mut x = shift;
     for j in 0..n {
@@ -87,32 +105,85 @@ pub fn stark_prove<A: Air>(air: &A, trace: &[Fp], n_queries: usize) -> StarkProo
         comp_d.push(compose(air, g, x, &window, &periodic, &coeffs));
         x = x * omega;
     }
-
-    // FRI proves the composition is low degree; its first root commits it.
-    let fri = fri_prove(&comp_d, shift, fri_log_blowup, n_queries);
     let comp_tree = MerkleTree::commit(&comp_d);
+    transcript.absorb_digest(&comp_tree.root());
 
-    // Consistency positions, bound after the composition commitment.
+    // The out-of-domain point and the trace frame there: every column at
+    // g^k * z for each window row k.
+    let z = draw_ood_point(&mut transcript, shift, n, t);
+    let mut ood_frame: Vec<Fp> = Vec::with_capacity(window_size * width);
+    for k in 0..window_size {
+        let zk = z * g.pow(k as u64);
+        for coeffs_c in &trace_coeffs {
+            ood_frame.push(eval(coeffs_c, zk));
+        }
+    }
+    for value in &ood_frame {
+        transcript.absorb_fp(*value);
+    }
+
+    // The composition at z follows from the frame; a dishonest frame makes the
+    // DEEP quotient below fail the low-degree test.
+    let periodic_z: Vec<Fp> = {
+        let h_pts: Vec<Fp> = {
+            let mut v = Vec::with_capacity(t);
+            let mut p = Fp::ONE;
+            for _ in 0..t {
+                v.push(p);
+                p = p * g;
+            }
+            v
+        };
+        periodic_cols.iter().map(|col| super::super::poly::eval_lagrange(&h_pts, col, z)).collect()
+    };
+    let comp_z = compose(air, g, z, &ood_frame, &periodic_z, &coeffs);
+
+    // DEEP coefficients: one per (column, window row) quotient and one for the
+    // composition quotient.
+    let deep_coeffs: Vec<Fp> =
+        (0..width * window_size + 1).map(|_| transcript.challenge_fp()).collect();
+
+    // The DEEP polynomial over the coset: every quotient is a polynomial exactly
+    // when the committed values match the out-of-domain claims.
+    let mut deep_d: Vec<Fp> = Vec::with_capacity(n);
+    let mut x = shift;
+    for j in 0..n {
+        let mut acc = Fp::ZERO;
+        for k in 0..window_size {
+            let zk = z * g.pow(k as u64);
+            let inv_x_zk = (x - zk).inv();
+            for (c, column) in trace_d.iter().enumerate() {
+                let claimed = ood_frame[k * width + c];
+                acc = acc + deep_coeffs[k * width + c] * ((column[j] - claimed) * inv_x_zk);
+            }
+        }
+        let e = deep_coeffs[width * window_size];
+        acc = acc + e * ((comp_d[j] - comp_z) * (x - z).inv());
+        deep_d.push(acc);
+        x = x * omega;
+    }
+
+    // FRI proves the DEEP polynomial is low degree; its first root commits it.
+    let fri = fri_prove(&deep_d, shift, fri_log_blowup, n_queries);
+    let deep_tree = MerkleTree::commit(&deep_d);
     transcript.absorb_digest(&fri.roots[0]);
+
+    // Consistency queries: open the DEEP value, each trace column, and the
+    // composition at each sampled position.
     let mut queries: Vec<StarkQuery> = Vec::with_capacity(n_queries);
     for _ in 0..n_queries {
         let p = transcript.challenge_index(n);
-        let mut window: Vec<Fp> = Vec::with_capacity(window_size * width);
-        let mut window_paths: Vec<Vec<[u8; 32]>> = Vec::with_capacity(window_size * width);
-        for k in 0..window_size {
-            let idx = (p + k * blowup) % n;
-            for (column, tree) in trace_d.iter().zip(trace_trees.iter()) {
-                window.push(column[idx]);
-                window_paths.push(tree.open(idx));
-            }
-        }
+        let trace_vals: Vec<Fp> = trace_d.iter().map(|col| col[p]).collect();
+        let trace_paths: Vec<Vec<[u8; 32]>> = trace_trees.iter().map(|tree| tree.open(p)).collect();
         queries.push(StarkQuery {
+            deep: deep_d[p],
+            deep_path: deep_tree.open(p),
+            trace: trace_vals,
+            trace_paths,
             comp: comp_d[p],
             comp_path: comp_tree.open(p),
-            window,
-            window_paths,
         });
     }
 
-    StarkProof { trace_roots, fri, queries }
+    StarkProof { trace_roots, comp_root: comp_tree.root(), ood_frame, fri, queries }
 }

--- a/src/crypto/stark/air/types.rs
+++ b/src/crypto/stark/air/types.rs
@@ -14,27 +14,35 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! The STARK proof: one Merkle commitment per trace column, a FRI proof that the
-//! constraint composition is low degree, and per-query openings that bind the
-//! composition back to the committed trace over the whole constraint window.
+//! The STARK proof in its DEEP form: commitments to the trace columns and the
+//! constraint composition, the trace evaluations at an out-of-domain point (the
+//! OOD frame), a FRI proof that the DEEP quotient polynomial is low degree, and
+//! per-query openings binding that quotient to the committed trace and
+//! composition.
 
 use super::super::field::Fp;
 use super::super::fri::FriProof;
 use alloc::vec::Vec;
 
-/// One consistency query: the composition value at position `p`, and the trace
-/// values across the constraint window at `p`, laid out row-major
-/// (`window[k * width + col]`), each with a Merkle path to its column commitment.
+/// One consistency query at position `p`: the DEEP polynomial value (opened
+/// against the FRI layer-zero commitment), each trace column at `p`, and the
+/// composition at `p`, each with a Merkle path to its commitment.
 pub struct StarkQuery {
+    pub deep: Fp,
+    pub deep_path: Vec<[u8; 32]>,
+    pub trace: Vec<Fp>,
+    pub trace_paths: Vec<Vec<[u8; 32]>>,
     pub comp: Fp,
     pub comp_path: Vec<[u8; 32]>,
-    pub window: Vec<Fp>,
-    pub window_paths: Vec<Vec<[u8; 32]>>,
 }
 
 /// A complete STARK proof.
 pub struct StarkProof {
     pub trace_roots: Vec<[u8; 32]>,
+    pub comp_root: [u8; 32],
+    /// The trace columns evaluated at `g^k * z` for each window row `k`, laid
+    /// out row-major like a transition window: `ood_frame[k * width + col]`.
+    pub ood_frame: Vec<Fp>,
     pub fri: FriProof,
     pub queries: Vec<StarkQuery>,
 }

--- a/src/crypto/stark/air/verify.rs
+++ b/src/crypto/stark/air/verify.rs
@@ -14,18 +14,21 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! The STARK verifier, generic over any AIR. It checks the composition is low
-//! degree through FRI, then at each sampled position checks the committed
-//! composition equals the constraint composition recomputed from the committed
-//! trace window across all columns. A false trace yields either a high-degree
-//! composition (FRI rejects) or one that disagrees with the trace (consistency
-//! rejects). It only reads the proof and never panics.
+//! The DEEP STARK verifier, generic over any AIR. It recomputes the transcript,
+//! evaluates the constraints once at the out-of-domain point using the claimed
+//! trace frame, checks with FRI that the DEEP quotient polynomial is low degree,
+//! and at each sampled position recomputes that quotient from the committed
+//! trace and composition openings. A false trace either breaks a quotient (FRI
+//! rejects) or disagrees with an opening (the consistency check rejects). It
+//! only reads the proof and never panics.
 
 use super::super::field::Fp;
 use super::super::fri::{fri_verify, root_of_unity};
 use super::super::merkle::verify_path;
+use super::super::poly::eval_lagrange;
 use super::super::transcript::Transcript;
-use super::composition::{compose, domain_params, eval_periodic, num_coeffs};
+use super::composition::{compose, domain_params, num_coeffs};
+use super::prove::draw_ood_point;
 use super::spec::Air;
 use super::types::StarkProof;
 use alloc::vec::Vec;
@@ -36,13 +39,16 @@ const SHIFT: u64 = 7;
 /// derived from the AIR, matching the prover.
 pub fn stark_verify<A: Air>(air: &A, proof: &StarkProof, n_queries: usize) -> bool {
     let log_t = air.log_trace_len();
+    let t = 1usize << log_t;
     let width = air.trace_width();
     let (log_n, fri_log_blowup) = domain_params(air);
     let n = 1usize << log_n;
-    let blowup = 1usize << (log_n - log_t);
     let window_size = air.window_size();
 
-    if proof.trace_roots.len() != width || proof.queries.len() != n_queries {
+    if proof.trace_roots.len() != width
+        || proof.ood_frame.len() != window_size * width
+        || proof.queries.len() != n_queries
+    {
         return false;
     }
 
@@ -50,54 +56,74 @@ pub fn stark_verify<A: Air>(air: &A, proof: &StarkProof, n_queries: usize) -> bo
     let omega = root_of_unity(log_n);
     let shift = Fp::from_u64(SHIFT);
 
-    // Trace-domain points g^i, for interpolating the public periodic columns.
-    let t = 1usize << log_t;
-    let mut h_pts: Vec<Fp> = Vec::with_capacity(t);
-    let mut hp = Fp::ONE;
-    for _ in 0..t {
-        h_pts.push(hp);
-        hp = hp * g;
-    }
-    let periodic_cols = air.periodic_columns();
-
-    // 1. The composition must be low degree (below the derived bound).
-    if !fri_verify(&proof.fri, shift, log_n, fri_log_blowup, n_queries) {
-        return false;
-    }
-    let comp_root = proof.fri.roots[0];
-
-    // 2. Recover the composition coefficients and query positions.
+    // Rebuild the transcript exactly as the prover did.
     let mut transcript = Transcript::new(b"NONOS-STARK");
     for root in &proof.trace_roots {
         transcript.absorb_digest(root);
     }
     let coeffs: Vec<Fp> = (0..num_coeffs(air)).map(|_| transcript.challenge_fp()).collect();
-    transcript.absorb_digest(&comp_root);
+    transcript.absorb_digest(&proof.comp_root);
+    let z = draw_ood_point(&mut transcript, shift, n, t);
+    for value in &proof.ood_frame {
+        transcript.absorb_fp(*value);
+    }
+    let deep_coeffs: Vec<Fp> =
+        (0..width * window_size + 1).map(|_| transcript.challenge_fp()).collect();
 
-    // 3. The committed composition must equal the constraint composition of the
-    // committed trace window, across every column, at every sampled position.
-    let expected_window = window_size * width;
+    // The constraints, checked once at the out-of-domain point: the composition
+    // there is derived from the claimed frame with this verifier's own boundary
+    // and transition algebra.
+    let h_pts: Vec<Fp> = {
+        let mut v = Vec::with_capacity(t);
+        let mut p = Fp::ONE;
+        for _ in 0..t {
+            v.push(p);
+            p = p * g;
+        }
+        v
+    };
+    let periodic_z: Vec<Fp> =
+        air.periodic_columns().iter().map(|col| eval_lagrange(&h_pts, col, z)).collect();
+    let comp_z = compose(air, g, z, &proof.ood_frame, &periodic_z, &coeffs);
+
+    // The DEEP quotient polynomial must be low degree.
+    if !fri_verify(&proof.fri, shift, log_n, fri_log_blowup, n_queries) {
+        return false;
+    }
+    let deep_root = proof.fri.roots[0];
+    transcript.absorb_digest(&deep_root);
+
+    // Every sampled position: bind the openings to their commitments and
+    // recompute the DEEP value from them.
     for qd in &proof.queries {
         let p = transcript.challenge_index(n);
-        if qd.window.len() != expected_window || qd.window_paths.len() != expected_window {
+        if qd.trace.len() != width || qd.trace_paths.len() != width {
             return false;
         }
-        if !verify_path(&comp_root, p, qd.comp, &qd.comp_path) {
+        if !verify_path(&deep_root, p, qd.deep, &qd.deep_path)
+            || !verify_path(&proof.comp_root, p, qd.comp, &qd.comp_path)
+        {
             return false;
         }
-        for k in 0..window_size {
-            let idx = (p + k * blowup) % n;
-            for c in 0..width {
-                let slot = k * width + c;
-                if !verify_path(&proof.trace_roots[c], idx, qd.window[slot], &qd.window_paths[slot])
-                {
-                    return false;
-                }
+        for c in 0..width {
+            if !verify_path(&proof.trace_roots[c], p, qd.trace[c], &qd.trace_paths[c]) {
+                return false;
             }
         }
+
         let x = shift * omega.pow(p as u64);
-        let periodic = eval_periodic(&periodic_cols, &h_pts, x);
-        if qd.comp != compose(air, g, x, &qd.window, &periodic, &coeffs) {
+        let mut acc = Fp::ZERO;
+        for k in 0..window_size {
+            let zk = z * g.pow(k as u64);
+            let inv_x_zk = (x - zk).inv();
+            for c in 0..width {
+                let claimed = proof.ood_frame[k * width + c];
+                acc = acc + deep_coeffs[k * width + c] * ((qd.trace[c] - claimed) * inv_x_zk);
+            }
+        }
+        let e = deep_coeffs[width * window_size];
+        acc = acc + e * ((qd.comp - comp_z) * (x - z).inv());
+        if acc != qd.deep {
             return false;
         }
     }

--- a/userland/stark_proofs/src/air_tests.rs
+++ b/userland/stark_proofs/src/air_tests.rs
@@ -298,6 +298,40 @@ fn a_tampered_trace_opening_is_rejected() {
     let seed = Fp::from_u64(3);
     let air = Squaring { log_t: 3, seed };
     let mut proof = stark_prove(&air, &squaring_trace(3, seed), QUERIES);
-    proof.queries[0].window[0] = proof.queries[0].window[0] + Fp::ONE;
+    proof.queries[0].trace[0] = proof.queries[0].trace[0] + Fp::ONE;
     assert!(!stark_verify(&air, &proof, QUERIES), "a tampered trace opening verified");
+}
+
+#[test]
+fn a_full_scale_poseidon_preimage_verifies() {
+    // The scale check: 256 rounds, a width-8 trace, an evaluation domain of
+    // 4096 points. This is the NTT prover at work; the quadratic extension it
+    // replaced would not finish this in reasonable test time.
+    let log_t = 8u32;
+    let params = Poseidon::new(log_t, [Fp::ZERO; RATE]);
+    let (trace, digest) = poseidon_trace(&params, absorb(sample_input()), log_t);
+    let air = Poseidon::new(log_t, digest);
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(stark_verify(&air, &proof, QUERIES), "full-scale poseidon preimage rejected");
+}
+
+#[test]
+fn a_long_squaring_chain_verifies() {
+    // A 1024-row single-column trace, domain 4096.
+    let seed = Fp::from_u64(3);
+    let air = Squaring { log_t: 10, seed };
+    let proof = stark_prove(&air, &squaring_trace(10, seed), QUERIES);
+    assert!(stark_verify(&air, &proof, QUERIES), "long squaring chain rejected");
+}
+
+#[test]
+fn a_tampered_ood_frame_is_rejected() {
+    // The out-of-domain frame is the point where the constraints are actually
+    // checked. A frame that lies about the trace breaks the DEEP quotients, and
+    // the low-degree test rejects.
+    let seed = Fp::from_u64(3);
+    let air = Squaring { log_t: 3, seed };
+    let mut proof = stark_prove(&air, &squaring_trace(3, seed), QUERIES);
+    proof.ood_frame[0] = proof.ood_frame[0] + Fp::ONE;
+    assert!(!stark_verify(&air, &proof, QUERIES), "a tampered ood frame verified");
 }


### PR DESCRIPTION
Reworks the prover and verifier to the DEEP construction (the ethSTARK / DEEP-ALI design), the last piece that makes the soundness production-grade rather than query-only.

The trace columns and the constraint composition are each committed. The verifier then draws an out-of-domain point z that lies off both the trace domain and the evaluation coset, and the prover sends the trace evaluations at z (the OOD frame). The constraints are evaluated once, at z, against that frame. FRI runs on a single DEEP quotient polynomial that ties every committed column and the composition to their claimed values at z through quotients (f(x) - f(z)) / (x - z). Each such quotient is a polynomial only if the claim is truthful, so a dishonest trace or frame fails the low-degree test with overwhelming probability by Schwartz-Zippel.

Why it matters: the whole trace is now bound at one random field point, not just at the handful of sampled domain positions, so soundness no longer rests on the queries alone. As a side effect each query opens a single row per column instead of a full constraint window.

Tests: a tampered OOD frame is rejected; all prior honest/adversarial cases still hold; and two full-scale proofs land, a 256-round width-8 Poseidon preimage (domain 4096) and a 1024-row squaring chain, which the previous O(n^2) extension could not have run at test speed. This exercises the NTT path from the stacked base. 44/44 tests, clippy -D warnings clean, kernel builds.

Stacked on Stark-Ntt (#297).