### PR TITLE
stark: algebraic Poseidon Merkle commitment (recursion foundation)

### DIFF
--- a/src/crypto/stark/air/poseidon.rs
+++ b/src/crypto/stark/air/poseidon.rs
@@ -93,6 +93,31 @@ impl Poseidon {
         digest.copy_from_slice(&state[..RATE]);
         digest
     }
+
+    /// The full permutation: every round applied to a state. This is the
+    /// primitive a Poseidon Merkle commitment compresses with, and because it is
+    /// all field operations it can be arithmetized, which is what makes a
+    /// commitment recursion-friendly.
+    pub fn permute(&self, mut state: [Fp; WIDTH]) -> [Fp; WIDTH] {
+        let rounds = 1usize << self.log_t;
+        for r in 0..rounds {
+            state = self.round(&state, r);
+        }
+        state
+    }
+
+    /// A fixed-length two-to-one compression: place two rate-sized digests in the
+    /// full state, permute, and return the first rate lanes. This is the node
+    /// hash of a Poseidon Merkle tree.
+    pub fn compress(&self, left: &[Fp; RATE], right: &[Fp; RATE]) -> [Fp; RATE] {
+        let mut state = [Fp::ZERO; WIDTH];
+        state[..RATE].copy_from_slice(left);
+        state[RATE..].copy_from_slice(right);
+        let out = self.permute(state);
+        let mut digest = [Fp::ZERO; RATE];
+        digest.copy_from_slice(&out[..RATE]);
+        digest
+    }
 }
 
 impl Air for Poseidon {

--- a/src/crypto/stark/mod.rs
+++ b/src/crypto/stark/mod.rs
@@ -13,4 +13,5 @@ pub mod field;
 pub mod fri;
 pub mod merkle;
 pub mod poly;
+pub mod poseidon_merkle;
 pub mod transcript;

--- a/src/crypto/stark/poseidon_merkle/mod.rs
+++ b/src/crypto/stark/poseidon_merkle/mod.rs
@@ -1,0 +1,28 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! A Merkle commitment whose node hash is the Poseidon permutation rather than
+//! BLAKE3. Its point is not speed but arithmetization: every node is a fixed
+//! sequence of field operations, so a path check can be expressed as AIR
+//! constraints and proven inside another STARK. That is the commitment a
+//! recursive verifier needs, since a bitwise hash like BLAKE3 cannot be proven
+//! cheaply. Digests are `RATE` field elements; leaves are already digests.
+
+mod tree;
+mod verify;
+
+pub use tree::PoseidonMerkleTree;
+pub use verify::verify_path;

--- a/src/crypto/stark/poseidon_merkle/tree.rs
+++ b/src/crypto/stark/poseidon_merkle/tree.rs
@@ -1,0 +1,94 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Building the Poseidon Merkle tree and opening authentication paths.
+
+use super::super::air::{Poseidon, RATE};
+use super::super::field::Fp;
+use alloc::vec::Vec;
+
+/// A committed binary Merkle tree over `RATE`-element digests, whose node hash is
+/// the Poseidon two-to-one compression. The leaf count is padded to a power of
+/// two.
+pub struct PoseidonMerkleTree {
+    layers: Vec<Vec<[Fp; RATE]>>,
+    root: [Fp; RATE],
+}
+
+impl PoseidonMerkleTree {
+    /// Commit to a sequence of digest leaves under `hasher`. An empty input
+    /// commits to a single zero leaf so the root is always defined.
+    pub fn commit(hasher: &Poseidon, leaves: &[[Fp; RATE]]) -> PoseidonMerkleTree {
+        let mut level: Vec<[Fp; RATE]> = leaves.to_vec();
+        if level.is_empty() {
+            level.push([Fp::ZERO; RATE]);
+        }
+        while !level.len().is_power_of_two() {
+            level.push([Fp::ZERO; RATE]);
+        }
+
+        let mut layers = Vec::new();
+        layers.push(level.clone());
+        while level.len() > 1 {
+            let mut next = Vec::with_capacity(level.len() / 2);
+            let mut i = 0;
+            while i + 1 < level.len() {
+                next.push(hasher.compress(&level[i], &level[i + 1]));
+                i += 2;
+            }
+            level = next;
+            layers.push(level.clone());
+        }
+
+        let root = layers.last().and_then(|top| top.first()).copied().unwrap_or([Fp::ZERO; RATE]);
+        PoseidonMerkleTree { layers, root }
+    }
+
+    /// The commitment root.
+    pub fn root(&self) -> [Fp; RATE] {
+        self.root
+    }
+
+    /// The number of padded leaves.
+    pub fn len(&self) -> usize {
+        self.layers.first().map(Vec::len).unwrap_or(0)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The authentication path for a leaf: the sibling digest at each level from
+    /// the leaves up to just below the root. Empty if the index is out of range.
+    pub fn open(&self, index: usize) -> Vec<[Fp; RATE]> {
+        let mut path = Vec::new();
+        if index >= self.len() {
+            return path;
+        }
+        let mut idx = index;
+        for level in &self.layers {
+            if level.len() <= 1 {
+                break;
+            }
+            let sibling = idx ^ 1;
+            if let Some(node) = level.get(sibling) {
+                path.push(*node);
+            }
+            idx >>= 1;
+        }
+        path
+    }
+}

--- a/src/crypto/stark/poseidon_merkle/verify.rs
+++ b/src/crypto/stark/poseidon_merkle/verify.rs
@@ -1,0 +1,46 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Verifying a Poseidon Merkle path. Recompute the root from a leaf and its
+//! siblings with the same two-to-one compression, and compare. Every step is a
+//! field operation, which is exactly the property a recursive verifier needs:
+//! this check can be re-expressed as AIR constraints and proven inside a STARK.
+
+use super::super::air::{Poseidon, RATE};
+use super::super::field::Fp;
+
+/// Recompute the root implied by `leaf` at `index` under `path` and return
+/// whether it equals `root`. A path of the wrong length, or a tampered leaf,
+/// sibling, or root, all yield `false`.
+pub fn verify_path(
+    hasher: &Poseidon,
+    root: &[Fp; RATE],
+    index: usize,
+    leaf: [Fp; RATE],
+    path: &[[Fp; RATE]],
+) -> bool {
+    let mut node = leaf;
+    let mut idx = index;
+    for sibling in path {
+        node = if idx & 1 == 0 {
+            hasher.compress(&node, sibling)
+        } else {
+            hasher.compress(sibling, &node)
+        };
+        idx >>= 1;
+    }
+    idx == 0 && node == *root
+}

--- a/userland/stark_proofs/src/lib.rs
+++ b/userland/stark_proofs/src/lib.rs
@@ -18,3 +18,5 @@ mod merkle_tests;
 mod ntt_tests;
 #[cfg(test)]
 mod poly_tests;
+#[cfg(test)]
+mod poseidon_merkle_tests;

--- a/userland/stark_proofs/src/poseidon_merkle_tests.rs
+++ b/userland/stark_proofs/src/poseidon_merkle_tests.rs
@@ -1,0 +1,125 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::crypto::stark::air::{Poseidon, RATE};
+use crate::crypto::stark::field::Fp;
+use crate::crypto::stark::poseidon_merkle::{verify_path, PoseidonMerkleTree};
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+// The Poseidon Merkle commitment is the recursion-friendly one: its node hash is
+// a permutation of field elements, so a path check is a fixed sequence of field
+// operations and can be proven inside another STARK. These checks establish the
+// same soundness the BLAKE3 tree has, on the real Poseidon compression: honest
+// openings verify, and nothing tampered ever does.
+
+fn xorshift(state: &mut u64) -> u64 {
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+    *state
+}
+
+fn leaves(n: usize, seed: u64) -> Vec<[Fp; RATE]> {
+    let mut s = seed | 1;
+    (0..n)
+        .map(|_| {
+            let mut d = [Fp::ZERO; RATE];
+            for c in d.iter_mut() {
+                *c = Fp::from_u64(xorshift(&mut s));
+            }
+            d
+        })
+        .collect()
+}
+
+fn hasher() -> Poseidon {
+    Poseidon::new(5, [Fp::ZERO; RATE])
+}
+
+#[test]
+fn the_compression_diffuses() {
+    // Changing one input lane changes every output lane: the node hash mixes.
+    let h = hasher();
+    let a = h.compress(
+        &[Fp::from_u64(1), Fp::from_u64(2), Fp::from_u64(3), Fp::from_u64(4)],
+        &[Fp::ZERO; RATE],
+    );
+    let b = h.compress(
+        &[Fp::from_u64(1), Fp::from_u64(2), Fp::from_u64(3), Fp::from_u64(5)],
+        &[Fp::ZERO; RATE],
+    );
+    for i in 0..RATE {
+        assert_ne!(a[i], b[i], "compression lane {i} did not diffuse");
+    }
+}
+
+#[test]
+fn honest_openings_always_verify() {
+    let h = hasher();
+    for &n in &[1usize, 2, 3, 5, 8, 16, 100] {
+        let ls = leaves(n, 0x100 + n as u64);
+        let tree = PoseidonMerkleTree::commit(&h, &ls);
+        let root = tree.root();
+        for (i, &leaf) in ls.iter().enumerate() {
+            let path = tree.open(i);
+            assert!(verify_path(&h, &root, i, leaf, &path), "honest opening at {i} of {n} failed");
+        }
+    }
+}
+
+#[test]
+fn tampering_is_rejected() {
+    let h = hasher();
+    let ls = leaves(32, 7);
+    let tree = PoseidonMerkleTree::commit(&h, &ls);
+    let root = tree.root();
+    let i = 5usize;
+    let path = tree.open(i);
+    assert!(verify_path(&h, &root, i, ls[i], &path));
+
+    // Tampered leaf.
+    let mut wrong = ls[i];
+    wrong[0] = wrong[0] + Fp::ONE;
+    assert!(!verify_path(&h, &root, i, wrong, &path), "a tampered leaf verified");
+    // Tampered sibling.
+    let mut bad = path.clone();
+    bad[0][0] = bad[0][0] + Fp::ONE;
+    assert!(!verify_path(&h, &root, i, ls[i], &bad), "a tampered path verified");
+    // Tampered root.
+    let mut bad_root = root;
+    bad_root[0] = bad_root[0] + Fp::ONE;
+    assert!(!verify_path(&h, &bad_root, i, ls[i], &path), "a tampered root verified");
+    // Wrong position.
+    assert!(!verify_path(&h, &root, i + 1, ls[i], &path), "a wrong index verified");
+    // Wrong path length.
+    let mut short = path.clone();
+    short.pop();
+    assert!(!verify_path(&h, &root, i, ls[i], &short), "a truncated path verified");
+}
+
+#[test]
+fn distinct_leaf_sets_give_distinct_roots() {
+    let h = hasher();
+    let a = PoseidonMerkleTree::commit(&h, &leaves(64, 1)).root();
+    let b = PoseidonMerkleTree::commit(&h, &leaves(64, 2)).root();
+    assert_ne!(a, b);
+    let mut ls = leaves(64, 1);
+    ls[20][2] = ls[20][2] + Fp::ONE;
+    let c = PoseidonMerkleTree::commit(&h, &ls).root();
+    assert_ne!(a, c, "a single changed leaf must change the root");
+}


### PR DESCRIPTION
The first real rung toward recursion: a commitment whose hash can be proven inside a STARK.

A recursive verifier arithmetizes another proofs verification, and the dominant cost there is the Merkle path checks. You cannot cheaply arithmetize a bitwise hash like BLAKE3, so the commitment must use an algebraic hash. This adds a Merkle tree whose node hash is the Poseidon two-to-one compression: every node is a fixed sequence of field operations, so a path check is field arithmetic that can be re-expressed as AIR constraints.

Adds the full permutation and a fixed-length two-to-one compression to the real Poseidon primitive, then the tree, opening, and path verification over rate-sized digests. It mirrors the soundness of the BLAKE3 tree on the algebraic hash.

Host proofs: the compression diffuses (one changed input lane changes every output lane), honest openings always verify, and a tampered leaf, sibling, root, wrong index, and wrong path length are all rejected, with binding across distinct leaf sets. 48/48 stark_proofs tests, clippy -D warnings clean, kernel builds.

This is the foundation; the next rungs arithmetize the path check as a membership AIR, then the FRI verifier itself, toward a full recursive STARK.

Stacked on Stark-Deep (#298).