### PR TITLE
stark: arithmetize Fiat-Shamir challenge derivation

### DIFF
--- a/src/crypto/stark/air/fiat_shamir.rs
+++ b/src/crypto/stark/air/fiat_shamir.rs
@@ -1,0 +1,137 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Arithmetizing Fiat-Shamir: an AIR that proves a challenge was squeezed from a
+//! sequence of absorbed values through a Poseidon sponge. Each block absorbs one
+//! value into the first lane and permutes; the AIR runs the same state, with a
+//! Poseidon round within a block and an absorb-then-carry at each boundary. The
+//! first absorbed value seeds the state and the final squeezed lane is pinned to
+//! the public challenge. A recursive verifier needs this to derive its own
+//! challenges in circuit; a bitwise transcript hash could not be proven, an
+//! algebraic one can.
+
+use super::super::field::Fp;
+use super::poseidon::{Poseidon, WIDTH};
+use super::spec::Air;
+use alloc::vec::Vec;
+
+pub struct FiatShamir {
+    hasher: Poseidon,
+    log_rounds: u32,
+    log_slots: u32,
+    /// The absorbed values, one per block.
+    inputs: Vec<Fp>,
+    /// The squeezed challenge (first lane after the final permutation).
+    challenge: Fp,
+}
+
+impl FiatShamir {
+    pub fn new(
+        hasher: Poseidon,
+        log_rounds: u32,
+        log_slots: u32,
+        inputs: Vec<Fp>,
+        challenge: Fp,
+    ) -> FiatShamir {
+        FiatShamir { hasher, log_rounds, log_slots, inputs, challenge }
+    }
+
+    fn rounds(&self) -> usize {
+        1usize << self.log_rounds
+    }
+
+    fn blocks(&self) -> usize {
+        (1usize << self.log_slots) - 1
+    }
+}
+
+impl Air for FiatShamir {
+    fn log_trace_len(&self) -> u32 {
+        self.log_rounds + self.log_slots
+    }
+
+    fn trace_width(&self) -> usize {
+        WIDTH
+    }
+
+    fn window_size(&self) -> usize {
+        2
+    }
+
+    fn constraint_degree(&self) -> usize {
+        7
+    }
+
+    fn num_transition(&self) -> usize {
+        WIDTH
+    }
+
+    fn periodic_columns(&self) -> Vec<Vec<Fp>> {
+        let l = self.rounds();
+        let blocks = self.blocks();
+        let n = 1usize << self.log_trace_len();
+        // WIDTH round-constant columns, a boundary selector, and the absorbed value.
+        let mut cols: Vec<Vec<Fp>> = (0..WIDTH + 2).map(|_| Vec::with_capacity(n)).collect();
+        for r in 0..n {
+            let rc = self.hasher.round_constant(r % l);
+            for (j, col) in cols.iter_mut().take(WIDTH).enumerate() {
+                col.push(rc[j]);
+            }
+            let is_boundary = r % l == l - 1 && r < blocks * l;
+            cols[WIDTH].push(if is_boundary { Fp::ONE } else { Fp::ZERO });
+            // The block being formed absorbs its input; the final block absorbs
+            // nothing and just carries the squeeze forward.
+            let m = (r + 1) / l;
+            let input = if is_boundary && m < blocks { self.inputs[m] } else { Fp::ZERO };
+            cols[WIDTH + 1].push(input);
+        }
+        cols
+    }
+
+    fn transition(&self, window: &[Fp], periodic: &[Fp]) -> Vec<Fp> {
+        let mut state = [Fp::ZERO; WIDTH];
+        state.copy_from_slice(&window[..WIDTH]);
+        let mut rc = [Fp::ZERO; WIDTH];
+        rc.copy_from_slice(&periodic[..WIDTH]);
+        let bnd = periodic[WIDTH];
+        let input = periodic[WIDTH + 1];
+
+        let pr = self.hasher.round_with_rc(&state, &rc);
+
+        let mut out = Vec::with_capacity(WIDTH);
+        for (j, next) in window[WIDTH..2 * WIDTH].iter().enumerate() {
+            // Every lane follows the permutation; the first also absorbs the input
+            // at a boundary.
+            let extra = if j == 0 { bnd * input } else { Fp::ZERO };
+            out.push(*next - (pr[j] + extra));
+        }
+        out
+    }
+
+    fn boundary(&self) -> Vec<(usize, usize, Fp)> {
+        let l = self.rounds();
+        let blocks = self.blocks();
+        let mut b = Vec::with_capacity(WIDTH + 1);
+        // The state starts empty with the first value absorbed into lane zero.
+        b.push((0, 0, self.inputs[0]));
+        for j in 1..WIDTH {
+            b.push((j, 0, Fp::ZERO));
+        }
+        // The final squeeze is the public challenge.
+        b.push((0, blocks * l, self.challenge));
+        b
+    }
+}

--- a/src/crypto/stark/air/mod.rs
+++ b/src/crypto/stark/air/mod.rs
@@ -23,6 +23,7 @@
 //! verifier is proven against forgeries, not assumed sound.
 
 mod composition;
+mod fiat_shamir;
 mod fibonacci;
 mod fri_fold;
 mod merkle_membership;
@@ -35,6 +36,7 @@ mod squaring;
 mod types;
 mod verify;
 
+pub use fiat_shamir::FiatShamir;
 pub use fibonacci::Fibonacci;
 pub use fri_fold::FriFold;
 pub use merkle_membership::MerkleMembership;

--- a/userland/stark_proofs/src/air_tests.rs
+++ b/userland/stark_proofs/src/air_tests.rs
@@ -15,8 +15,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::crypto::stark::air::{
-    stark_prove, stark_verify, Fibonacci, FriFold, MerkleMembership, Permutation2, Poseidon,
-    PowerChain, Squaring, RATE, WIDTH,
+    stark_prove, stark_verify, FiatShamir, Fibonacci, FriFold, MerkleMembership, Permutation2,
+    Poseidon, PowerChain, Squaring, RATE, WIDTH,
 };
 use crate::crypto::stark::field::Fp;
 use crate::crypto::stark::fri::root_of_unity;
@@ -438,6 +438,72 @@ fn a_membership_proof_for_a_wrong_root_is_rejected() {
     );
     let proof = stark_prove(&air, &trace, QUERIES);
     assert!(!stark_verify(&air, &proof, QUERIES), "a wrong-root membership proof verified");
+}
+
+/// Run the Poseidon sponge transcript: seed with the first value, then permute
+/// and absorb each remaining value, and squeeze the first lane. Returns the
+/// trace and the challenge.
+fn fiat_shamir_trace(
+    hasher: &Poseidon,
+    inputs: &[Fp],
+    log_rounds: u32,
+    log_slots: u32,
+) -> (Vec<Fp>, Fp) {
+    let l = 1usize << log_rounds;
+    let blocks = (1usize << log_slots) - 1;
+    let mut rows: Vec<[Fp; WIDTH]> = Vec::with_capacity((blocks + 1) * l);
+    let mut state = [Fp::ZERO; WIDTH];
+    state[0] = inputs[0];
+    for k in 0..blocks {
+        for round in 0..l {
+            rows.push(state);
+            state = hasher.round_with_rc(&state, &hasher.round_constant(round));
+        }
+        if k + 1 < blocks {
+            state[0] = state[0] + inputs[k + 1];
+        }
+    }
+    let challenge = state[0];
+    for round in 0..l {
+        rows.push(state);
+        state = hasher.round_with_rc(&state, &hasher.round_constant(round));
+    }
+    let mut trace = Vec::with_capacity(rows.len() * WIDTH);
+    for row in &rows {
+        trace.extend_from_slice(row);
+    }
+    (trace, challenge)
+}
+
+#[test]
+fn a_fiat_shamir_transcript_verifies() {
+    // Prove a challenge was squeezed from a sequence of absorbed values through a
+    // Poseidon transcript: challenge derivation, arithmetized, the last piece a
+    // recursive verifier needs to run its own Fiat-Shamir in circuit.
+    let (log_rounds, log_slots) = (3u32, 2u32); // 8-round permute, 3 absorbs
+    let hasher = Poseidon::new(log_rounds, [Fp::ZERO; RATE]);
+    let inputs = alloc::vec![Fp::from_u64(111), Fp::from_u64(222), Fp::from_u64(333)];
+    let (trace, challenge) = fiat_shamir_trace(&hasher, &inputs, log_rounds, log_slots);
+
+    let air = FiatShamir::new(
+        Poseidon::new(log_rounds, [Fp::ZERO; RATE]),
+        log_rounds,
+        log_slots,
+        inputs.clone(),
+        challenge,
+    );
+    let proof = stark_prove(&air, &trace, QUERIES);
+    assert!(stark_verify(&air, &proof, QUERIES), "an honest transcript was rejected");
+
+    let bad = FiatShamir::new(
+        Poseidon::new(log_rounds, [Fp::ZERO; RATE]),
+        log_rounds,
+        log_slots,
+        inputs,
+        challenge + Fp::ONE,
+    );
+    let bad_proof = stark_prove(&bad, &trace, QUERIES);
+    assert!(!stark_verify(&bad, &bad_proof, QUERIES), "a wrong challenge verified");
 }
 
 #[test]


### PR DESCRIPTION
The final FRI-verification step as AIR constraints. With this, every operation a FRI verifier performs is provable in a STARK, so the recursion component set is complete.

`FiatShamir` proves a challenge was squeezed from a sequence of absorbed values through a Poseidon transcript. Each block absorbs one value into the first lane and permutes; the transition runs a Poseidon round within a block and an absorb-then-carry at each block boundary. The first value seeds the state and the final squeezed lane is pinned to the public challenge.

Why it matters for recursion: a verifier derives its challenges by hashing the commitments, and a recursive verifier must redo that in circuit. A bitwise transcript hash cannot be proven cheaply; an algebraic sponge can, and this is it.

Host proofs: absorb a sequence of values, squeeze a challenge, and prove the derivation; a wrong challenge is rejected. 52/52 stark_proofs tests, clippy -D warnings clean, kernel builds.

The recursion components are now all arithmetized and tested: the algebraic commitment (#299), the hash preimage (#296), the Merkle opening (#302), the FRI fold (#303), and this transcript. A full recursive verifier is their integration into a single AIR.

Stacked on Stark-Fri-Fold (#303).