### PR TITLE
stark: prove a Poseidon Merkle opening inside a STARK (recursion gadget)

### DIFF
--- a/src/crypto/stark/air/merkle_membership.rs
+++ b/src/crypto/stark/air/merkle_membership.rs
@@ -1,0 +1,165 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The recursion gadget: an AIR that proves a Poseidon Merkle path, so a
+//! commitment opening is checked inside a STARK. The trace is the Poseidon state
+//! evolving through the path, `2^log_rounds` rows per compression. Within a
+//! compression the transition is a Poseidon round; at each compression boundary
+//! it takes the output digest and injects the next sibling by the index bit,
+//! forming the next input. The public root is pinned at the final checkpoint and
+//! the public siblings at the boundaries; the leaf stays private, so a valid
+//! proof is knowledge of a leaf whose path reaches the root.
+
+use super::super::field::Fp;
+use super::poseidon::{Poseidon, RATE, WIDTH};
+use super::spec::Air;
+use alloc::vec::Vec;
+
+pub struct MerkleMembership {
+    hasher: Poseidon,
+    log_rounds: u32,
+    log_slots: u32,
+    root: [Fp; RATE],
+    /// One sibling digest per tree level, from the leaf up.
+    siblings: Vec<[Fp; RATE]>,
+    /// The index bit at each level: false when the node is the left child.
+    directions: Vec<bool>,
+}
+
+impl MerkleMembership {
+    /// Build the AIR. `hasher` must be the same Poseidon the tree committed with,
+    /// with `2^log_rounds` rounds. `2^log_slots` slots hold the `2^log_slots - 1`
+    /// compressions of a path that deep, plus the final root checkpoint.
+    pub fn new(
+        hasher: Poseidon,
+        log_rounds: u32,
+        log_slots: u32,
+        root: [Fp; RATE],
+        siblings: Vec<[Fp; RATE]>,
+        directions: Vec<bool>,
+    ) -> MerkleMembership {
+        MerkleMembership { hasher, log_rounds, log_slots, root, siblings, directions }
+    }
+
+    fn rounds(&self) -> usize {
+        1usize << self.log_rounds
+    }
+
+    /// The number of compressions, the tree depth.
+    fn depth(&self) -> usize {
+        (1usize << self.log_slots) - 1
+    }
+}
+
+impl Air for MerkleMembership {
+    fn log_trace_len(&self) -> u32 {
+        self.log_rounds + self.log_slots
+    }
+
+    fn trace_width(&self) -> usize {
+        WIDTH
+    }
+
+    fn window_size(&self) -> usize {
+        2
+    }
+
+    fn constraint_degree(&self) -> usize {
+        7
+    }
+
+    fn num_transition(&self) -> usize {
+        WIDTH
+    }
+
+    fn periodic_columns(&self) -> Vec<Vec<Fp>> {
+        let l = self.rounds();
+        let depth = self.depth();
+        let n = 1usize << self.log_trace_len();
+
+        // WIDTH round-constant columns, then a boundary selector, a direction,
+        // and RATE sibling columns.
+        let mut cols: Vec<Vec<Fp>> = (0..WIDTH + 2 + RATE).map(|_| Vec::with_capacity(n)).collect();
+        for r in 0..n {
+            let rc = self.hasher.round_constant(r % l);
+            for (j, col) in cols.iter_mut().take(WIDTH).enumerate() {
+                col.push(rc[j]);
+            }
+            // A boundary transition is the last round of a real compression: its
+            // successor row starts the next slot.
+            let is_boundary = r % l == l - 1 && r < depth * l;
+            cols[WIDTH].push(if is_boundary { Fp::ONE } else { Fp::ZERO });
+            // The slot the boundary forms, and the sibling and direction it uses.
+            let m = (r + 1) / l;
+            let (dir, sib) = if is_boundary && m < depth {
+                (self.directions[m], self.siblings[m])
+            } else {
+                (false, [Fp::ZERO; RATE])
+            };
+            cols[WIDTH + 1].push(if dir { Fp::ONE } else { Fp::ZERO });
+            for (c, s) in sib.iter().enumerate() {
+                cols[WIDTH + 2 + c].push(*s);
+            }
+        }
+        cols
+    }
+
+    fn transition(&self, window: &[Fp], periodic: &[Fp]) -> Vec<Fp> {
+        let mut state = [Fp::ZERO; WIDTH];
+        state.copy_from_slice(&window[..WIDTH]);
+        let mut rc = [Fp::ZERO; WIDTH];
+        rc.copy_from_slice(&periodic[..WIDTH]);
+        let bnd = periodic[WIDTH];
+        let dir = periodic[WIDTH + 1];
+        let sib = &periodic[WIDTH + 2..WIDTH + 2 + RATE];
+
+        // One Poseidon round with the periodic constants: the within-compression
+        // update, and its first RATE lanes are the output digest at a boundary.
+        let pr = self.hasher.round_with_rc(&state, &rc);
+        let one = Fp::ONE;
+
+        let mut out = Vec::with_capacity(WIDTH);
+        for (j, next) in window[WIDTH..2 * WIDTH].iter().enumerate() {
+            // Injection: the digest and the sibling arranged by the index bit.
+            let inj = if j < RATE {
+                (one - dir) * pr[j] + dir * sib[j]
+            } else {
+                (one - dir) * sib[j - RATE] + dir * pr[j - RATE]
+            };
+            let expected = (one - bnd) * pr[j] + bnd * inj;
+            out.push(*next - expected);
+        }
+        out
+    }
+
+    fn boundary(&self) -> Vec<(usize, usize, Fp)> {
+        let l = self.rounds();
+        let depth = self.depth();
+        let mut b = Vec::with_capacity(WIDTH);
+
+        // The first slot holds [leaf, sibling_0] by the first index bit; the leaf
+        // half is free, the sibling half is pinned.
+        let base = if self.directions[0] { 0 } else { RATE };
+        for (c, s) in self.siblings[0].iter().enumerate() {
+            b.push((base + c, 0, *s));
+        }
+        // The final checkpoint holds the root in its rate lanes.
+        for (c, r) in self.root.iter().enumerate() {
+            b.push((c, depth * l, *r));
+        }
+        b
+    }
+}

--- a/src/crypto/stark/air/mod.rs
+++ b/src/crypto/stark/air/mod.rs
@@ -24,6 +24,7 @@
 
 mod composition;
 mod fibonacci;
+mod merkle_membership;
 mod permutation2;
 mod poseidon;
 mod power_chain;
@@ -34,6 +35,7 @@ mod types;
 mod verify;
 
 pub use fibonacci::Fibonacci;
+pub use merkle_membership::MerkleMembership;
 pub use permutation2::Permutation2;
 pub use poseidon::{Poseidon, RATE, WIDTH};
 pub use power_chain::PowerChain;

--- a/src/crypto/stark/air/poseidon.rs
+++ b/src/crypto/stark/air/poseidon.rs
@@ -94,6 +94,31 @@ impl Poseidon {
         digest
     }
 
+    /// One round using externally supplied constants: full x^7 S-box, MDS mix,
+    /// then add `rc`. The membership AIR feeds the round constants as periodic
+    /// values, so it shares this exact round function with the hash.
+    pub fn round_with_rc(&self, state: &[Fp; WIDTH], rc: &[Fp; WIDTH]) -> [Fp; WIDTH] {
+        let mut sbox = [Fp::ZERO; WIDTH];
+        for (s, v) in sbox.iter_mut().zip(state.iter()) {
+            *s = (*v).pow(7);
+        }
+        let mut out = [Fp::ZERO; WIDTH];
+        for (j, o) in out.iter_mut().enumerate() {
+            let mut acc = rc[j];
+            for (m, s) in self.mds[j].iter().zip(sbox.iter()) {
+                acc = acc + *m * *s;
+            }
+            *o = acc;
+        }
+        out
+    }
+
+    /// The round constant for round `r`, exposed so the membership AIR can build
+    /// its periodic columns from the same schedule the hash uses.
+    pub fn round_constant(&self, r: usize) -> [Fp; WIDTH] {
+        self.rc[r]
+    }
+
     /// The full permutation: every round applied to a state. This is the
     /// primitive a Poseidon Merkle commitment compresses with, and because it is
     /// all field operations it can be arithmetized, which is what makes a

--- a/userland/stark_proofs/src/air_tests.rs
+++ b/userland/stark_proofs/src/air_tests.rs
@@ -15,9 +15,11 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::crypto::stark::air::{
-    stark_prove, stark_verify, Fibonacci, Permutation2, Poseidon, PowerChain, Squaring, RATE, WIDTH,
+    stark_prove, stark_verify, Fibonacci, MerkleMembership, Permutation2, Poseidon, PowerChain,
+    Squaring, RATE, WIDTH,
 };
 use crate::crypto::stark::field::Fp;
+use crate::crypto::stark::poseidon_merkle::PoseidonMerkleTree;
 
 extern crate alloc;
 use alloc::vec::Vec;
@@ -322,6 +324,112 @@ fn a_long_squaring_chain_verifies() {
     let air = Squaring { log_t: 10, seed };
     let proof = stark_prove(&air, &squaring_trace(10, seed), QUERIES);
     assert!(stark_verify(&air, &proof, QUERIES), "long squaring chain rejected");
+}
+
+/// Build the Poseidon-state trace of a Merkle path: for each compression, place
+/// the node and sibling by the index bit, run the rounds, and carry the digest
+/// up; the final slot holds the root.
+fn membership_trace(
+    hasher: &Poseidon,
+    leaf: [Fp; RATE],
+    siblings: &[[Fp; RATE]],
+    directions: &[bool],
+    log_rounds: u32,
+    log_slots: u32,
+) -> Vec<Fp> {
+    let l = 1usize << log_rounds;
+    let depth = (1usize << log_slots) - 1;
+    let mut rows: Vec<[Fp; WIDTH]> = Vec::with_capacity((depth + 1) * l);
+    let mut node = leaf;
+    for k in 0..depth {
+        let mut state = [Fp::ZERO; WIDTH];
+        if !directions[k] {
+            state[..RATE].copy_from_slice(&node);
+            state[RATE..].copy_from_slice(&siblings[k]);
+        } else {
+            state[..RATE].copy_from_slice(&siblings[k]);
+            state[RATE..].copy_from_slice(&node);
+        }
+        for round in 0..l {
+            rows.push(state);
+            state = hasher.round_with_rc(&state, &hasher.round_constant(round));
+        }
+        node.copy_from_slice(&state[..RATE]);
+    }
+    let mut state = [Fp::ZERO; WIDTH];
+    state[..RATE].copy_from_slice(&node);
+    for round in 0..l {
+        rows.push(state);
+        state = hasher.round_with_rc(&state, &hasher.round_constant(round));
+    }
+    let mut trace = Vec::with_capacity(rows.len() * WIDTH);
+    for row in &rows {
+        trace.extend_from_slice(row);
+    }
+    trace
+}
+
+fn merkle_leaves(n: usize) -> Vec<[Fp; RATE]> {
+    (0..n)
+        .map(|i| {
+            let mut d = [Fp::ZERO; RATE];
+            for (c, cell) in d.iter_mut().enumerate() {
+                *cell = Fp::from_u64((i * RATE + c + 1) as u64);
+            }
+            d
+        })
+        .collect()
+}
+
+#[test]
+fn a_merkle_membership_proof_verifies() {
+    // Prove, inside a STARK, that a leaf opens to a public Poseidon Merkle root:
+    // the commitment check is now itself a proof, the core recursion step.
+    let (log_rounds, log_slots) = (3u32, 2u32); // 8-round hash, depth-3 tree
+    let hasher = Poseidon::new(log_rounds, [Fp::ZERO; RATE]);
+    let leaves = merkle_leaves(8);
+    let tree = PoseidonMerkleTree::commit(&hasher, &leaves);
+    let root = tree.root();
+    let index = 5usize;
+    let path = tree.open(index);
+    let directions: Vec<bool> = (0..path.len()).map(|k| (index >> k) & 1 == 1).collect();
+
+    let trace = membership_trace(&hasher, leaves[index], &path, &directions, log_rounds, log_slots);
+    let air = MerkleMembership::new(
+        Poseidon::new(log_rounds, [Fp::ZERO; RATE]),
+        log_rounds,
+        log_slots,
+        root,
+        path.clone(),
+        directions.clone(),
+    );
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(stark_verify(&air, &proof, QUERIES), "an honest membership proof was rejected");
+}
+
+#[test]
+fn a_membership_proof_for_a_wrong_root_is_rejected() {
+    let (log_rounds, log_slots) = (3u32, 2u32);
+    let hasher = Poseidon::new(log_rounds, [Fp::ZERO; RATE]);
+    let leaves = merkle_leaves(8);
+    let tree = PoseidonMerkleTree::commit(&hasher, &leaves);
+    let index = 5usize;
+    let path = tree.open(index);
+    let directions: Vec<bool> = (0..path.len()).map(|k| (index >> k) & 1 == 1).collect();
+    let trace = membership_trace(&hasher, leaves[index], &path, &directions, log_rounds, log_slots);
+
+    let mut wrong = tree.root();
+    wrong[0] = wrong[0] + Fp::ONE;
+    let air = MerkleMembership::new(
+        Poseidon::new(log_rounds, [Fp::ZERO; RATE]),
+        log_rounds,
+        log_slots,
+        wrong,
+        path,
+        directions,
+    );
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(!stark_verify(&air, &proof, QUERIES), "a wrong-root membership proof verified");
 }
 
 #[test]


### PR DESCRIPTION
The core recursion step: a Merkle path check, arithmetized. A recursive verifier spends most of its work checking commitment openings, and this proves one inside a STARK.

The AIR trace is the Poseidon state evolving through a path, one compression (2^log_rounds rounds) per tree level. Within a compression the transition is a Poseidon round; at each level boundary a selector switches it to take the output digest and inject the next sibling by the index bit, forming the next compression input. The final slot holds the root. Public inputs are the root (pinned at the final checkpoint) and the siblings (at the boundaries); the leaf is private, so a valid proof is knowledge of a leaf whose path reaches the root, which is a real membership statement since Poseidon cannot be inverted.

Built on the two pieces already in place: the per-round-constant engine and the algebraic Poseidon Merkle commitment. Exposes a Poseidon round that takes external constants so the AIR and the hash share the exact round function.

Host proofs: build a real Poseidon Merkle tree, open a leaf, and prove membership; a wrong root is rejected. 50/50 stark_proofs tests, clippy -D warnings clean, kernel builds.

This is piece three of recursion (foundation commitment #299, arithmetized hash #296, this opening gadget). The remaining piece is arithmetizing the FRI verifier itself, a larger effort.

Stacked on Stark-Poseidon-Merkle (#299).