### PR TITLE
stark: arithmetize the FRI fold consistency check

### DIFF
--- a/src/crypto/stark/air/fri_fold.rs
+++ b/src/crypto/stark/air/fri_fold.rs
@@ -1,0 +1,120 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The FRI fold-consistency gadget: an AIR that checks a query walks the FRI
+//! layers correctly. Each row is a layer's opened pair `(a, b) = (f(x), f(-x))`.
+//! The transition recomputes the fold
+//! `v = (a + b)/2 + beta * (a - b) / (2x)` and checks it equals the value the
+//! next layer carries for this query, selected by the position bit. The final
+//! layer is pinned to the proof's committed constant. This is the last FRI
+//! verification step to become AIR constraints; composed with the Merkle
+//! opening gadget and the transcript, it is a recursive FRI verifier.
+
+use super::super::field::Fp;
+use super::spec::Air;
+use alloc::vec::Vec;
+
+pub struct FriFold {
+    log_layers: u32,
+    n_folds: usize,
+    /// Inverse of the low domain point at each folding layer.
+    x_inv: Vec<Fp>,
+    /// The folding challenge at each layer.
+    beta: Vec<Fp>,
+    /// Whether the folded value lands in the next layer's second slot.
+    dir: Vec<bool>,
+    /// The committed final-layer value.
+    final_value: Fp,
+}
+
+impl FriFold {
+    pub fn new(
+        log_layers: u32,
+        n_folds: usize,
+        x_inv: Vec<Fp>,
+        beta: Vec<Fp>,
+        dir: Vec<bool>,
+        final_value: Fp,
+    ) -> FriFold {
+        FriFold { log_layers, n_folds, x_inv, beta, dir, final_value }
+    }
+}
+
+impl Air for FriFold {
+    fn log_trace_len(&self) -> u32 {
+        self.log_layers
+    }
+
+    fn trace_width(&self) -> usize {
+        2
+    }
+
+    fn window_size(&self) -> usize {
+        2
+    }
+
+    fn constraint_degree(&self) -> usize {
+        // The fold is linear in the trace, but the constraint multiplies several
+        // periodic columns (the selector, the challenge, the inverse point) into
+        // it, so the composition degree is that of four interpolated columns. The
+        // engine sizes the domain from this.
+        4
+    }
+
+    fn num_transition(&self) -> usize {
+        1
+    }
+
+    fn periodic_columns(&self) -> Vec<Vec<Fp>> {
+        let n = 1usize << self.log_layers;
+        // The fold applies at layers 0..n_folds; other rows are inert.
+        let mut sel = Vec::with_capacity(n);
+        let mut xi = Vec::with_capacity(n);
+        let mut bt = Vec::with_capacity(n);
+        let mut dr = Vec::with_capacity(n);
+        for r in 0..n {
+            let active = r < self.n_folds;
+            sel.push(if active { Fp::ONE } else { Fp::ZERO });
+            xi.push(if active { self.x_inv[r] } else { Fp::ZERO });
+            bt.push(if active { self.beta[r] } else { Fp::ZERO });
+            dr.push(if active && self.dir[r] { Fp::ONE } else { Fp::ZERO });
+        }
+        alloc::vec![sel, xi, bt, dr]
+    }
+
+    fn transition(&self, window: &[Fp], periodic: &[Fp]) -> Vec<Fp> {
+        let (a, b) = (window[0], window[1]);
+        let (next_a, next_b) = (window[2], window[3]);
+        let sel = periodic[0];
+        let x_inv = periodic[1];
+        let beta = periodic[2];
+        let dir = periodic[3];
+
+        let inv2 = Fp::from_u64(2).inv();
+        let even = (a + b) * inv2;
+        let odd = (a - b) * inv2 * x_inv;
+        let folded = even + beta * odd;
+
+        let expected = (Fp::ONE - dir) * next_a + dir * next_b;
+        // Enforced only on the active folding rows.
+        alloc::vec![sel * (folded - expected)]
+    }
+
+    fn boundary(&self) -> Vec<(usize, usize, Fp)> {
+        // The layer after the last fold carries the committed final value.
+        alloc::vec![(0, self.n_folds, self.final_value)]
+    }
+}

--- a/src/crypto/stark/air/mod.rs
+++ b/src/crypto/stark/air/mod.rs
@@ -24,6 +24,7 @@
 
 mod composition;
 mod fibonacci;
+mod fri_fold;
 mod merkle_membership;
 mod permutation2;
 mod poseidon;
@@ -35,6 +36,7 @@ mod types;
 mod verify;
 
 pub use fibonacci::Fibonacci;
+pub use fri_fold::FriFold;
 pub use merkle_membership::MerkleMembership;
 pub use permutation2::Permutation2;
 pub use poseidon::{Poseidon, RATE, WIDTH};

--- a/userland/stark_proofs/src/air_tests.rs
+++ b/userland/stark_proofs/src/air_tests.rs
@@ -15,14 +15,22 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::crypto::stark::air::{
-    stark_prove, stark_verify, Fibonacci, MerkleMembership, Permutation2, Poseidon, PowerChain,
-    Squaring, RATE, WIDTH,
+    stark_prove, stark_verify, Fibonacci, FriFold, MerkleMembership, Permutation2, Poseidon,
+    PowerChain, Squaring, RATE, WIDTH,
 };
 use crate::crypto::stark::field::Fp;
+use crate::crypto::stark::fri::root_of_unity;
 use crate::crypto::stark::poseidon_merkle::PoseidonMerkleTree;
 
 extern crate alloc;
 use alloc::vec::Vec;
+
+fn xs(state: &mut u64) -> u64 {
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+    *state
+}
 
 // The end-to-end STARK: a real proof that a computation ran correctly, with no
 // trusted setup and hash-only cryptography. The engine is generic over the AIR,
@@ -430,6 +438,83 @@ fn a_membership_proof_for_a_wrong_root_is_rejected() {
     );
     let proof = stark_prove(&air, &trace, QUERIES);
     assert!(!stark_verify(&air, &proof, QUERIES), "a wrong-root membership proof verified");
+}
+
+#[test]
+fn a_fri_fold_chain_verifies() {
+    // Fold a real codeword four times, extract one query's path down the layers,
+    // and prove inside a STARK that the folds are consistent and reach the
+    // committed final value. This is the FRI verifier's fold check, arithmetized.
+    let (k, n_folds, log_layers) = (5u32, 4usize, 3u32); // domain 32, fold to size 2
+    let n = 1usize << k;
+    let inv2 = Fp::from_u64(2).inv();
+    let base_omega = root_of_unity(k);
+    let shift = Fp::from_u64(7);
+
+    let mut s = 0xf01d_1234u64 | 1;
+    let mut layers: Vec<Vec<Fp>> = Vec::new();
+    let mut betas: Vec<Fp> = Vec::new();
+    let mut cur: Vec<Fp> = (0..n).map(|_| Fp::from_u64(xs(&mut s))).collect();
+    layers.push(cur.clone());
+    let mut omega = base_omega;
+    let mut coset = shift;
+    for _ in 0..n_folds {
+        let beta = Fp::from_u64(xs(&mut s));
+        betas.push(beta);
+        let half = cur.len() / 2;
+        let mut next = Vec::with_capacity(half);
+        let mut x = coset;
+        for i in 0..half {
+            let (a, b) = (cur[i], cur[i + half]);
+            next.push((a + b) * inv2 + beta * ((a - b) * inv2 * x.inv()));
+            x = x * omega;
+        }
+        cur = next;
+        layers.push(cur.clone());
+        omega = omega.square();
+        coset = coset.square();
+    }
+
+    // Extract query q's path (q even so the last fold lands in the first slot).
+    let q = 6usize;
+    let rows = 1usize << log_layers;
+    let mut trace = alloc::vec![Fp::ZERO; rows * 2];
+    let (mut x_inv, mut beta_col, mut dir) = (Vec::new(), Vec::new(), Vec::new());
+    let mut om = base_omega;
+    let mut cs = shift;
+    for m in 0..n_folds {
+        let half = layers[m].len() / 2;
+        let i = q % half;
+        trace[m * 2] = layers[m][i];
+        trace[m * 2 + 1] = layers[m][i + half];
+        x_inv.push((cs * om.pow(i as u64)).inv());
+        beta_col.push(betas[m]);
+        dir.push(i >= half / 2);
+        om = om.square();
+        cs = cs.square();
+    }
+    // Final layer row: its pair, first slot is the committed value.
+    trace[n_folds * 2] = layers[n_folds][0];
+    trace[n_folds * 2 + 1] = layers[n_folds][1];
+    let final_value = layers[n_folds][0];
+
+    let air = FriFold::new(
+        log_layers,
+        n_folds,
+        x_inv.clone(),
+        beta_col.clone(),
+        dir.clone(),
+        final_value,
+    );
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(stark_verify(&air, &proof, QUERIES), "an honest fri fold chain was rejected");
+
+    // Tamper one opened value: the fold no longer lands on the next layer.
+    let mut bad = trace.clone();
+    bad[2] = bad[2] + Fp::ONE;
+    let bad_air = FriFold::new(log_layers, n_folds, x_inv, beta_col, dir, final_value);
+    let bad_proof = stark_prove(&bad_air, &bad, QUERIES);
+    assert!(!stark_verify(&bad_air, &bad_proof, QUERIES), "a broken fold chain verified");
 }
 
 #[test]


### PR DESCRIPTION
The last FRI-verification step expressed as AIR constraints. With this, every operation a FRI verifier performs is now itself provable in a STARK.

`FriFold` proves that a query walks the FRI layers correctly. Each trace row is a layers opened pair `(a, b) = (f(x), f(-x))`. The transition recomputes the fold `v = (a + b)/2 + beta*(a - b)/(2x)` and checks it equals the value the next layer carries for this query, selected by the position bit; the final layer is pinned to the committed constant.

Note on degree: the fold is linear in the trace, but the constraint multiplies the selector, the challenge, and the inverse domain point into it, so the composition degree is that of four interpolated columns. The AIR declares that so the engine sizes the evaluation domain correctly (an honest proof is rejected if it is under-declared, which is a good check that the degree accounting is real).

Host proofs: fold a real codeword four times, extract one querys path down the layers, and prove the chain is consistent and reaches the committed final value; a tampered opening breaks a fold and is rejected. 51/51 stark_proofs tests, clippy -D warnings clean, kernel builds.

This completes the component set for recursion: the algebraic commitment (#299), the hash preimage AIR (#296), the Merkle opening AIR (#302), and this fold check. A full recursive FRI verifier is their integration into one AIR with transcript replay.

Stacked on Stark-Merkle-Membership (#302).