### PR TITLE
stark: recursion-ready FRI committed with Poseidon

### DIFF
--- a/src/crypto/stark/air/poseidon.rs
+++ b/src/crypto/stark/air/poseidon.rs
@@ -46,6 +46,7 @@ pub const RATE: usize = 4;
 
 const RC_DOMAIN: &[u8] = b"NONOS-POSEIDON-GOLDILOCKS-RC";
 
+#[derive(Clone)]
 pub struct Poseidon {
     log_t: u32,
     mds: [[Fp; WIDTH]; WIDTH],

--- a/src/crypto/stark/fri_poseidon/fold.rs
+++ b/src/crypto/stark/fri_poseidon/fold.rs
@@ -1,0 +1,34 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The FRI folding step over a coset, identical to the BLAKE3 FRI's fold.
+
+use super::super::field::Fp;
+use alloc::vec::Vec;
+
+pub(super) fn fold_layer(evals: &[Fp], beta: Fp, shift: Fp, omega: Fp, inv2: Fp) -> Vec<Fp> {
+    let half = evals.len() / 2;
+    let (lo, hi) = evals.split_at(half);
+    let mut out = Vec::with_capacity(half);
+    let mut x = shift;
+    for (a, b) in lo.iter().zip(hi.iter()) {
+        let even = (*a + *b) * inv2;
+        let odd = (*a - *b) * inv2 * x.inv();
+        out.push(even + beta * odd);
+        x = x * omega;
+    }
+    out
+}

--- a/src/crypto/stark/fri_poseidon/mod.rs
+++ b/src/crypto/stark/fri_poseidon/mod.rs
@@ -1,0 +1,28 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! FRI committed with Poseidon instead of BLAKE3. The commitments and the
+//! transcript are algebraic, so a proof made here can be verified by an AIR:
+//! the prerequisite for a recursive STARK. It is otherwise the same protocol.
+
+mod fold;
+mod prove;
+mod types;
+mod verify;
+
+pub use prove::fri_prove;
+pub use types::{FriProof, LayerOpening, QueryProof};
+pub use verify::fri_verify;

--- a/src/crypto/stark/fri_poseidon/prove.rs
+++ b/src/crypto/stark/fri_poseidon/prove.rs
@@ -1,0 +1,99 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The Poseidon-committed FRI prover: commit each folded layer with a Poseidon
+//! Merkle tree, drive the challenges from a Poseidon transcript, and open the
+//! sampled positions. The commitment and the transcript are algebraic, so the
+//! proof can be verified inside a STARK.
+
+use super::super::air::{Poseidon, RATE};
+use super::super::field::Fp;
+use super::super::fri::root_of_unity;
+use super::super::poseidon_merkle::PoseidonMerkleTree;
+use super::super::poseidon_transcript::PoseidonTranscript;
+use super::fold::fold_layer;
+use super::types::{FriProof, LayerOpening, QueryProof};
+use alloc::vec::Vec;
+
+/// A codeword value embedded as a rate-sized Merkle leaf.
+pub(super) fn leaf(value: Fp) -> [Fp; RATE] {
+    let mut d = [Fp::ZERO; RATE];
+    d[0] = value;
+    d
+}
+
+/// Prove `codeword` is low degree, committing with Poseidon. `hasher` is the
+/// Poseidon used for both the Merkle nodes and the transcript.
+pub fn fri_prove(
+    codeword: &[Fp],
+    shift: Fp,
+    log_blowup: u32,
+    n_queries: usize,
+    hasher: &Poseidon,
+) -> FriProof {
+    let n = codeword.len();
+    let log_n = n.trailing_zeros();
+    let n_folds = (log_n - log_blowup) as usize;
+    let base_omega = root_of_unity(log_n);
+    let inv2 = Fp::from_u64(2).inv();
+
+    let mut transcript = PoseidonTranscript::new(hasher.clone());
+    let mut layers: Vec<Vec<Fp>> = Vec::with_capacity(n_folds);
+    let mut trees: Vec<PoseidonMerkleTree> = Vec::with_capacity(n_folds);
+    let mut roots: Vec<[Fp; RATE]> = Vec::with_capacity(n_folds);
+
+    let mut current = codeword.to_vec();
+    let mut omega = base_omega;
+    let mut coset = shift;
+    for _ in 0..n_folds {
+        let leaves: Vec<[Fp; RATE]> = current.iter().map(|v| leaf(*v)).collect();
+        let tree = PoseidonMerkleTree::commit(hasher, &leaves);
+        let root = tree.root();
+        transcript.absorb_digest(&root);
+        let beta = transcript.challenge();
+        let next = fold_layer(&current, beta, coset, omega, inv2);
+        layers.push(current);
+        trees.push(tree);
+        roots.push(root);
+        current = next;
+        omega = omega.square();
+        coset = coset.square();
+    }
+
+    let final_layer = current;
+    for value in &final_layer {
+        transcript.absorb(*value);
+    }
+
+    let mut queries: Vec<QueryProof> = Vec::with_capacity(n_queries);
+    for _ in 0..n_queries {
+        let q = transcript.challenge_index(n);
+        let mut opened: Vec<LayerOpening> = Vec::with_capacity(n_folds);
+        for (layer, tree) in layers.iter().zip(trees.iter()) {
+            let half = layer.len() / 2;
+            let i = q % half;
+            opened.push(LayerOpening {
+                a: layer[i],
+                a_path: tree.open(i),
+                b: layer[i + half],
+                b_path: tree.open(i + half),
+            });
+        }
+        queries.push(QueryProof { layers: opened });
+    }
+
+    FriProof { roots, final_layer, queries }
+}

--- a/src/crypto/stark/fri_poseidon/types.rs
+++ b/src/crypto/stark/fri_poseidon/types.rs
@@ -1,0 +1,44 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The Poseidon-committed FRI proof: the same shape as the BLAKE3 one, but roots
+//! and Merkle paths are rate-sized field digests, so the proof can be verified
+//! by an AIR.
+
+use super::super::air::RATE;
+use super::super::field::Fp;
+use alloc::vec::Vec;
+
+/// One layer's contribution to a query: the value at the queried position and at
+/// its negation, each with a Poseidon Merkle path to that layer's root.
+pub struct LayerOpening {
+    pub a: Fp,
+    pub a_path: Vec<[Fp; RATE]>,
+    pub b: Fp,
+    pub b_path: Vec<[Fp; RATE]>,
+}
+
+/// The openings a single query induces across every folded layer.
+pub struct QueryProof {
+    pub layers: Vec<LayerOpening>,
+}
+
+/// A complete Poseidon-committed FRI proof.
+pub struct FriProof {
+    pub roots: Vec<[Fp; RATE]>,
+    pub final_layer: Vec<Fp>,
+    pub queries: Vec<QueryProof>,
+}

--- a/src/crypto/stark/fri_poseidon/verify.rs
+++ b/src/crypto/stark/fri_poseidon/verify.rs
@@ -1,0 +1,102 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The Poseidon-committed FRI verifier. Same checks as the BLAKE3 verifier, over
+//! Poseidon Merkle openings and a Poseidon transcript, so this exact procedure
+//! can later be arithmetized as an AIR.
+
+use super::super::air::Poseidon;
+use super::super::field::Fp;
+use super::super::fri::root_of_unity;
+use super::super::poseidon_merkle::verify_path;
+use super::super::poseidon_transcript::PoseidonTranscript;
+use super::prove::leaf;
+use super::types::FriProof;
+use alloc::vec::Vec;
+
+pub fn fri_verify(
+    proof: &FriProof,
+    shift: Fp,
+    log_n: u32,
+    log_blowup: u32,
+    n_queries: usize,
+    hasher: &Poseidon,
+) -> bool {
+    let n = 1usize << log_n;
+    let blowup = 1usize << log_blowup;
+    let n_folds = (log_n - log_blowup) as usize;
+
+    if proof.roots.len() != n_folds
+        || proof.final_layer.len() != blowup
+        || proof.queries.len() != n_queries
+    {
+        return false;
+    }
+
+    let base_omega = root_of_unity(log_n);
+    let inv2 = Fp::from_u64(2).inv();
+
+    let mut transcript = PoseidonTranscript::new(hasher.clone());
+    let mut betas: Vec<Fp> = Vec::with_capacity(n_folds);
+    for root in &proof.roots {
+        transcript.absorb_digest(root);
+        betas.push(transcript.challenge());
+    }
+
+    let final_value = proof.final_layer[0];
+    for value in &proof.final_layer {
+        if *value != final_value {
+            return false;
+        }
+        transcript.absorb(*value);
+    }
+
+    for qp in &proof.queries {
+        if qp.layers.len() != n_folds {
+            return false;
+        }
+        let q = transcript.challenge_index(n);
+        for (m, beta) in betas.iter().enumerate() {
+            let half = n >> (m + 1);
+            let i = q % half;
+            let op = &qp.layers[m];
+
+            if !verify_path(hasher, &proof.roots[m], i, leaf(op.a), &op.a_path)
+                || !verify_path(hasher, &proof.roots[m], i + half, leaf(op.b), &op.b_path)
+            {
+                return false;
+            }
+
+            let x = (shift * base_omega.pow(i as u64)).pow(1u64 << m);
+            let even = (op.a + op.b) * inv2;
+            let odd = (op.a - op.b) * inv2 * x.inv();
+            let folded = even + *beta * odd;
+
+            if m + 1 < n_folds {
+                let half_next = n >> (m + 2);
+                let next = &qp.layers[m + 1];
+                let expected = if i < half_next { next.a } else { next.b };
+                if folded != expected {
+                    return false;
+                }
+            } else if folded != final_value {
+                return false;
+            }
+        }
+    }
+
+    true
+}

--- a/src/crypto/stark/mod.rs
+++ b/src/crypto/stark/mod.rs
@@ -11,7 +11,9 @@
 pub mod air;
 pub mod field;
 pub mod fri;
+pub mod fri_poseidon;
 pub mod merkle;
 pub mod poly;
 pub mod poseidon_merkle;
+pub mod poseidon_transcript;
 pub mod transcript;

--- a/src/crypto/stark/poseidon_transcript.rs
+++ b/src/crypto/stark/poseidon_transcript.rs
@@ -1,0 +1,62 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! A Fiat-Shamir transcript over the Poseidon permutation, the algebraic
+//! counterpart of the BLAKE3 transcript. Absorbing adds a value into the first
+//! lane and permutes; a challenge reads the first lane and permutes. It is the
+//! same duplex the `FiatShamir` AIR proves, so a proof made with this transcript
+//! can have its challenges re-derived inside a STARK: the requirement for
+//! recursion.
+
+use super::air::{Poseidon, RATE, WIDTH};
+use super::field::Fp;
+
+pub struct PoseidonTranscript {
+    hasher: Poseidon,
+    state: [Fp; WIDTH],
+}
+
+impl PoseidonTranscript {
+    pub fn new(hasher: Poseidon) -> PoseidonTranscript {
+        PoseidonTranscript { hasher, state: [Fp::ZERO; WIDTH] }
+    }
+
+    /// Absorb one field element.
+    pub fn absorb(&mut self, value: Fp) {
+        self.state[0] = self.state[0] + value;
+        self.state = self.hasher.permute(self.state);
+    }
+
+    /// Absorb a rate-sized digest, lane by lane.
+    pub fn absorb_digest(&mut self, digest: &[Fp; RATE]) {
+        for v in digest.iter() {
+            self.absorb(*v);
+        }
+    }
+
+    /// Draw a field-element challenge.
+    pub fn challenge(&mut self) -> Fp {
+        let c = self.state[0];
+        self.state = self.hasher.permute(self.state);
+        c
+    }
+
+    /// Draw a query index in `[0, bound)`. `bound` is a power of two, so masking
+    /// is unbiased.
+    pub fn challenge_index(&mut self, bound: usize) -> usize {
+        (self.challenge().value() as usize) & (bound - 1)
+    }
+}

--- a/userland/stark_proofs/src/fri_poseidon_tests.rs
+++ b/userland/stark_proofs/src/fri_poseidon_tests.rs
@@ -1,0 +1,94 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::crypto::stark::air::{Poseidon, RATE};
+use crate::crypto::stark::field::Fp;
+use crate::crypto::stark::fri::root_of_unity;
+use crate::crypto::stark::fri_poseidon::{fri_prove, fri_verify};
+use crate::crypto::stark::poly::eval;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+// The Poseidon-committed FRI: the same low-degree test, but the commitments and
+// the transcript are algebraic. A proof made here is verifiable inside a STARK,
+// which the BLAKE3 version is not. Soundness is checked the same way: honest
+// low-degree codewords pass, and a high-degree codeword and a tampered opening
+// fail.
+
+fn xorshift(state: &mut u64) -> u64 {
+    *state ^= *state << 13;
+    *state ^= *state >> 7;
+    *state ^= *state << 17;
+    *state
+}
+
+fn hasher() -> Poseidon {
+    Poseidon::new(3, [Fp::ZERO; RATE])
+}
+
+fn low_degree_codeword(log_n: u32, d: usize, shift: Fp, seed: u64) -> Vec<Fp> {
+    let n = 1usize << log_n;
+    let omega = root_of_unity(log_n);
+    let mut s = seed | 1;
+    let coeffs: Vec<Fp> = (0..d).map(|_| Fp::from_u64(xorshift(&mut s))).collect();
+    let mut x = shift;
+    let mut codeword = Vec::with_capacity(n);
+    for _ in 0..n {
+        codeword.push(eval(&coeffs, x));
+        x = x * omega;
+    }
+    codeword
+}
+
+#[test]
+fn an_honest_low_degree_codeword_verifies() {
+    let (log_n, log_blowup, degree, queries) = (5u32, 2u32, 8usize, 30usize);
+    let shift = Fp::from_u64(7);
+    let h = hasher();
+    let codeword = low_degree_codeword(log_n, degree, shift, 0xABCD);
+    let proof = fri_prove(&codeword, shift, log_blowup, queries, &h);
+    assert!(fri_verify(&proof, shift, log_n, log_blowup, queries, &h), "honest proof rejected");
+}
+
+#[test]
+fn a_high_degree_codeword_is_rejected() {
+    let (log_n, log_blowup, queries) = (5u32, 2u32, 30usize);
+    let shift = Fp::from_u64(7);
+    let h = hasher();
+    let n = 1usize << log_n;
+    let mut s = 0x99u64 | 1;
+    let codeword: Vec<Fp> = (0..n).map(|_| Fp::from_u64(xorshift(&mut s))).collect();
+    let proof = fri_prove(&codeword, shift, log_blowup, queries, &h);
+    assert!(
+        !fri_verify(&proof, shift, log_n, log_blowup, queries, &h),
+        "a random codeword verified"
+    );
+}
+
+#[test]
+fn a_tampered_opening_is_rejected() {
+    let (log_n, log_blowup, queries) = (5u32, 2u32, 30usize);
+    let shift = Fp::from_u64(7);
+    let h = hasher();
+    let codeword = low_degree_codeword(log_n, 8, shift, 0x2468);
+    let mut proof = fri_prove(&codeword, shift, log_blowup, queries, &h);
+    proof.queries[0].layers[0].a = proof.queries[0].layers[0].a + Fp::ONE;
+    assert!(
+        !fri_verify(&proof, shift, log_n, log_blowup, queries, &h),
+        "a tampered opening verified"
+    );
+}

--- a/userland/stark_proofs/src/lib.rs
+++ b/userland/stark_proofs/src/lib.rs
@@ -11,6 +11,8 @@ mod air_tests;
 #[cfg(test)]
 mod field_tests;
 #[cfg(test)]
+mod fri_poseidon_tests;
+#[cfg(test)]
 mod fri_tests;
 #[cfg(test)]
 mod merkle_tests;


### PR DESCRIPTION
Step 1 of the recursive verifier. An inner proof can only be checked inside a STARK if its own hashing is algebraic, so this makes a FRI whose commitments and transcript are Poseidon rather than BLAKE3.

Adds a Poseidon transcript (the duplex the FiatShamir AIR #304 proves) and a FRI that commits each folded layer with the Poseidon Merkle tree #299 and derives its challenges from that transcript. It is the same protocol and the same soundness as the BLAKE3 FRI, but every commitment root and every challenge is now field arithmetic, which is the property a recursive verifier needs.

Host proofs: an honest low-degree codeword verifies; a high-degree codeword and a tampered opening are rejected, against the real Poseidon commitment and transcript. 55/55 stark_proofs tests, clippy -D warnings clean, kernel builds.

Next (step 2, mine): the FriQueryVerifier AIR that verifies one query of a proof like this in a single trace. Steps 3-4 (transcript-driven verifier and full assembly) are being built in parallel by another agent against that interface.

Stacked on Stark-Fiat-Shamir (#304).