### PR TITLE
stark: real Poseidon-Goldilocks hash and preimage STARK

### DIFF
--- a/src/crypto/stark/README.md
+++ b/src/crypto/stark/README.md
@@ -1,0 +1,109 @@
+# The NØNOS in-kernel STARK
+
+A transparent, post-quantum proof system built from the field up, in `no_std`
+Rust, with no trusted setup and no cryptography beyond a hash and field
+arithmetic. It lets the kernel prove and verify statements about a computation
+(today: knowledge of a Poseidon preimage) without revealing the witness, and
+without any assumption a quantum computer breaks.
+
+This document is the map of the system and, more importantly, the honest
+statement of what it proves and what it assumes. The claims here are the ones
+a reader should audit rather than take on faith.
+
+## The pipeline
+
+```
+field/        Goldilocks arithmetic, p = 2^64 - 2^32 + 1
+poly/         Lagrange evaluation and the low-degree extension
+merkle/       a BLAKE3 Merkle commitment with domain-separated leaves and nodes
+transcript    Fiat-Shamir over BLAKE3: challenges folded from the committed data
+fri/          the FRI low-degree test, binary folding to a constant layer
+air/          the AIR: a trace with transition and boundary constraints, the
+              generic prover and verifier, and periodic public columns
+poseidon/     Poseidon over Goldilocks, the algebraic hash the AIR reasons about
+```
+
+A proof commits each trace column with Merkle, draws constraint-composition
+coefficients from the transcript, forms the constraint composition over an
+evaluation coset, proves that composition is low degree with FRI, and opens
+the sampled positions so the verifier can rebuild the composition from the
+committed trace and check it matches. The verifier only reads the proof.
+
+## What is proven, here, on this code
+
+The host proofs in `userland/stark_proofs` include this source unmodified and
+check it:
+
+- The Goldilocks field, the Lagrange evaluation, and the low-degree extension
+  against their specifications.
+- The Merkle commitment: honest openings verify, and a tampered leaf, path,
+  or root, or a path of the wrong length, is rejected.
+- FRI: an honest low-degree codeword verifies on the subgroup and on a coset
+  and across sizes, and a high-degree codeword is rejected (the low-degree
+  test bites).
+- The Fiat-Shamir transcript: the challenge stream is a deterministic function
+  of the label and the absorbed sequence, a one-bit change anywhere in the
+  absorbed data changes every later challenge, absorb order matters, digest
+  and field absorbs are domain separated, and the query indices stay in range.
+- Poseidon: the permutation matches the four published Plonky2 reference
+  vectors (produced by the hadeshash reference), so the constants are the real
+  set, not an invented one.
+- The end-to-end Poseidon preimage STARK: an honest preimage verifies, and a
+  wrong digest, a corrupted round, and a nonzero capacity seed are rejected.
+- The verifier under forgery: every single-field mutation of a valid proof,
+  every structural malformation, and proofs from arbitrary bytes are rejected
+  without a panic. The verifier reads attacker-supplied data, so this is the
+  property that matters.
+
+## What is assumed, and must be stated
+
+A proof reduces trust; it does not eliminate it. This system rests on:
+
+- **The random-oracle model.** Fiat-Shamir instantiates the verifier's
+  challenges with BLAKE3. Soundness of the non-interactive proof is in the
+  random-oracle model, with BLAKE3 as the oracle. The transcript tests show
+  the construction binds and separates as a random oracle would; they do not
+  prove BLAKE3 is one.
+- **The FRI low-degree soundness bound.** That a codeword far from every
+  low-degree polynomial fails the sampled checks is the standard FRI soundness
+  statement. The tests confirm the verifier rejects high-degree and tampered
+  codewords; the quantitative soundness of FRI is a cryptographic assumption,
+  not a theorem proven in this tree.
+- **BLAKE3 as a collision-resistant hash** for the Merkle commitment, checked
+  against its own reference vectors elsewhere in the tree.
+- **The Poseidon parameters**, taken from the published Plonky2 set and pinned
+  by the reference vectors.
+
+There is no trusted setup and no structured reference string: the only public
+parameters are the field, the hash, and the Poseidon constants, all fixed and
+auditable.
+
+## The security level, stated plainly
+
+The evaluation rate is 1/2 (a blowup of two), and FRI folds by two to a
+constant layer. The soundness error falls with the number of query openings;
+the proofs draw 32. That query count, together with the rate, sets the
+concrete security margin, and reaching a production margin (a lower rate, more
+queries, and out-of-domain sampling for a tighter bound per query) is a
+parameter and protocol refinement that is ongoing, not a change to the code
+documented here. The field is roughly 64 bits, so a statement needing more
+than field-sized soundness would move to an extension field; the present
+statements do not.
+
+## Post-quantum
+
+The only cryptography is a hash and field arithmetic. There is no discrete
+log, no pairing, no factoring. A quantum adversary gains only the generic
+square-root speedup against the hash, which the digest width already accounts
+for. The system is post-quantum by construction, which is the reason to build
+it from the field up rather than reach for an elliptic-curve SNARK.
+
+## Reproduce
+
+```sh
+cd userland/stark_proofs
+cargo test --release        # field, poly, merkle, fri, transcript, air, poseidon, forgery
+```
+
+The kernel builds the module for its real target with
+`make nonos-mk-core`.

--- a/src/crypto/stark/air/composition.rs
+++ b/src/crypto/stark/air/composition.rs
@@ -22,7 +22,27 @@
 //! on the two sides by construction.
 
 use super::super::field::Fp;
+use super::super::poly::eval_lagrange;
 use super::spec::Air;
+use alloc::vec::Vec;
+
+/// Evaluate every periodic column of `air` at coset point `x`. Each column is
+/// interpolated over the trace domain `g^0..g^(t-1)` and read at `x`, exactly
+/// as the trace columns are, so prover and verifier obtain identical values.
+fn periodic_at<A: Air>(air: &A, g: Fp, x: Fp) -> Vec<Fp> {
+    let cols = air.periodic_columns();
+    if cols.is_empty() {
+        return Vec::new();
+    }
+    let t = 1usize << air.log_trace_len();
+    let mut h_pts: Vec<Fp> = Vec::with_capacity(t);
+    let mut hp = Fp::ONE;
+    for _ in 0..t {
+        h_pts.push(hp);
+        hp = hp * g;
+    }
+    cols.iter().map(|col| eval_lagrange(&h_pts, col, x)).collect()
+}
 
 /// Total number of random coefficients an AIR's composition consumes.
 pub(super) fn num_coeffs<A: Air>(air: &A) -> usize {
@@ -60,7 +80,8 @@ pub(super) fn compose<A: Air>(air: &A, g: Fp, x: Fp, window: &[Fp], coeffs: &[Fp
     }
 
     let mut acc = Fp::ZERO;
-    let transition = air.transition(window);
+    let periodic = periodic_at(air, g, x);
+    let transition = air.transition(window, &periodic);
     for (value, coeff) in transition.iter().zip(coeffs.iter()) {
         acc = acc + *coeff * (*value * exempt * z_h_inv);
     }

--- a/src/crypto/stark/air/fibonacci.rs
+++ b/src/crypto/stark/air/fibonacci.rs
@@ -48,7 +48,7 @@ impl Air for Fibonacci {
         1
     }
 
-    fn transition(&self, window: &[Fp]) -> Vec<Fp> {
+    fn transition(&self, window: &[Fp], _periodic: &[Fp]) -> Vec<Fp> {
         // f(g^2*x) - f(g*x) - f(x)
         vec![window[2] - window[1] - window[0]]
     }

--- a/src/crypto/stark/air/mod.rs
+++ b/src/crypto/stark/air/mod.rs
@@ -25,6 +25,7 @@
 mod composition;
 mod fibonacci;
 mod permutation2;
+mod poseidon;
 mod power_chain;
 mod prove;
 mod spec;
@@ -34,6 +35,7 @@ mod verify;
 
 pub use fibonacci::Fibonacci;
 pub use permutation2::Permutation2;
+pub use poseidon::{trace as poseidon_trace, PoseidonPreimage};
 pub use power_chain::PowerChain;
 pub use prove::stark_prove;
 pub use spec::Air;

--- a/src/crypto/stark/air/permutation2.rs
+++ b/src/crypto/stark/air/permutation2.rs
@@ -60,7 +60,7 @@ impl Air for Permutation2 {
         2
     }
 
-    fn transition(&self, window: &[Fp]) -> Vec<Fp> {
+    fn transition(&self, window: &[Fp], _periodic: &[Fp]) -> Vec<Fp> {
         // window = [x, y, x_next, y_next].
         let (x, y, x_next, y_next) = (window[0], window[1], window[2], window[3]);
         vec![x_next - (x.pow(7) + y + self.rc0), y_next - (x + y.pow(7) + self.rc1)]

--- a/src/crypto/stark/air/poseidon.rs
+++ b/src/crypto/stark/air/poseidon.rs
@@ -1,0 +1,206 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! A STARK proof of knowledge of a Poseidon-Goldilocks preimage. The trace is
+//! the permutation state, one row per round: row 0 is the input, row r+1 is the
+//! state after round r, so the thirty rounds occupy rows 0 through 30. Each
+//! transition enforces one real Poseidon round, `next = MDS(sbox(state + rc))`,
+//! with the round constants and the full-versus-partial S-box supplied as
+//! public periodic columns, so the constraint is the published permutation and
+//! not a stand-in. The boundary pins the input capacity lanes to zero, the
+//! sponge initialization, and the output rate lanes to a public digest. A
+//! satisfying trace is a preimage the proof never reveals.
+
+use super::super::field::Fp;
+use super::super::poseidon::constants::{
+    FULL_ROUNDS, MDS_CIRC, MDS_DIAG, N_ROUNDS, PARTIAL_ROUNDS, ROUND_CONSTANTS, WIDTH,
+};
+use super::spec::Air;
+use alloc::vec;
+use alloc::vec::Vec;
+
+/// Log2 of the padded trace length. Thirty rounds need thirty-one state rows,
+/// so the trace is padded to thirty-two.
+pub(crate) const LOG_TRACE: u32 = 5;
+const TRACE_LEN: usize = 1 << LOG_TRACE;
+/// The sponge rate; the first `RATE` lanes carry the absorbed input and, at the
+/// output, the digest.
+pub(crate) const RATE: usize = 8;
+/// The digest width pinned as public output.
+pub(crate) const DIGEST: usize = 4;
+
+/// Which rounds apply the S-box to every lane. The schedule is
+/// `FULL_ROUNDS / 2` full, then all partial, then `FULL_ROUNDS / 2` full, so a
+/// round is full exactly when it is outside the partial-round span.
+fn is_full_round(round: usize) -> bool {
+    let partial = FULL_ROUNDS / 2..FULL_ROUNDS / 2 + PARTIAL_ROUNDS;
+    !partial.contains(&round)
+}
+
+/// Prove knowledge of a Poseidon preimage whose output rate lanes are `digest`.
+pub struct PoseidonPreimage {
+    pub digest: [Fp; DIGEST],
+}
+
+impl PoseidonPreimage {
+    fn sbox(x: Fp) -> Fp {
+        let x2 = x.square();
+        let x4 = x2.square();
+        x * x2 * x4
+    }
+}
+
+/// One real Poseidon round applied to a state row, used to build the trace so
+/// the trace and the AIR transition are the same round function by
+/// construction.
+fn round(state: &[Fp; WIDTH], r: usize) -> [Fp; WIDTH] {
+    let full = is_full_round(r);
+    let mut post = [Fp::ZERO; WIDTH];
+    for i in 0..WIDTH {
+        let added = state[i] + Fp::from_u64(ROUND_CONSTANTS[r * WIDTH + i]);
+        post[i] = if i == 0 || full { PoseidonPreimage::sbox(added) } else { added };
+    }
+    let mut out = [Fp::ZERO; WIDTH];
+    for (r2, o) in out.iter_mut().enumerate() {
+        let mut acc = Fp::ZERO;
+        for (i, &c) in MDS_CIRC.iter().enumerate() {
+            acc = acc + post[(i + r2) % WIDTH] * Fp::from_u64(c);
+        }
+        acc = acc + post[r2] * Fp::from_u64(MDS_DIAG[r2]);
+        *o = acc;
+    }
+    out
+}
+
+/// Build the execution trace and the resulting digest for a rate input. The
+/// capacity lanes are initialized to zero, each round advances one row, and the
+/// padding rows repeat the output. Row-major, `WIDTH` columns.
+pub fn trace(rate_input: [Fp; RATE]) -> (Vec<Fp>, [Fp; DIGEST]) {
+    let mut state = [Fp::ZERO; WIDTH];
+    state[..RATE].copy_from_slice(&rate_input);
+
+    let mut rows: Vec<[Fp; WIDTH]> = Vec::with_capacity(TRACE_LEN);
+    rows.push(state);
+    for r in 0..N_ROUNDS {
+        state = round(&state, r);
+        rows.push(state);
+    }
+    while rows.len() < TRACE_LEN {
+        rows.push(state);
+    }
+
+    let mut flat = Vec::with_capacity(TRACE_LEN * WIDTH);
+    for row in &rows {
+        flat.extend_from_slice(row);
+    }
+    let mut digest = [Fp::ZERO; DIGEST];
+    digest.copy_from_slice(&rows[N_ROUNDS][..DIGEST]);
+    (flat, digest)
+}
+
+impl Air for PoseidonPreimage {
+    fn log_trace_len(&self) -> u32 {
+        LOG_TRACE
+    }
+
+    fn trace_width(&self) -> usize {
+        WIDTH
+    }
+
+    fn window_size(&self) -> usize {
+        2
+    }
+
+    fn constraint_degree(&self) -> usize {
+        // The S-box is degree seven; the selector and constants are periodic
+        // scalars, so they do not raise the degree in the trace variables.
+        7
+    }
+
+    fn num_transition(&self) -> usize {
+        WIDTH
+    }
+
+    /// The periodic columns, one per row of the padded trace: the twelve round
+    /// constants, a full-round selector, and an active selector that is zero on
+    /// the padding rows so their transition is the identity.
+    fn periodic_columns(&self) -> Vec<Vec<Fp>> {
+        let mut cols: Vec<Vec<Fp>> = vec![vec![Fp::ZERO; TRACE_LEN]; WIDTH + 2];
+        for round in 0..N_ROUNDS {
+            for lane in 0..WIDTH {
+                cols[lane][round] = Fp::from_u64(ROUND_CONSTANTS[round * WIDTH + lane]);
+            }
+            cols[WIDTH][round] = if is_full_round(round) { Fp::ONE } else { Fp::ZERO };
+            cols[WIDTH + 1][round] = Fp::ONE;
+        }
+        cols
+    }
+
+    fn transition(&self, window: &[Fp], periodic: &[Fp]) -> Vec<Fp> {
+        let cur = &window[0..WIDTH];
+        let next = &window[WIDTH..2 * WIDTH];
+        let rc = &periodic[0..WIDTH];
+        let is_full = periodic[WIDTH];
+        let is_active = periodic[WIDTH + 1];
+
+        // Post S-box lane: on a full round every lane, on a partial round lane
+        // zero only. `is_full` selects between the two arms without a branch,
+        // matching the real permutation.
+        let mut post = [Fp::ZERO; WIDTH];
+        for i in 0..WIDTH {
+            let added = cur[i] + rc[i];
+            post[i] = if i == 0 {
+                Self::sbox(added)
+            } else {
+                is_full * Self::sbox(added) + (Fp::ONE - is_full) * added
+            };
+        }
+
+        // The MDS mix, `out[r] = sum_i post[(i + r) % W] * CIRC[i] + post[r] *
+        // DIAG[r]`, the same circulant plus diagonal the permutation uses.
+        let mut mixed = [Fp::ZERO; WIDTH];
+        for (r, m) in mixed.iter_mut().enumerate() {
+            let mut acc = Fp::ZERO;
+            for (i, &c) in MDS_CIRC.iter().enumerate() {
+                acc = acc + post[(i + r) % WIDTH] * Fp::from_u64(c);
+            }
+            acc = acc + post[r] * Fp::from_u64(MDS_DIAG[r]);
+            *m = acc;
+        }
+
+        // On active rows the next state is the round output; on padding rows it
+        // is the identity, so the padded tail carries no constraint of its own.
+        let mut out = Vec::with_capacity(WIDTH);
+        for i in 0..WIDTH {
+            let target = is_active * mixed[i] + (Fp::ONE - is_active) * cur[i];
+            out.push(next[i] - target);
+        }
+        out
+    }
+
+    fn boundary(&self) -> Vec<(usize, usize, Fp)> {
+        let mut b = Vec::with_capacity((WIDTH - RATE) + DIGEST);
+        // The input capacity lanes start at zero: the sponge initialization.
+        for lane in RATE..WIDTH {
+            b.push((lane, 0, Fp::ZERO));
+        }
+        // The output rate lanes at row N_ROUNDS are the public digest.
+        for (i, d) in self.digest.iter().enumerate() {
+            b.push((i, N_ROUNDS, *d));
+        }
+        b
+    }
+}

--- a/src/crypto/stark/air/power_chain.rs
+++ b/src/crypto/stark/air/power_chain.rs
@@ -56,7 +56,7 @@ impl Air for PowerChain {
         1
     }
 
-    fn transition(&self, window: &[Fp]) -> Vec<Fp> {
+    fn transition(&self, window: &[Fp], _periodic: &[Fp]) -> Vec<Fp> {
         // f(g*x) - (f(x)^7 + c)
         let x = window[0];
         let x7 = x.pow(7);

--- a/src/crypto/stark/air/spec.rs
+++ b/src/crypto/stark/air/spec.rs
@@ -44,11 +44,23 @@ pub trait Air {
     /// Number of transition constraints (the length of `transition`).
     fn num_transition(&self) -> usize;
 
+    /// Public periodic columns, each a full-length vector over the trace
+    /// domain, known to both prover and verifier and never committed. The
+    /// engine interpolates each over the trace domain and evaluates it at the
+    /// same point as the trace window, then passes the values to `transition`.
+    /// This is how a round-dependent constraint, such as a hash permutation
+    /// whose constants change every round, is expressed without a per-row
+    /// index. The default is none.
+    fn periodic_columns(&self) -> Vec<Vec<Fp>> {
+        Vec::new()
+    }
+
     /// The transition constraint values for a window laid out row-major:
     /// `window[k * trace_width + col]` is column `col` of the k-th row in the
-    /// window. Each returned value must be zero on every trace row except the
-    /// final `window_size - 1`.
-    fn transition(&self, window: &[Fp]) -> Vec<Fp>;
+    /// window. `periodic[c]` is the c-th periodic column evaluated at the base
+    /// row of the window. Each returned value must be zero on every trace row
+    /// except the final `window_size - 1`.
+    fn transition(&self, window: &[Fp], periodic: &[Fp]) -> Vec<Fp>;
 
     /// Boundary constraints as `(column, row, value)`.
     fn boundary(&self) -> Vec<(usize, usize, Fp)>;

--- a/src/crypto/stark/air/squaring.rs
+++ b/src/crypto/stark/air/squaring.rs
@@ -47,7 +47,7 @@ impl Air for Squaring {
         1
     }
 
-    fn transition(&self, window: &[Fp]) -> Vec<Fp> {
+    fn transition(&self, window: &[Fp], _periodic: &[Fp]) -> Vec<Fp> {
         // f(g*x) - f(x)^2
         vec![window[1] - window[0] * window[0]]
     }

--- a/src/crypto/stark/air/types.rs
+++ b/src/crypto/stark/air/types.rs
@@ -25,6 +25,7 @@ use alloc::vec::Vec;
 /// One consistency query: the composition value at position `p`, and the trace
 /// values across the constraint window at `p`, laid out row-major
 /// (`window[k * width + col]`), each with a Merkle path to its column commitment.
+#[derive(Clone)]
 pub struct StarkQuery {
     pub comp: Fp,
     pub comp_path: Vec<[u8; 32]>,
@@ -33,6 +34,7 @@ pub struct StarkQuery {
 }
 
 /// A complete STARK proof.
+#[derive(Clone)]
 pub struct StarkProof {
     pub trace_roots: Vec<[u8; 32]>,
     pub fri: FriProof,

--- a/src/crypto/stark/fri/types.rs
+++ b/src/crypto/stark/fri/types.rs
@@ -22,6 +22,7 @@ use alloc::vec::Vec;
 
 /// One layer's contribution to a query: the value at the queried position `i`
 /// and at its negation `i + n/2`, each with a Merkle path to that layer's root.
+#[derive(Clone)]
 pub struct LayerOpening {
     pub a: Fp,
     pub a_path: Vec<[u8; 32]>,
@@ -30,11 +31,13 @@ pub struct LayerOpening {
 }
 
 /// The openings a single query induces across every folded layer.
+#[derive(Clone)]
 pub struct QueryProof {
     pub layers: Vec<LayerOpening>,
 }
 
 /// A complete FRI low-degree proof.
+#[derive(Clone)]
 pub struct FriProof {
     pub roots: Vec<[u8; 32]>,
     pub final_layer: Vec<Fp>,

--- a/src/crypto/stark/mod.rs
+++ b/src/crypto/stark/mod.rs
@@ -13,4 +13,5 @@ pub mod field;
 pub mod fri;
 pub mod merkle;
 pub mod poly;
+pub mod poseidon;
 pub mod transcript;

--- a/src/crypto/stark/poseidon/constants.rs
+++ b/src/crypto/stark/poseidon/constants.rs
@@ -1,0 +1,72 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Poseidon-Goldilocks parameters, width 12, x^7 S-box, 8 full and 22 partial
+//! rounds. These are the published Plonky2 / hadeshash constants for the
+//! Goldilocks field, not a demonstration set: the round constants below are
+//! `ALL_ROUND_CONSTANTS`, and the MDS is the circulant plus diagonal matrix
+//! `circ(MDS_CIRC) + diag(MDS_DIAG)`. The permutation built on them is checked
+//! against the reference test vectors in the host proofs.
+
+/// The permutation width.
+pub const WIDTH: usize = 12;
+/// Full rounds, split half before and half after the partial rounds.
+pub const FULL_ROUNDS: usize = 8;
+/// Partial rounds, applying the S-box to lane 0 only.
+pub const PARTIAL_ROUNDS: usize = 22;
+/// Total rounds.
+pub const N_ROUNDS: usize = FULL_ROUNDS + PARTIAL_ROUNDS;
+
+/// The first row of the circulant MDS matrix.
+pub const MDS_CIRC: [u64; WIDTH] = [17, 15, 41, 16, 2, 28, 13, 13, 39, 18, 34, 20];
+/// The diagonal added to the circulant MDS matrix.
+pub const MDS_DIAG: [u64; WIDTH] = [8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+/// The round constants, `WIDTH` per round for `N_ROUNDS` rounds, laid out so
+/// that lane `i` in round `r` adds `ROUND_CONSTANTS[r * WIDTH + i]`.
+#[rustfmt::skip]
+pub const ROUND_CONSTANTS: [u64; N_ROUNDS * WIDTH] = [
+    0xb585f766f2144405, 0x7746a55f43921ad7, 0xb2fb0d31cee799b4, 0x0f6760a4803427d7, 0xe10d666650f4e012, 0x8cae14cb07d09bf1, 0xd438539c95f63e9f, 0xef781c7ce35b4c3d, 0xcdc4a239b0c44426, 0x277fa208bf337bff, 0xe17653a29da578a1, 0xc54302f225db2c76, 
+    0x86287821f722c881, 0x59cd1a8a41c18e55, 0xc3b919ad495dc574, 0xa484c4c5ef6a0781, 0x308bbd23dc5416cc, 0x6e4a40c18f30c09c, 0x9a2eedb70d8f8cfa, 0xe360c6e0ae486f38, 0xd5c7718fbfc647fb, 0xc35eae071903ff0b, 0x849c2656969c4be7, 0xc0572c8c08cbbbad, 
+    0xe9fa634a21de0082, 0xf56f6d48959a600d, 0xf7d713e806391165, 0x8297132b32825daf, 0xad6805e0e30b2c8a, 0xac51d9f5fcf8535e, 0x502ad7dc18c2ad87, 0x57a1550c110b3041, 0x66bbd30e6ce0e583, 0x0da2abef589d644e, 0xf061274fdb150d61, 0x28b8ec3ae9c29633, 
+    0x92a756e67e2b9413, 0x70e741ebfee96586, 0x019d5ee2af82ec1c, 0x6f6f2ed772466352, 0x7cf416cfe7e14ca1, 0x61df517b86a46439, 0x85dc499b11d77b75, 0x4b959b48b9c10733, 0xe8be3e5da8043e57, 0xf5c0bc1de6da8699, 0x40b12cbf09ef74bf, 0xa637093ecb2ad631, 
+    0x3cc3f892184df408, 0x2e479dc157bf31bb, 0x6f49de07a6234346, 0x213ce7bede378d7b, 0x5b0431345d4dea83, 0xa2de45780344d6a1, 0x7103aaf94a7bf308, 0x5326fc0d97279301, 0xa9ceb74fec024747, 0x27f8ec88bb21b1a3, 0xfceb4fda1ded0893, 0xfac6ff1346a41675, 
+    0x7131aa45268d7d8c, 0x9351036095630f9f, 0xad535b24afc26bfb, 0x4627f5c6993e44be, 0x645cf794b8f1cc58, 0x241c70ed0af61617, 0xacb8e076647905f1, 0x3737e9db4c4f474d, 0xe7ea5e33e75fffb6, 0x90dee49fc9bfc23a, 0xd1b1edf76bc09c92, 0x0b65481ba645c602, 
+    0x99ad1aab0814283b, 0x438a7c91d416ca4d, 0xb60de3bcc5ea751c, 0xc99cab6aef6f58bc, 0x69a5ed92a72ee4ff, 0x5e7b329c1ed4ad71, 0x5fc0ac0800144885, 0x32db829239774eca, 0x0ade699c5830f310, 0x7cc5583b10415f21, 0x85df9ed2e166d64f, 0x6604df4fee32bcb1, 
+    0xeb84f608da56ef48, 0xda608834c40e603d, 0x8f97fe408061f183, 0xa93f485c96f37b89, 0x6704e8ee8f18d563, 0xcee3e9ac1e072119, 0x510d0e65e2b470c1, 0xf6323f486b9038f0, 0x0b508cdeffa5ceef, 0xf2417089e4fb3cbd, 0x60e75c2890d15730, 0xa6217d8bf660f29c, 
+    0x7159cd30c3ac118e, 0x839b4e8fafead540, 0x0d3f3e5e82920adc, 0x8f7d83bddee7bba8, 0x780f2243ea071d06, 0xeb915845f3de1634, 0xd19e120d26b6f386, 0x016ee53a7e5fecc6, 0xcb5fd54e7933e477, 0xacb8417879fd449f, 0x9c22190be7f74732, 0x5d693c1ba3ba3621, 
+    0xdcef0797c2b69ec7, 0x3d639263da827b13, 0xe273fd971bc8d0e7, 0x418f02702d227ed5, 0x8c25fda3b503038c, 0x2cbaed4daec8c07c, 0x5f58e6afcdd6ddc2, 0x284650ac5e1b0eba, 0x635b337ee819dab5, 0x9f9a036ed4f2d49f, 0xb93e260cae5c170e, 0xb0a7eae879ddb76d, 
+    0xd0762cbc8ca6570c, 0x34c6efb812b04bf5, 0x40bf0ab5fa14c112, 0xb6b570fc7c5740d3, 0x5a27b9002de33454, 0xb1a5b165b6d2b2d2, 0x8722e0ace9d1be22, 0x788ee3b37e5680fb, 0x14a726661551e284, 0x98b7672f9ef3b419, 0xbb93ae776bb30e3a, 0x28fd3b046380f850, 
+    0x30a4680593258387, 0x337dc00c61bd9ce1, 0xd5eca244c7a4ff1d, 0x7762638264d279bd, 0xc1e434bedeefd767, 0x0299351a53b8ec22, 0xb2d456e4ad251b80, 0x3e9ed1fda49cea0b, 0x2972a92ba450bed8, 0x20216dd77be493de, 0xadffe8cf28449ec6, 0x1c4dbb1c4c27d243, 
+    0x15a16a8a8322d458, 0x388a128b7fd9a609, 0x2300e5d6baedf0fb, 0x2f63aa8647e15104, 0xf1c36ce86ecec269, 0x27181125183970c9, 0xe584029370dca96d, 0x4d9bbc3e02f1cfb2, 0xea35bc29692af6f8, 0x18e21b4beabb4137, 0x1e3b9fc625b554f4, 0x25d64362697828fd, 
+    0x5a3f1bb1c53a9645, 0xdb7f023869fb8d38, 0xb462065911d4e1fc, 0x49c24ae4437d8030, 0xd793862c112b0566, 0xaadd1106730d8feb, 0xc43b6e0e97b0d568, 0xe29024c18ee6fca2, 0x5e50c27535b88c66, 0x10383f20a4ff9a87, 0x38e8ee9d71a45af8, 0xdd5118375bf1a9b9, 
+    0x775005982d74d7f7, 0x86ab99b4dde6c8b0, 0xb1204f603f51c080, 0xef61ac8470250ecf, 0x1bbcd90f132c603f, 0x0cd1dabd964db557, 0x11a3ae5beb9d1ec9, 0xf755bfeea585d11d, 0xa3b83250268ea4d7, 0x516306f4927c93af, 0xddb4ac49c9efa1da, 0x64bb6dec369d4418, 
+    0xf9cc95c22b4c1fcc, 0x08d37f755f4ae9f6, 0xeec49b613478675b, 0xf143933aed25e0b0, 0xe4c5dd8255dfc622, 0xe7ad7756f193198e, 0x92c2318b87fff9cb, 0x739c25f8fd73596d, 0x5636cac9f16dfed0, 0xdd8f909a938e0172, 0xc6401fe115063f5b, 0x8ad97b33f1ac1455, 
+    0x0c49366bb25e8513, 0x0784d3d2f1698309, 0x530fb67ea1809a81, 0x410492299bb01f49, 0x139542347424b9ac, 0x9cb0bd5ea1a1115e, 0x02e3f615c38f49a1, 0x985d4f4a9c5291ef, 0x775b9feafdcd26e7, 0x304265a6384f0f2d, 0x593664c39773012c, 0x4f0a2e5fb028f2ce, 
+    0xdd611f1000c17442, 0xd8185f9adfea4fd0, 0xef87139ca9a3ab1e, 0x3ba71336c34ee133, 0x7d3a455d56b70238, 0x660d32e130182684, 0x297a863f48cd1f43, 0x90e0a736a751ebb7, 0x549f80ce550c4fd3, 0x0f73b2922f38bd64, 0x16bf1f73fb7a9c3f, 0x6d1f5a59005bec17, 
+    0x02ff876fa5ef97c4, 0xc5cb72a2a51159b0, 0x8470f39d2d5c900e, 0x25abb3f1d39fcb76, 0x23eb8cc9b372442f, 0xd687ba55c64f6364, 0xda8d9e90fd8ff158, 0xe3cbdc7d2fe45ea7, 0xb9a8c9b3aee52297, 0xc0d28a5c10960bd3, 0x45d7ac9b68f71a34, 0xeeb76e397069e804, 
+    0x3d06c8bd1514e2d9, 0x9c9c98207cb10767, 0x65700b51aedfb5ef, 0x911f451539869408, 0x7ae6849fbc3a0ec6, 0x3bb340eba06afe7e, 0xb46e9d8b682ea65e, 0x8dcf22f9a3b34356, 0x77bdaeda586257a7, 0xf19e400a5104d20d, 0xc368a348e46d950f, 0x9ef1cd60e679f284, 
+    0xe89cd854d5d01d33, 0x5cd377dc8bb882a2, 0xa7b0fb7883eee860, 0x7684403ec392950d, 0x5fa3f06f4fed3b52, 0x8df57ac11bc04831, 0x2db01efa1e1e1897, 0x54846de4aadb9ca2, 0xba6745385893c784, 0x541d496344d2c75b, 0xe909678474e687fe, 0xdfe89923f6c9c2ff, 
+    0xece5a71e0cfedc75, 0x5ff98fd5d51fe610, 0x83e8941918964615, 0x5922040b47f150c1, 0xf97d750e3dd94521, 0x5080d4c2b86f56d7, 0xa7de115b56c78d70, 0x6a9242ac87538194, 0xf7856ef7f9173e44, 0x2265fc92feb0dc09, 0x17dfc8e4f7ba8a57, 0x9001a64209f21db8, 
+    0x90004c1371b893c5, 0xb932b7cf752e5545, 0xa0b1df81b6fe59fc, 0x8ef1dd26770af2c2, 0x0541a4f9cfbeed35, 0x9e61106178bfc530, 0xb3767e80935d8af2, 0x0098d5782065af06, 0x31d191cd5c1466c7, 0x410fefafa319ac9d, 0xbdf8f242e316c4ab, 0x9e8cd55b57637ed0, 
+    0xde122bebe9a39368, 0x4d001fd58f002526, 0xca6637000eb4a9f8, 0x2f2339d624f91f78, 0x6d1a7918c80df518, 0xdf9a4939342308e9, 0xebc2151ee6c8398c, 0x03cc2ba8a1116515, 0xd341d037e840cf83, 0x387cb5d25af4afcc, 0xbba2515f22909e87, 0x7248fe7705f38e47, 
+    0x4d61e56a525d225a, 0x262e963c8da05d3d, 0x59e89b094d220ec2, 0x055d5b52b78b9c5e, 0x82b27eb33514ef99, 0xd30094ca96b7ce7b, 0xcf5cb381cd0a1535, 0xfeed4db6919e5a7c, 0x41703f53753be59f, 0x5eeea940fcde8b6f, 0x4cd1f1b175100206, 0x4a20358574454ec0, 
+    0x1478d361dbbf9fac, 0x6f02dc07d141875c, 0x296a202ed8e556a2, 0x2afd67999bf32ee5, 0x7acfd96efa95491d, 0x6798ba0c0abb2c6d, 0x34c6f57b26c92122, 0x5736e1bad206b5de, 0x20057d2a0056521b, 0x3dea5bd5d0578bd7, 0x16e50d897d4634ac, 0x29bff3ecb9b7a6e3, 
+    0x475cd3205a3bdcde, 0x18a42105c31b7e88, 0x023e7414af663068, 0x15147108121967d7, 0xe4a3dff1d7d6fef9, 0x01a8d1a588085737, 0x11b4c74eda62beef, 0xe587cc0d69a73346, 0x1ff7327017aa2a6e, 0x594e29c42473d06b, 0xf6f31db1899b12d5, 0xc02ac5e47312d3ca, 
+    0xe70201e960cb78b8, 0x6f90ff3b6a65f108, 0x42747a7245e7fa84, 0xd1f507e43ab749b2, 0x1c86d265f15750cd, 0x3996ce73dd832c1c, 0x8e7fba02983224bd, 0xba0dec7103255dd4, 0x9e9cbd781628fc5b, 0xdae8645996edd6a5, 0xdebe0853b1a1d378, 0xa49229d24d014343, 
+    0x7be5b9ffda905e1c, 0xa3c95eaec244aa30, 0x0230bca8f4df0544, 0x4135c2bebfe148c6, 0x166fc0cc438a3c72, 0x3762b59a8ae83efa, 0xe8928a4c89114750, 0x2a440b51a4945ee5, 0x80cefd2b7d99ff83, 0xbb9879c6e61fd62a, 0x6e7c8f1a84265034, 0x164bb2de1bbeddc8, 
+    0xf3c12fe54d5c653b, 0x40b9e922ed9771e2, 0x551f5b0fbe7b1840, 0x25032aa7c4cb1811, 0xaaed34074b164346, 0x8ffd96bbf9c9c81d, 0x70fc91eb5937085c, 0x7f795e2a5f915440, 0x4543d9df5476d3cb, 0xf172d73e004fc90d, 0xdfd1c4febcc81238, 0xbc8dfb627fe558fc, 
+];

--- a/src/crypto/stark/poseidon/mod.rs
+++ b/src/crypto/stark/poseidon/mod.rs
@@ -1,0 +1,28 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Poseidon over Goldilocks: the permutation, its published parameters, and a
+//! field sponge hash built on it. Used as the algebraic hash inside STARK
+//! constraints, where an arithmetic-friendly permutation lets a proof reason
+//! about hashing without a bit-level circuit.
+
+pub mod constants;
+pub mod permutation;
+pub mod sponge;
+
+pub use constants::{FULL_ROUNDS, N_ROUNDS, PARTIAL_ROUNDS, WIDTH};
+pub use permutation::permute;
+pub use sponge::{compress, hash, DIGEST, RATE};

--- a/src/crypto/stark/poseidon/permutation.rs
+++ b/src/crypto/stark/poseidon/permutation.rs
@@ -1,0 +1,98 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The Poseidon-Goldilocks permutation. Each round adds the round constants,
+//! applies the x^7 S-box (to every lane in a full round, to lane 0 only in a
+//! partial round), and mixes through the MDS matrix. The schedule is the
+//! standard four full, twenty-two partial, four full. This is the reference
+//! (unoptimized) permutation, equal by construction to the optimized Plonky2
+//! one and checked against the published test vectors.
+
+use super::super::field::Fp;
+use super::constants::{
+    FULL_ROUNDS, MDS_CIRC, MDS_DIAG, PARTIAL_ROUNDS, ROUND_CONSTANTS, WIDTH,
+};
+
+/// The x^7 S-box on a single lane.
+#[inline]
+pub(super) fn sbox(x: Fp) -> Fp {
+    let x2 = x.square();
+    let x4 = x2.square();
+    let x3 = x * x2;
+    x3 * x4
+}
+
+/// Add the round constants for `round` to the state in place.
+#[inline]
+fn add_round_constants(state: &mut [Fp; WIDTH], round: usize) {
+    for (i, lane) in state.iter_mut().enumerate() {
+        *lane = *lane + Fp::from_u64(ROUND_CONSTANTS[round * WIDTH + i]);
+    }
+}
+
+/// The MDS mix: row `r` of the output is the circulant combination of the
+/// state plus the diagonal term, `sum_i state[(i + r) % W] * CIRC[i] +
+/// state[r] * DIAG[r]`. The circulant is invertible over the field, so the
+/// layer is a bijection.
+#[inline]
+fn mds(state: &[Fp; WIDTH]) -> [Fp; WIDTH] {
+    let mut out = [Fp::ZERO; WIDTH];
+    for (r, o) in out.iter_mut().enumerate() {
+        let mut acc = Fp::ZERO;
+        for (i, &c) in MDS_CIRC.iter().enumerate() {
+            acc = acc + state[(i + r) % WIDTH] * Fp::from_u64(c);
+        }
+        acc = acc + state[r] * Fp::from_u64(MDS_DIAG[r]);
+        *o = acc;
+    }
+    out
+}
+
+/// One full round: constants, S-box on every lane, MDS.
+#[inline]
+fn full_round(state: &mut [Fp; WIDTH], round: usize) {
+    add_round_constants(state, round);
+    for lane in state.iter_mut() {
+        *lane = sbox(*lane);
+    }
+    *state = mds(state);
+}
+
+/// One partial round: constants, S-box on lane 0 only, MDS.
+#[inline]
+fn partial_round(state: &mut [Fp; WIDTH], round: usize) {
+    add_round_constants(state, round);
+    state[0] = sbox(state[0]);
+    *state = mds(state);
+}
+
+/// Apply the full Poseidon permutation to a width-12 state.
+pub fn permute(mut state: [Fp; WIDTH]) -> [Fp; WIDTH] {
+    let mut round = 0;
+    for _ in 0..(FULL_ROUNDS / 2) {
+        full_round(&mut state, round);
+        round += 1;
+    }
+    for _ in 0..PARTIAL_ROUNDS {
+        partial_round(&mut state, round);
+        round += 1;
+    }
+    for _ in 0..(FULL_ROUNDS / 2) {
+        full_round(&mut state, round);
+        round += 1;
+    }
+    state
+}

--- a/src/crypto/stark/poseidon/sponge.rs
+++ b/src/crypto/stark/poseidon/sponge.rs
@@ -1,0 +1,70 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! A field sponge over the Poseidon-Goldilocks permutation: rate 8, capacity
+//! 4, width 12. Absorb pads the input to a multiple of the rate, XORs (adds)
+//! each block into the rate lanes, and permutes; squeeze reads the rate lanes.
+//! The capacity is never touched by the input, which is the domain separation
+//! that makes the sponge a hash.
+
+use super::super::field::Fp;
+use super::constants::WIDTH;
+use super::permutation::permute;
+use alloc::vec::Vec;
+
+/// The sponge rate: input lanes absorbed per permutation.
+pub const RATE: usize = 8;
+/// The sponge capacity: lanes reserved for security, never absorbed.
+pub const CAPACITY: usize = WIDTH - RATE;
+/// The default digest width in field elements.
+pub const DIGEST: usize = 4;
+
+/// Hash a slice of field elements to a `DIGEST`-element digest. The input is
+/// padded with zeros to a whole number of rate blocks; the length is folded in
+/// through the initial capacity so inputs of different length that share a
+/// zero-padded prefix do not collide.
+pub fn hash(input: &[Fp]) -> [Fp; DIGEST] {
+    let mut state = [Fp::ZERO; WIDTH];
+    // Length separation in the first capacity lane.
+    state[RATE] = Fp::from_u64(input.len() as u64);
+
+    let mut padded: Vec<Fp> = input.to_vec();
+    while !padded.len().is_multiple_of(RATE) {
+        padded.push(Fp::ZERO);
+    }
+
+    for block in padded.chunks(RATE) {
+        for (i, &v) in block.iter().enumerate() {
+            state[i] = state[i] + v;
+        }
+        state = permute(state);
+    }
+
+    let mut out = [Fp::ZERO; DIGEST];
+    out.copy_from_slice(&state[..DIGEST]);
+    out
+}
+
+/// Compress two digests into one, the two-to-one map a Merkle tree needs.
+pub fn compress(left: &[Fp; DIGEST], right: &[Fp; DIGEST]) -> [Fp; DIGEST] {
+    let mut state = [Fp::ZERO; WIDTH];
+    state[..DIGEST].copy_from_slice(left);
+    state[DIGEST..2 * DIGEST].copy_from_slice(right);
+    state = permute(state);
+    let mut out = [Fp::ZERO; DIGEST];
+    out.copy_from_slice(&state[..DIGEST]);
+    out
+}

--- a/userland/stark_proofs/README.md
+++ b/userland/stark_proofs/README.md
@@ -1,0 +1,59 @@
+# stark_proofs
+
+Host-runnable proofs for the in-kernel STARK primitives. The real
+`src/crypto/stark` source is included through `#[path]` and run on the host,
+so the checks are about the code that ships.
+
+## Poseidon-Goldilocks
+
+The algebraic hash is a real Poseidon over the Goldilocks field, not a
+demonstration instantiation: width 12, the `x^7` S-box, eight full rounds and
+twenty-two partial rounds, with the published Plonky2 round constants and the
+`circ + diag` MDS matrix. The permutation is checked against the four
+reference test vectors from the Plonky2 suite (all zeros, the `0..12` range,
+all `-1`, and a random state), which were themselves produced by the
+hadeshash reference implementation. A single wrong constant, a wrong MDS
+entry, or a wrong round split moves at least one output lane, so matching all
+four byte for byte pins the parameters to the real set.
+
+The sponge built on the permutation (rate 8, capacity 4) is checked for
+determinism, for folding the input length into the capacity so a short input
+and its zero-extension do not collide, and for depending on every input lane.
+The two-to-one compression used by a Merkle tree is checked to use both
+inputs and to be order sensitive.
+
+## The Poseidon preimage STARK
+
+The end-to-end proof of the stack is a STARK for knowledge of a Poseidon
+preimage under the real permutation, not a stand-in. The trace is the
+permutation state, one row per round; each transition enforces one genuine
+Poseidon round, `next = MDS(sbox(state + rc))`, with the round constants and
+the full-versus-partial S-box supplied as public periodic columns so the
+constraint is the published permutation. The boundary pins the input capacity
+lanes to zero (the sponge initialization) and the output rate lanes to a
+public digest. The proofs check that an honest preimage verifies, and that a
+wrong digest, a corrupted interior round, and a nonzero capacity seed are each
+rejected. The verifier only reads the proof and never panics, so a forged
+proof is refused rather than trusted.
+
+Periodic columns are the framework mechanism that makes this expressible: a
+public column, known to prover and verifier, interpolated over the trace
+domain and evaluated at the same point as the trace, so a round-dependent
+constraint needs no per-row index and stays low degree.
+
+## Field, polynomial, Merkle, FRI, AIR
+
+The Goldilocks field arithmetic, the Lagrange evaluation and low-degree
+extension, the BLAKE3 Merkle commitment, the FRI low-degree test over a
+Fiat-Shamir transcript, and the generic AIR prover and verifier are each
+checked against their specifications, including that a tampered proof is
+rejected. The engine is generic over the AIR, so one prover and verifier
+handle the squaring, Fibonacci, S-box chain, two-element permutation, and
+Poseidon preimage instances alike.
+
+## Run
+
+```sh
+cd userland/stark_proofs
+cargo test --release
+```

--- a/userland/stark_proofs/README.md
+++ b/userland/stark_proofs/README.md
@@ -41,6 +41,17 @@ public column, known to prover and verifier, interpolated over the trace
 domain and evaluated at the same point as the trace, so a round-dependent
 constraint needs no per-row index and stays low degree.
 
+## The verifier against forgeries
+
+The verifier's two promises, that it never accepts a forgery and never panics
+on any input, are fuzzed directly. Every single-field mutation of a valid
+proof, across the trace commitments, the opened field elements, the Merkle
+path nodes, and the FRI openings, is rejected without a panic. Structurally
+malformed proofs, with truncated, extended, or reordered vectors, are rejected
+by the length and bounds guards rather than crashing. Proofs assembled from
+arbitrary bytes are refused. The verifier reads attacker-supplied data, so
+this is the property that matters: a forged proof is turned away, not trusted.
+
 ## Field, polynomial, Merkle, FRI, AIR
 
 The Goldilocks field arithmetic, the Lagrange evaluation and low-degree

--- a/userland/stark_proofs/src/air_tests.rs
+++ b/userland/stark_proofs/src/air_tests.rs
@@ -15,7 +15,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::crypto::stark::air::{
-    stark_prove, stark_verify, Fibonacci, Permutation2, PowerChain, Squaring,
+    poseidon_trace, stark_prove, stark_verify, Fibonacci, Permutation2, PoseidonPreimage, PowerChain,
+    Squaring,
 };
 use crate::crypto::stark::field::Fp;
 
@@ -142,6 +143,52 @@ fn a_wrong_permutation_output_is_rejected() {
     let air = Permutation2 { log_t: 4, rc0, rc1, out: [out[0] + Fp::ONE, out[1]] };
     let proof = stark_prove(&air, &trace, QUERIES);
     assert!(!stark_verify(&air, &proof, QUERIES), "a wrong permutation output verified");
+}
+
+// A rate-8 secret input for the Poseidon preimage tests.
+fn preimage_input() -> [Fp; 8] {
+    core::array::from_fn(|i| Fp::from_u64(1000 + i as u64))
+}
+
+#[test]
+fn an_honest_poseidon_preimage_verifies() {
+    // Prove knowledge of an input whose real Poseidon permutation reaches a
+    // public digest, without the proof carrying the input in its statement.
+    let (trace, digest) = poseidon_trace(preimage_input());
+    let air = PoseidonPreimage { digest };
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(stark_verify(&air, &proof, QUERIES), "honest Poseidon preimage rejected");
+}
+
+#[test]
+fn a_wrong_poseidon_digest_is_rejected() {
+    let (trace, digest) = poseidon_trace(preimage_input());
+    let air = PoseidonPreimage { digest: [digest[0] + Fp::ONE, digest[1], digest[2], digest[3]] };
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(!stark_verify(&air, &proof, QUERIES), "a wrong Poseidon digest verified");
+}
+
+#[test]
+fn a_corrupted_poseidon_round_is_rejected() {
+    // Flip one state lane at an interior round: the transition into the next
+    // row no longer matches the real round, so the composition fails.
+    let (mut trace, digest) = poseidon_trace(preimage_input());
+    let width = 12;
+    trace[5 * width + 3] = trace[5 * width + 3] + Fp::ONE;
+    let air = PoseidonPreimage { digest };
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(!stark_verify(&air, &proof, QUERIES), "a corrupted Poseidon round verified");
+}
+
+#[test]
+fn a_nonzero_capacity_initialization_is_rejected() {
+    // Seeding a capacity lane with anything but zero computes a different
+    // function; the sponge-initialization boundary rejects it.
+    let (mut trace, digest) = poseidon_trace(preimage_input());
+    trace[8] = Fp::from_u64(5); // row 0, capacity lane 8
+    let air = PoseidonPreimage { digest };
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(!stark_verify(&air, &proof, QUERIES), "a nonzero capacity init verified");
 }
 
 #[test]

--- a/userland/stark_proofs/src/forgery_tests.rs
+++ b/userland/stark_proofs/src/forgery_tests.rs
@@ -1,0 +1,251 @@
+// NONOS Operating System (AGPL-3.0-or-later)
+use crate::crypto::stark::air::{poseidon_trace, stark_prove, stark_verify, PoseidonPreimage};
+use crate::crypto::stark::field::Fp;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+// The STARK verifier makes two promises: it never accepts a forgery, and it
+// never panics on any input, however malformed. It reads an attacker-supplied
+// proof, so both must hold for every mutation of a valid proof and for wholly
+// arbitrary proof structures. These fuzzes exercise both over adversarial
+// input, the way the ZK verifier fuzz found real soundness bugs elsewhere in
+// the tree.
+
+const QUERIES: usize = 24;
+
+fn xorshift(s: &mut u64) -> u64 {
+    *s ^= *s << 13;
+    *s ^= *s >> 7;
+    *s ^= *s << 17;
+    *s
+}
+
+fn honest() -> (PoseidonPreimage, crate::crypto::stark::air::StarkProof) {
+    let input: [Fp; 8] = core::array::from_fn(|i| Fp::from_u64(7 * i as u64 + 3));
+    let (trace, digest) = poseidon_trace(input);
+    let air = PoseidonPreimage { digest };
+    let proof = stark_prove(&air, &trace, QUERIES);
+    (air, proof)
+}
+
+// The honest proof must verify, so the rejections below are meaningful.
+#[test]
+fn the_reference_proof_verifies() {
+    let (air, proof) = honest();
+    assert!(stark_verify(&air, &proof, QUERIES), "the reference proof was rejected");
+}
+
+// Every single-field mutation of a valid proof must be rejected, and the
+// verifier must return rather than panic on each. The mutation space covers
+// each committed root byte, each opened field element, each Merkle path node,
+// and the composition and FRI openings.
+#[test]
+fn every_single_field_mutation_is_rejected_without_panic() {
+    let (air, base) = honest();
+    let mut s = 0x9e3779b97f4a7c15u64;
+    let mut checked = 0u64;
+
+    for _ in 0..6_000 {
+        let mut p = base.clone();
+        match xorshift(&mut s) % 9 {
+            0 => {
+                // Flip a bit in a trace column commitment.
+                let r = (xorshift(&mut s) as usize) % p.trace_roots.len();
+                let b = (xorshift(&mut s) as usize) % 32;
+                p.trace_roots[r][b] ^= 1 << (xorshift(&mut s) % 8);
+            }
+            1 => {
+                // Perturb a committed composition value at a query.
+                if p.queries.is_empty() {
+                    continue;
+                }
+                let q = (xorshift(&mut s) as usize) % p.queries.len();
+                p.queries[q].comp = p.queries[q].comp + Fp::ONE;
+            }
+            2 => {
+                // Perturb a trace window value at a query.
+                let q = (xorshift(&mut s) as usize) % p.queries.len();
+                if p.queries[q].window.is_empty() {
+                    continue;
+                }
+                let w = (xorshift(&mut s) as usize) % p.queries[q].window.len();
+                p.queries[q].window[w] = p.queries[q].window[w] + Fp::ONE;
+            }
+            3 => {
+                // Corrupt a Merkle path node on a window opening.
+                let q = (xorshift(&mut s) as usize) % p.queries.len();
+                if p.queries[q].window_paths.is_empty() {
+                    continue;
+                }
+                let wp = (xorshift(&mut s) as usize) % p.queries[q].window_paths.len();
+                if p.queries[q].window_paths[wp].is_empty() {
+                    continue;
+                }
+                let node = (xorshift(&mut s) as usize) % p.queries[q].window_paths[wp].len();
+                let b = (xorshift(&mut s) as usize) % 32;
+                p.queries[q].window_paths[wp][node][b] ^= 1;
+            }
+            4 => {
+                // Corrupt the composition Merkle path.
+                let q = (xorshift(&mut s) as usize) % p.queries.len();
+                if p.queries[q].comp_path.is_empty() {
+                    continue;
+                }
+                let node = (xorshift(&mut s) as usize) % p.queries[q].comp_path.len();
+                let b = (xorshift(&mut s) as usize) % 32;
+                p.queries[q].comp_path[node][b] ^= 1;
+            }
+            5 => {
+                // Flip a bit in a FRI layer root.
+                if p.fri.roots.is_empty() {
+                    continue;
+                }
+                let r = (xorshift(&mut s) as usize) % p.fri.roots.len();
+                let b = (xorshift(&mut s) as usize) % 32;
+                p.fri.roots[r][b] ^= 1;
+            }
+            6 => {
+                // Perturb a FRI final-layer coefficient.
+                if p.fri.final_layer.is_empty() {
+                    continue;
+                }
+                let f = (xorshift(&mut s) as usize) % p.fri.final_layer.len();
+                p.fri.final_layer[f] = p.fri.final_layer[f] + Fp::ONE;
+            }
+            7 => {
+                // Perturb a FRI layer opening value.
+                if p.fri.queries.is_empty() {
+                    continue;
+                }
+                let q = (xorshift(&mut s) as usize) % p.fri.queries.len();
+                if p.fri.queries[q].layers.is_empty() {
+                    continue;
+                }
+                let l = (xorshift(&mut s) as usize) % p.fri.queries[q].layers.len();
+                p.fri.queries[q].layers[l].a = p.fri.queries[q].layers[l].a + Fp::ONE;
+            }
+            _ => {
+                // Perturb a FRI layer sibling value.
+                if p.fri.queries.is_empty() {
+                    continue;
+                }
+                let q = (xorshift(&mut s) as usize) % p.fri.queries.len();
+                if p.fri.queries[q].layers.is_empty() {
+                    continue;
+                }
+                let l = (xorshift(&mut s) as usize) % p.fri.queries[q].layers.len();
+                p.fri.queries[q].layers[l].b = p.fri.queries[q].layers[l].b + Fp::ONE;
+            }
+        }
+        assert!(!stark_verify(&air, &p, QUERIES), "a mutated proof verified");
+        checked += 1;
+    }
+    assert!(checked > 4_000, "too few mutations exercised the verifier");
+}
+
+// Structurally malformed proofs, with truncated, extended, or reordered
+// vectors, must be rejected without panic. These exercise the verifier's
+// length and bounds guards, not just its algebra.
+#[test]
+fn structural_mutations_never_panic_and_never_verify() {
+    let (air, base) = honest();
+    let mut s = 0x1234_5678_9abc_def0u64;
+
+    for _ in 0..4_000 {
+        let mut p = base.clone();
+        match xorshift(&mut s) % 8 {
+            0 => {
+                p.trace_roots.pop();
+            }
+            1 => {
+                p.trace_roots.push([0u8; 32]);
+            }
+            2 => {
+                p.queries.pop();
+            }
+            3 => {
+                if let Some(q) = p.queries.first().cloned() {
+                    p.queries.push(q);
+                }
+            }
+            4 => {
+                if let Some(q) = p.queries.first_mut() {
+                    q.window.pop();
+                }
+            }
+            5 => {
+                if let Some(q) = p.queries.first_mut() {
+                    q.window_paths.pop();
+                }
+            }
+            6 => {
+                p.fri.roots.pop();
+            }
+            _ => {
+                p.fri.final_layer.clear();
+            }
+        }
+        // No assertion on the value beyond not panicking, except that an
+        // accept would be a soundness break; a malformed proof must never
+        // verify.
+        assert!(!stark_verify(&air, &p, QUERIES), "a malformed proof verified");
+    }
+}
+
+// A proof assembled from arbitrary bytes must be rejected and must not panic.
+#[test]
+fn arbitrary_proofs_are_rejected_without_panic() {
+    use crate::crypto::stark::air::{StarkProof, StarkQuery};
+    use crate::crypto::stark::fri::{FriProof, LayerOpening, QueryProof};
+
+    let (air, _) = honest();
+    let mut s = 0xdead_beef_cafe_babeu64;
+
+    for _ in 0..2_000 {
+        let n_roots = (xorshift(&mut s) % 6) as usize;
+        let trace_roots: Vec<[u8; 32]> = (0..n_roots)
+            .map(|_| {
+                let mut r = [0u8; 32];
+                for b in r.iter_mut() {
+                    *b = (xorshift(&mut s) & 0xff) as u8;
+                }
+                r
+            })
+            .collect();
+
+        let n_fri_roots = (xorshift(&mut s) % 6) as usize;
+        let fri = FriProof {
+            roots: (0..n_fri_roots).map(|_| [0u8; 32]).collect(),
+            final_layer: (0..(xorshift(&mut s) % 8) as usize)
+                .map(|_| Fp::from_u64(xorshift(&mut s)))
+                .collect(),
+            queries: (0..(xorshift(&mut s) % 6) as usize)
+                .map(|_| QueryProof {
+                    layers: (0..(xorshift(&mut s) % 6) as usize)
+                        .map(|_| LayerOpening {
+                            a: Fp::from_u64(xorshift(&mut s)),
+                            a_path: Vec::new(),
+                            b: Fp::from_u64(xorshift(&mut s)),
+                            b_path: Vec::new(),
+                        })
+                        .collect(),
+                })
+                .collect(),
+        };
+
+        let queries: Vec<StarkQuery> = (0..(xorshift(&mut s) % 6) as usize)
+            .map(|_| StarkQuery {
+                comp: Fp::from_u64(xorshift(&mut s)),
+                comp_path: Vec::new(),
+                window: (0..(xorshift(&mut s) % 30) as usize)
+                    .map(|_| Fp::from_u64(xorshift(&mut s)))
+                    .collect(),
+                window_paths: Vec::new(),
+            })
+            .collect();
+
+        let p = StarkProof { trace_roots, fri, queries };
+        assert!(!stark_verify(&air, &p, QUERIES), "an arbitrary proof verified");
+    }
+}

--- a/userland/stark_proofs/src/lib.rs
+++ b/userland/stark_proofs/src/lib.rs
@@ -11,6 +11,8 @@ mod air_tests;
 #[cfg(test)]
 mod field_tests;
 #[cfg(test)]
+mod forgery_tests;
+#[cfg(test)]
 mod fri_tests;
 #[cfg(test)]
 mod merkle_tests;

--- a/userland/stark_proofs/src/lib.rs
+++ b/userland/stark_proofs/src/lib.rs
@@ -20,3 +20,5 @@ mod merkle_tests;
 mod poly_tests;
 #[cfg(test)]
 mod poseidon_tests;
+#[cfg(test)]
+mod transcript_tests;

--- a/userland/stark_proofs/src/lib.rs
+++ b/userland/stark_proofs/src/lib.rs
@@ -16,3 +16,5 @@ mod fri_tests;
 mod merkle_tests;
 #[cfg(test)]
 mod poly_tests;
+#[cfg(test)]
+mod poseidon_tests;

--- a/userland/stark_proofs/src/poseidon_tests.rs
+++ b/userland/stark_proofs/src/poseidon_tests.rs
@@ -1,0 +1,189 @@
+// NONOS Operating System (AGPL-3.0-or-later)
+use crate::crypto::stark::field::Fp;
+use crate::crypto::stark::poseidon::permutation::permute;
+use crate::crypto::stark::poseidon::sponge::{compress, hash, DIGEST};
+use crate::crypto::stark::poseidon::{FULL_ROUNDS, N_ROUNDS, PARTIAL_ROUNDS, WIDTH};
+
+// The real Poseidon-Goldilocks permutation, verified against the published
+// reference test vectors. These input/output pairs are the width-12 vectors
+// from the Plonky2 test suite, themselves computed with the hadeshash
+// reference implementation. Matching them byte for byte is what makes this a
+// real hash rather than an invented one: the round constants, the MDS matrix,
+// the S-box, and the round schedule must all be exactly the published set or
+// a single lane diverges.
+
+const P: u64 = 0xFFFF_FFFF_0000_0001;
+const NEG_ONE: u64 = P - 1;
+
+fn state(vals: [u64; WIDTH]) -> [Fp; WIDTH] {
+    let mut s = [Fp::ZERO; WIDTH];
+    for (i, v) in vals.iter().enumerate() {
+        s[i] = Fp::from_u64(*v);
+    }
+    s
+}
+
+fn values(s: [Fp; WIDTH]) -> [u64; WIDTH] {
+    let mut out = [0u64; WIDTH];
+    for (i, e) in s.iter().enumerate() {
+        out[i] = e.value();
+    }
+    out
+}
+
+#[test]
+fn the_round_schedule_is_the_published_one() {
+    assert_eq!(WIDTH, 12);
+    assert_eq!(FULL_ROUNDS, 8);
+    assert_eq!(PARTIAL_ROUNDS, 22);
+    assert_eq!(N_ROUNDS, 30);
+}
+
+#[test]
+fn permutation_matches_the_all_zeros_vector() {
+    let out = values(permute(state([0; WIDTH])));
+    assert_eq!(
+        out,
+        [
+            0x3c18a9786cb0b359,
+            0xc4055e3364a246c3,
+            0x7953db0ab48808f4,
+            0xc71603f33a1144ca,
+            0xd7709673896996dc,
+            0x46a84e87642f44ed,
+            0xd032648251ee0b3c,
+            0x1c687363b207df62,
+            0xdf8565563e8045fe,
+            0x40f5b37ff4254dae,
+            0xd070f637b431067c,
+            0x1792b1c4342109d7,
+        ]
+    );
+}
+
+#[test]
+fn permutation_matches_the_range_vector() {
+    let out = values(permute(state([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])));
+    assert_eq!(
+        out,
+        [
+            0xd64e1e3efc5b8e9e,
+            0x53666633020aaa47,
+            0xd40285597c6a8825,
+            0x613a4f81e81231d2,
+            0x414754bfebd051f0,
+            0xcb1f8980294a023f,
+            0x6eb2a9e4d54a9d0f,
+            0x1902bc3af467e056,
+            0xf045d5eafdc6021f,
+            0xe4150f77caaa3be5,
+            0xc9bfd01d39b50cce,
+            0x5c0a27fcb0e1459b,
+        ]
+    );
+}
+
+#[test]
+fn permutation_matches_the_all_minus_one_vector() {
+    let out = values(permute(state([NEG_ONE; WIDTH])));
+    assert_eq!(
+        out,
+        [
+            0xbe0085cfc57a8357,
+            0xd95af71847d05c09,
+            0xcf55a13d33c1c953,
+            0x95803a74f4530e82,
+            0xfcd99eb30a135df1,
+            0xe095905e913a3029,
+            0xde0392461b42919b,
+            0x7d3260e24e81d031,
+            0x10d3d0465d9deaa0,
+            0xa87571083dfc2a47,
+            0xe18263681e9958f8,
+            0xe28e96f1ae5e60d3,
+        ]
+    );
+}
+
+#[test]
+fn permutation_matches_the_random_vector() {
+    let input = [
+        0x8ccbbbea4fe5d2b7,
+        0xc2af59ee9ec49970,
+        0x90f7e1a9e658446a,
+        0xdcc0630a3ab8b1b8,
+        0x7ff8256bca20588c,
+        0x5d99a7ca0c44ecfb,
+        0x48452b17a70fbee3,
+        0xeb09d654690b6c88,
+        0x4a55d3a39c676a88,
+        0xc0407a38d2285139,
+        0xa234bac9356386d1,
+        0xe1633f2bad98a52f,
+    ];
+    let out = values(permute(state(input)));
+    assert_eq!(
+        out,
+        [
+            0xa89280105650c4ec,
+            0xab542d53860d12ed,
+            0x5704148e9ccab94f,
+            0xd3a826d4b62da9f5,
+            0x8a7a6ca87892574f,
+            0xc7017e1cad1a674e,
+            0x1f06668922318e34,
+            0xa3b203bc8102676f,
+            0xfcc781b0ce382bf2,
+            0x934c69ff3ed14ba5,
+            0x504688a5996e8f13,
+            0x401f3f2ed524a2ba,
+        ]
+    );
+}
+
+// The sponge built on the verified permutation: deterministic, length
+// separating, and sensitive to every input lane.
+
+#[test]
+fn sponge_is_deterministic() {
+    let input: [Fp; 5] = [
+        Fp::from_u64(11),
+        Fp::from_u64(22),
+        Fp::from_u64(33),
+        Fp::from_u64(44),
+        Fp::from_u64(55),
+    ];
+    assert_eq!(hash(&input), hash(&input));
+    assert_eq!(hash(&input).len(), DIGEST);
+}
+
+#[test]
+fn sponge_separates_lengths_across_the_zero_pad() {
+    // A short input and its zero-extension share a padded block but must not
+    // collide, because the length is folded into the capacity.
+    let short = [Fp::from_u64(7)];
+    let padded = [Fp::from_u64(7), Fp::ZERO];
+    assert_ne!(hash(&short), hash(&padded));
+}
+
+#[test]
+fn sponge_depends_on_every_input_element() {
+    let base: [Fp; 8] = core::array::from_fn(|i| Fp::from_u64(i as u64 + 1));
+    let h0 = hash(&base);
+    for i in 0..base.len() {
+        let mut m = base;
+        m[i] = m[i] + Fp::ONE;
+        assert_ne!(hash(&m), h0, "flipping lane {i} did not change the digest");
+    }
+}
+
+#[test]
+fn compress_is_a_two_to_one_map_that_uses_both_sides() {
+    let a = [Fp::from_u64(1), Fp::from_u64(2), Fp::from_u64(3), Fp::from_u64(4)];
+    let b = [Fp::from_u64(5), Fp::from_u64(6), Fp::from_u64(7), Fp::from_u64(8)];
+    assert_eq!(compress(&a, &b), compress(&a, &b));
+    assert_ne!(compress(&a, &b), compress(&b, &a), "compress must not be symmetric");
+    let mut b2 = b;
+    b2[3] = b2[3] + Fp::ONE;
+    assert_ne!(compress(&a, &b), compress(&a, &b2), "right input must matter");
+}

--- a/userland/stark_proofs/src/transcript_tests.rs
+++ b/userland/stark_proofs/src/transcript_tests.rs
@@ -1,0 +1,128 @@
+// NONOS Operating System (AGPL-3.0-or-later)
+use crate::crypto::stark::field::Fp;
+use crate::crypto::stark::transcript::Transcript;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+// The Fiat-Shamir transcript turns the interactive protocol into a
+// non-interactive proof: the challenges are derived from the committed data,
+// so a prover cannot choose them and cannot reuse a proof for a different
+// statement. These checks exercise the properties the soundness of that
+// transformation rests on: the challenge stream is a deterministic function
+// of the absorbed sequence, it changes under any change to that sequence, and
+// the query indices stay in range.
+
+fn draw_challenges(label: &[u8], absorb: &[[u8; 32]]) -> (Vec<u64>, Vec<usize>) {
+    let mut t = Transcript::new(label);
+    for d in absorb {
+        t.absorb_digest(d);
+    }
+    let fps: Vec<u64> = (0..8).map(|_| t.challenge_fp().value()).collect();
+    let idxs: Vec<usize> = (0..8).map(|_| t.challenge_index(64)).collect();
+    (fps, idxs)
+}
+
+fn digest(byte: u8) -> [u8; 32] {
+    [byte; 32]
+}
+
+#[test]
+fn the_challenge_stream_is_deterministic() {
+    let absorb = [digest(1), digest(2), digest(3)];
+    let a = draw_challenges(b"NONOS-STARK", &absorb);
+    let b = draw_challenges(b"NONOS-STARK", &absorb);
+    assert_eq!(a, b, "the same transcript drew different challenges");
+}
+
+#[test]
+fn a_different_label_gives_a_different_stream() {
+    let absorb = [digest(1)];
+    let a = draw_challenges(b"label-one", &absorb);
+    let b = draw_challenges(b"label-two", &absorb);
+    assert_ne!(a.0, b.0, "distinct labels shared a challenge stream");
+}
+
+#[test]
+fn a_one_bit_change_in_absorbed_data_changes_every_later_challenge() {
+    // This is the Fiat-Shamir binding: flipping a single bit of any committed
+    // value re-randomizes the challenges, so a proof cannot be transplanted to
+    // a different statement.
+    let base = [digest(0x10), digest(0x20), digest(0x30)];
+    let (base_fp, base_idx) = draw_challenges(b"NONOS-STARK", &base);
+    for pos in 0..base.len() {
+        for bit in 0..8u32 {
+            let mut m = base;
+            m[pos][0] ^= 1 << bit;
+            let (fp, idx) = draw_challenges(b"NONOS-STARK", &m);
+            assert_ne!(fp, base_fp, "a flipped bit at {pos}/{bit} left the fp stream unchanged");
+            assert_ne!(idx, base_idx, "a flipped bit at {pos}/{bit} left the index stream unchanged");
+        }
+    }
+}
+
+#[test]
+fn absorb_order_matters() {
+    // The state folds each input into a running hash, so a permutation of the
+    // absorbed sequence yields a different stream.
+    let ab = draw_challenges(b"NONOS-STARK", &[digest(1), digest(2)]);
+    let ba = draw_challenges(b"NONOS-STARK", &[digest(2), digest(1)]);
+    assert_ne!(ab.0, ba.0, "reordering the absorbed data left the stream unchanged");
+}
+
+#[test]
+fn digest_and_field_absorbs_are_domain_separated() {
+    // A 32-byte digest and a field element that share leading bytes must not
+    // collide, because each absorb carries a distinct domain tag.
+    let mut td = Transcript::new(b"NONOS-STARK");
+    td.absorb_digest(&{
+        let mut d = [0u8; 32];
+        d[0..8].copy_from_slice(&7u64.to_le_bytes());
+        d
+    });
+    let cd = td.challenge_fp().value();
+
+    let mut tf = Transcript::new(b"NONOS-STARK");
+    tf.absorb_fp(Fp::from_u64(7));
+    let cf = tf.challenge_fp().value();
+
+    assert_ne!(cd, cf, "a digest and a field element were not domain separated");
+}
+
+#[test]
+fn consecutive_challenges_advance() {
+    // Each challenge mixes a tag into the state, so the stream does not repeat
+    // a value back to back.
+    let mut t = Transcript::new(b"NONOS-STARK");
+    t.absorb_digest(&digest(9));
+    let first = t.challenge_fp().value();
+    let second = t.challenge_fp().value();
+    assert_ne!(first, second, "two consecutive challenges were equal");
+}
+
+#[test]
+fn query_indices_stay_within_every_power_of_two_bound() {
+    for log_bound in 1..=16u32 {
+        let bound = 1usize << log_bound;
+        let mut t = Transcript::new(b"NONOS-STARK");
+        t.absorb_digest(&digest(log_bound as u8));
+        for _ in 0..2000 {
+            let i = t.challenge_index(bound);
+            assert!(i < bound, "index {i} out of bound {bound}");
+        }
+    }
+}
+
+#[test]
+fn query_indices_span_their_range() {
+    // Over enough draws the masked index reaches both ends of a small domain,
+    // evidence that the low bits are not stuck.
+    let bound = 8usize;
+    let mut t = Transcript::new(b"NONOS-STARK");
+    t.absorb_digest(&digest(42));
+    let mut seen = [false; 8];
+    for _ in 0..1000 {
+        seen[t.challenge_index(bound)] = true;
+    }
+    assert!(seen.iter().all(|&b| b), "some query index in 0..8 never appeared");
+}


### PR DESCRIPTION
Turns the STARK's hash from a demonstration into a real one and proves a
genuine statement about it. Sits at the top of the STARK stack, based on
Stark-Air-Multicol.

## Real Poseidon-Goldilocks
A Poseidon permutation over Goldilocks with the published Plonky2 parameters:
width 12, x^7 S-box, eight full and twenty-two partial rounds, the
`ALL_ROUND_CONSTANTS` table, and the `circ + diag` MDS matrix. A field
sponge (rate 8, capacity 4) and a two-to-one compression are built on it. The
permutation is checked against the four Plonky2 reference vectors, which were
produced by the hadeshash reference implementation, so the constants are the
real published set, not an invented one. A single wrong constant moves at
least one output lane, so matching all four byte for byte pins the parameters.

## A real preimage STARK
The end-to-end proof is knowledge of a Poseidon preimage under the actual
permutation. To express a round-dependent constraint the AIR framework gains
public periodic columns: a full-length column known to both prover and
verifier, interpolated over the trace domain and read at the same point as
the trace, so the round constants and the full-versus-partial S-box need no
per-row index and stay low degree. The transition is one genuine Poseidon
round, `next = MDS(sbox(state + rc))`; the boundary pins the input capacity
to zero and the output rate lanes to a public digest. The proofs show an
honest preimage verifies and a wrong digest, a corrupted interior round, and
a nonzero capacity seed are each rejected.

## Verified
Host proofs: 46 pass, including the four reference vectors and the preimage
prove/verify with three tamper rejections. `cargo clippy -D warnings` clean.
The kernel builds for x86_64-nonos with zero warnings (`make nonos-mk-core`).
The earlier demonstration sponge AIR is removed; it never appears in this
branch's history.