### PR TITLE
stark: bind several columns at once in the wiring engine

### DIFF
--- a/src/crypto/stark/air/wired.rs
+++ b/src/crypto/stark/air/wired.rs
@@ -16,18 +16,19 @@
 
 //! Fuse several AIRs into one proof and bind values across them. Like the fused
 //! engine it stacks regions vertically with a per-row selector, but it adds a
-//! grand-product column that runs a Plonk copy constraint over the trace's first
-//! column: a public wiring permutation forces chosen cells, in different regions,
-//! to hold equal values. This is what the monolithic recursive verifier needs
-//! that plain fusion cannot express: a challenge witnessed in one region (a
-//! transcript squeeze) is forced to equal the value another region consumes (the
-//! fold's folding challenge), without laying them out adjacently, so the fold
-//! runs in-circuit on exactly the challenge the transcript produced.
+//! grand-product column that runs a Plonk copy constraint over a chosen set of
+//! the trace's columns: a public wiring permutation forces chosen cells, in
+//! different regions, to hold equal values. This is what the monolithic
+//! recursive verifier needs that plain fusion cannot express, and it binds more
+//! than one value at once: a fold is forced to run both on the challenge a
+//! transcript region squeezed and on the value a Merkle opening revealed, all
+//! without laying any of them out adjacently.
 //!
-//! The wiring column is column zero, so a region exposes a value to be bound by
-//! placing it there. The regions fill the first half of the trace; the grand
-//! product accumulates over that half and is pinned to one at the midpoint
-//! checkpoint, exactly when the wired cells agree, leaving the tail inert as the
+//! The wiring runs over `wired_cols`. Each wired cell is numbered `r * k + j` for
+//! row `r` and the `j`-th wired column, and `sigma` permutes those numbers; cells
+//! in one cycle are forced equal. The regions fill the first half of the trace,
+//! the product accumulates over that half and is pinned to one at the midpoint
+//! checkpoint exactly when every wiring holds, leaving the tail inert as the
 //! engine requires.
 
 use super::super::field::Fp;
@@ -41,8 +42,10 @@ pub struct Wired {
     offsets: Vec<usize>,
     /// First periodic slot each region owns, after the selectors.
     slot_offsets: Vec<usize>,
-    /// Wiring permutation over the region rows: `sigma[r]` is the row column zero
-    /// of row `r` is forced equal to. Identity except on the bound cells.
+    /// The trace columns the copy constraint runs over.
+    wired_cols: Vec<usize>,
+    /// Wiring permutation over the wired cells, numbered `row * k + j` for the
+    /// `j`-th wired column. Identity except on the bound cells.
     sigma: Vec<usize>,
     beta: Fp,
     gamma: Fp,
@@ -52,11 +55,18 @@ pub struct Wired {
 }
 
 impl Wired {
-    /// Stack `regions` and bind column zero under `sigma`. `sigma` is a
-    /// permutation over the region span (the fused row count rounded to a power
-    /// of two); equal cells sit in the same cycle. `beta` and `gamma` are the
-    /// copy-constraint challenges.
-    pub fn new(regions: Vec<Box<dyn Air>>, sigma: Vec<usize>, beta: Fp, gamma: Fp) -> Wired {
+    /// Stack `regions` and bind the `wired_cols` under `sigma`. `sigma` is a
+    /// permutation over the wired cells (`span * wired_cols.len()` of them, the
+    /// `j`-th wired column of row `r` numbered `r * wired_cols.len() + j`); equal
+    /// cells sit in the same cycle. `beta` and `gamma` are the copy-constraint
+    /// challenges.
+    pub fn new(
+        regions: Vec<Box<dyn Air>>,
+        wired_cols: Vec<usize>,
+        sigma: Vec<usize>,
+        beta: Fp,
+        gamma: Fp,
+    ) -> Wired {
         let mut offsets = Vec::with_capacity(regions.len());
         let mut slot_offsets = Vec::with_capacity(regions.len());
         let mut row = 0usize;
@@ -72,7 +82,18 @@ impl Wired {
             window = window.max(region.window_size());
         }
         let log_span = row.next_power_of_two().trailing_zeros();
-        Wired { regions, offsets, slot_offsets, sigma, beta, gamma, width, window, log_span }
+        Wired {
+            regions,
+            offsets,
+            slot_offsets,
+            wired_cols,
+            sigma,
+            beta,
+            gamma,
+            width,
+            window,
+            log_span,
+        }
     }
 
     /// The region span: the first half of the trace, holding the stacked regions
@@ -90,9 +111,25 @@ impl Wired {
         self.width + 1
     }
 
+    /// The per-row contribution to the grand product: over the wired columns,
+    /// `prod (cell + beta*id + gamma) / (cell + beta*sigma(id) + gamma)`.
+    fn ratio(&self, row: &[Fp], r: usize) -> Fp {
+        let k = self.wired_cols.len();
+        let (b, g) = (self.beta, self.gamma);
+        let mut num = Fp::ONE;
+        let mut den = Fp::ONE;
+        for (j, &col) in self.wired_cols.iter().enumerate() {
+            let v = row[col];
+            let id = r * k + j;
+            num = num * (v + b * Fp::from_u64(id as u64) + g);
+            den = den * (v + b * Fp::from_u64(self.sigma[id] as u64) + g);
+        }
+        num * den.inv()
+    }
+
     /// The witness: each region's trace at its offset in the low columns, and the
-    /// grand product over column zero in the last column. `traces[i]` is region
-    /// `i`'s own row-major trace.
+    /// grand product over the wired columns in the last column. `traces[i]` is
+    /// region `i`'s own row-major trace.
     pub fn trace(&self, traces: &[Vec<Fp>]) -> Vec<Fp> {
         let stride = self.stride();
         let span = self.span();
@@ -110,16 +147,14 @@ impl Wired {
             }
         }
 
-        // The grand product over column zero, accumulated across the span.
-        let (b, g) = (self.beta, self.gamma);
+        // The grand product over the wired columns, accumulated across the span.
         let mut z = Fp::ONE;
         for r in 0..total {
             trace[r * stride + z_col] = z;
             if r < span {
-                let w = trace[r * stride];
-                let num = w + b * Fp::from_u64(r as u64) + g;
-                let den = w + b * Fp::from_u64(self.sigma[r] as u64) + g;
-                z = z * num * den.inv();
+                let base = r * stride;
+                let ratio = self.ratio(&trace[base..base + stride], r);
+                z = z * ratio;
             }
         }
         trace
@@ -148,12 +183,12 @@ impl Air for Wired {
     fn constraint_degree(&self) -> usize {
         // The region constraints carry a selector factor, as in the fused engine,
         // with two factors of headroom; the grand product multiplies the product
-        // column, a wiring column, and its selector, degree three.
+        // column and one wiring factor per wired column, then its selector.
         let mut d = 1usize;
         for region in &self.regions {
             d = d.max(region.constraint_degree());
         }
-        (d + 2).max(3)
+        (d + 2).max(self.wired_cols.len() + 2)
     }
 
     fn num_transition(&self) -> usize {
@@ -169,6 +204,7 @@ impl Air for Wired {
         let total = 1usize << self.log_trace_len();
         let span = self.span();
         let sel = self.selectors();
+        let k = self.wired_cols.len();
         let mut cols: Vec<Vec<Fp>> = Vec::new();
 
         // Region selectors: one on a region's rows, except its last row.
@@ -191,18 +227,22 @@ impl Air for Wired {
                 cols.push(col);
             }
         }
-        // Grand-product columns: the row identity, the wiring, and the product
-        // selector, all live only over the span.
-        let mut id = alloc::vec![Fp::ZERO; total];
-        let mut sig = alloc::vec![Fp::ZERO; total];
-        let mut gp_sel = alloc::vec![Fp::ZERO; total];
-        for r in 0..span {
-            id[r] = Fp::from_u64(r as u64);
-            sig[r] = Fp::from_u64(self.sigma[r] as u64);
-            gp_sel[r] = Fp::ONE;
+        // Grand-product columns: for each wired column its cell identity and
+        // wiring, then the product selector, all live only over the span.
+        for j in 0..k {
+            let mut id = alloc::vec![Fp::ZERO; total];
+            let mut sig = alloc::vec![Fp::ZERO; total];
+            for r in 0..span {
+                id[r] = Fp::from_u64((r * k + j) as u64);
+                sig[r] = Fp::from_u64(self.sigma[r * k + j] as u64);
+            }
+            cols.push(id);
+            cols.push(sig);
         }
-        cols.push(id);
-        cols.push(sig);
+        let mut gp_sel = alloc::vec![Fp::ZERO; total];
+        for item in gp_sel.iter_mut().take(span) {
+            *item = Fp::ONE;
+        }
         cols.push(gp_sel);
         cols
     }
@@ -210,6 +250,7 @@ impl Air for Wired {
     fn transition(&self, window: &[Fp], periodic: &[Fp]) -> Vec<Fp> {
         let sel = self.selectors();
         let stride = self.stride();
+        let k = self.wired_cols.len();
         let region_slots: usize = self.slot_offsets.last().copied().unwrap_or(0)
             + self.regions.last().map(|r| r.periodic_columns().len()).unwrap_or(0);
         let mut out = alloc::vec![Fp::ZERO; self.num_transition()];
@@ -220,8 +261,8 @@ impl Air for Wired {
             let w = region.trace_width();
             let ws = region.window_size();
             let mut local = Vec::with_capacity(w * ws);
-            for k in 0..ws {
-                local.extend_from_slice(&window[k * stride..k * stride + w]);
+            for step in 0..ws {
+                local.extend_from_slice(&window[step * stride..step * stride + w]);
             }
             let base = sel + self.slot_offsets[i];
             let slots = region.periodic_columns().len();
@@ -231,16 +272,22 @@ impl Air for Wired {
             }
         }
 
-        // The grand product over column zero.
+        // The grand product over the wired columns.
         let gp = sel + region_slots;
-        let id = periodic[gp];
-        let sig = periodic[gp + 1];
-        let gp_sel = periodic[gp + 2];
-        let w = window[0];
+        let (b, g) = (self.beta, self.gamma);
         let z = window[self.width];
         let z_next = window[stride + self.width];
-        let (b, g) = (self.beta, self.gamma);
-        let product = z_next * (w + b * sig + g) - z * (w + b * id + g);
+        let mut num = Fp::ONE;
+        let mut den = Fp::ONE;
+        for (j, &col) in self.wired_cols.iter().enumerate() {
+            let v = window[col];
+            let id = periodic[gp + 2 * j];
+            let sig = periodic[gp + 2 * j + 1];
+            num = num * (v + b * id + g);
+            den = den * (v + b * sig + g);
+        }
+        let gp_sel = periodic[gp + 2 * k];
+        let product = z_next * den - z * num;
         let carry = z_next - z;
         let last = self.num_transition() - 1;
         out[last] = gp_sel * product + (Fp::ONE - gp_sel) * carry;
@@ -256,7 +303,7 @@ impl Air for Wired {
             }
         }
         // The product starts at one and closes to one at the checkpoint exactly
-        // when the wired cells agree.
+        // when every wired cell agrees.
         b.push((self.width, 0, Fp::ONE));
         b.push((self.width, self.span(), Fp::ONE));
         b

--- a/userland/stark_proofs/src/air_tests.rs
+++ b/userland/stark_proofs/src/air_tests.rs
@@ -918,7 +918,7 @@ fn a_value_is_bound_across_two_fused_regions() {
         Box::new(Squaring { log_t: 3, seed: Fp::from_u64(3) }),
         Box::new(Squaring { log_t: 3, seed: handoff }),
     ];
-    let wired = Wired::new(regions, sigma, Fp::from_u64(5), Fp::from_u64(7));
+    let wired = Wired::new(regions, alloc::vec![0], sigma, Fp::from_u64(5), Fp::from_u64(7));
     let witness = wired.trace(&[a_trace, b_trace]);
     let proof = stark_prove(&wired, &witness, QUERIES);
     assert!(stark_verify(&wired, &proof, QUERIES), "an honest cross-region binding was rejected");
@@ -941,7 +941,7 @@ fn a_broken_cross_region_binding_is_rejected() {
         Box::new(Squaring { log_t: 3, seed: Fp::from_u64(3) }),
         Box::new(Squaring { log_t: 3, seed: wrong }),
     ];
-    let wired = Wired::new(regions, sigma, Fp::from_u64(5), Fp::from_u64(7));
+    let wired = Wired::new(regions, alloc::vec![0], sigma, Fp::from_u64(5), Fp::from_u64(7));
     let witness = wired.trace(&[a_trace, b_trace]);
     let proof = stark_prove(&wired, &witness, QUERIES);
     assert!(!stark_verify(&wired, &proof, QUERIES), "a broken cross-region binding verified");
@@ -1039,7 +1039,7 @@ fn a_fold_bound_to_its_challenge_source_verifies() {
 
     let regions: Vec<Box<dyn Air>> =
         alloc::vec![Box::new(Squaring { log_t: 3, seed: beta[0] }), Box::new(fold),];
-    let wired = Wired::new(regions, sigma, Fp::from_u64(5), Fp::from_u64(7));
+    let wired = Wired::new(regions, alloc::vec![0], sigma, Fp::from_u64(5), Fp::from_u64(7));
     let witness = wired.trace(&[source, fold_trace]);
     let proof = stark_prove(&wired, &witness, QUERIES);
     assert!(stark_verify(&wired, &proof, QUERIES), "a fold bound to its challenge was rejected");
@@ -1059,8 +1059,57 @@ fn a_fold_using_the_wrong_challenge_is_rejected() {
 
     let regions: Vec<Box<dyn Air>> =
         alloc::vec![Box::new(Squaring { log_t: 3, seed: beta[0] + Fp::ONE }), Box::new(fold),];
-    let wired = Wired::new(regions, sigma, Fp::from_u64(5), Fp::from_u64(7));
+    let wired = Wired::new(regions, alloc::vec![0], sigma, Fp::from_u64(5), Fp::from_u64(7));
     let witness = wired.trace(&[source, fold_trace]);
     let proof = stark_prove(&wired, &witness, QUERIES);
     assert!(!stark_verify(&wired, &proof, QUERIES), "a fold on the wrong challenge verified");
+}
+
+#[test]
+fn a_fold_bound_to_both_its_challenge_and_opening_verifies() {
+    // The monolith's per-query binding: the fold must run on the transcript's
+    // challenge AND the opening's revealed value. A width-two source supplies
+    // both in one row; the wiring binds column zero (the challenge) and column
+    // one (the opened value) at once.
+    let (beta, a, b, x_inv, dir, final_value, log_layers, n_folds) = trace_fold_data(6);
+    let (rc0, rc1) = (Fp::from_u64(13), Fp::from_u64(17));
+    let (source, out) = permutation2_trace(3, beta[0], a[0], rc0, rc1);
+    let fold = TraceFold::new(log_layers, n_folds, x_inv, dir, final_value);
+    let fold_trace = fold.trace(&beta, &a, &b);
+
+    let mut sigma: Vec<usize> = (0..32).collect();
+    sigma.swap(0, 16); // source row 0 col 0 (challenge) <-> fold row 0 col 0
+    sigma.swap(1, 17); // source row 0 col 1 (opening)   <-> fold row 0 col 1
+
+    let regions: Vec<Box<dyn Air>> =
+        alloc::vec![Box::new(Permutation2 { log_t: 3, rc0, rc1, out }), Box::new(fold)];
+    let wired = Wired::new(regions, alloc::vec![0, 1], sigma, Fp::from_u64(5), Fp::from_u64(7));
+    let witness = wired.trace(&[source, fold_trace]);
+    let proof = stark_prove(&wired, &witness, QUERIES);
+    assert!(
+        stark_verify(&wired, &proof, QUERIES),
+        "a fold bound to challenge and opening was rejected"
+    );
+}
+
+#[test]
+fn a_fold_bound_to_a_wrong_opening_is_rejected() {
+    // The source supplies the right challenge but a different opened value; the
+    // multi-column wiring catches the opening even though the challenge matches.
+    let (beta, a, b, x_inv, dir, final_value, log_layers, n_folds) = trace_fold_data(6);
+    let (rc0, rc1) = (Fp::from_u64(13), Fp::from_u64(17));
+    let (source, out) = permutation2_trace(3, beta[0], a[0] + Fp::ONE, rc0, rc1);
+    let fold = TraceFold::new(log_layers, n_folds, x_inv, dir, final_value);
+    let fold_trace = fold.trace(&beta, &a, &b);
+
+    let mut sigma: Vec<usize> = (0..32).collect();
+    sigma.swap(0, 16);
+    sigma.swap(1, 17);
+
+    let regions: Vec<Box<dyn Air>> =
+        alloc::vec![Box::new(Permutation2 { log_t: 3, rc0, rc1, out }), Box::new(fold)];
+    let wired = Wired::new(regions, alloc::vec![0, 1], sigma, Fp::from_u64(5), Fp::from_u64(7));
+    let witness = wired.trace(&[source, fold_trace]);
+    let proof = stark_prove(&wired, &witness, QUERIES);
+    assert!(!stark_verify(&wired, &proof, QUERIES), "a fold on a wrong opening verified");
 }


### PR DESCRIPTION
Generalises the wiring engine from one bound column to a set, so a single proof can force a fold to run on BOTH the transcript challenge and the opened value, the per-query binding the monolithic verifier needs.

The single-column wiring (#317) could tie a fold to its folding challenge but not also to the value a Merkle opening revealed. This runs the grand product over `wired_cols`: each wired cell is numbered `row*k + column` and the permutation ranges over all of them, the full Plonk copy constraint. Degree scales as one factor per wired column.

Host proofs: a width-two source supplies a challenge and an opened value, a fold is wired to both; it verifies when it runs on both supplied values and is rejected when either the challenge or the opening differs, every region still internally valid. 73 suite tests green, clippy -D warnings clean, cargo fmt clean, kernel x86_64-nonos zero warnings.

With this, every binding the monolith needs (challenge->fold, opening->fold, index range-checks via #315) is expressible. Stacked on Stark-Trace-Fold (#318).