### PR TITLE
stark: expose opened scalar cells and bind an opening to a fold

### DIFF
--- a/src/crypto/stark/air/multi_membership.rs
+++ b/src/crypto/stark/air/multi_membership.rs
@@ -117,6 +117,24 @@ impl MultiMembership {
         }
         trace
     }
+
+    /// The `(row, column)` of each opening's committed scalar in the trace, one
+    /// per opening. A Poseidon-committed FRI leaf is `[value, 0, 0, 0]`, so the
+    /// scalar is lane zero of the leaf, which the first index bit places in the
+    /// low half of the initial state (column zero) or the high half (column
+    /// `RATE`). A wiring engine binds these cells to where a fold consumes the
+    /// opened value, so the fold runs on exactly what the opening committed.
+    pub fn opened_cells(&self) -> alloc::vec::Vec<(usize, usize)> {
+        let span = self.span();
+        self.openings
+            .iter()
+            .enumerate()
+            .map(|(o, opening)| {
+                let col = if opening.directions[0] { RATE } else { 0 };
+                (o * span, col)
+            })
+            .collect()
+    }
 }
 
 fn inject(node: [Fp; RATE], sibling: [Fp; RATE], right: bool) -> [Fp; WIDTH] {

--- a/userland/stark_proofs/src/air_tests.rs
+++ b/userland/stark_proofs/src/air_tests.rs
@@ -1113,3 +1113,67 @@ fn a_fold_bound_to_a_wrong_opening_is_rejected() {
     let proof = stark_prove(&wired, &witness, QUERIES);
     assert!(!stark_verify(&wired, &proof, QUERIES), "a fold on a wrong opening verified");
 }
+
+/// A single Merkle opening whose committed leaf is the scalar `v` (a FRI leaf is
+/// `[v, 0, 0, 0]`), at an even index so the scalar lands in column zero. Returns
+/// the opening trace, the AIR, and its `opened_cells()` map.
+fn opening_of_scalar(v: Fp, log_rounds: u32) -> (Vec<Fp>, MultiMembership, Vec<(usize, usize)>) {
+    let hasher = Poseidon::new(log_rounds, [Fp::ZERO; RATE]);
+    let mut leaves = merkle_leaves(4);
+    leaves[2] = [v, Fp::ZERO, Fp::ZERO, Fp::ZERO];
+    let tree = PoseidonMerkleTree::commit(&hasher, &leaves);
+    let opening = opening_at(&tree, &leaves, 2);
+    let mem = MultiMembership::new(hasher, log_rounds, alloc::vec![opening]);
+    let trace = mem.trace();
+    let cells = mem.opened_cells();
+    (trace, mem, cells)
+}
+
+#[test]
+fn a_fold_bound_to_its_committed_opening_verifies() {
+    // The other half of the monolith's per-query binding: the fold must fold the
+    // value the Merkle opening actually committed, not an arbitrary one. The
+    // opening commits `a[0]` as its leaf; the wiring binds that leaf cell to the
+    // fold's opened value.
+    let (beta, a, b, x_inv, dir, final_value, log_layers, n_folds) = trace_fold_data(6);
+    let (mem_trace, mem, cells) = opening_of_scalar(a[0], 2);
+    assert_eq!(cells[0].1, 0, "the committed scalar should sit in column zero");
+    let mem_h = mem_trace.len() / WIDTH;
+    let fold = TraceFold::new(log_layers, n_folds, x_inv, dir, final_value);
+    let fold_trace = fold.trace(&beta, &a, &b);
+
+    let fold_h = 1usize << log_layers;
+    let (k, span) = (2usize, (mem_h + fold_h).next_power_of_two());
+    let mut sigma: Vec<usize> = (0..span * k).collect();
+    // leaf scalar at (cells[0].0, col 0) <-> fold's opened value at (mem_h, col 1)
+    sigma.swap(cells[0].0 * k, mem_h * k + 1);
+
+    let regions: Vec<Box<dyn Air>> = alloc::vec![Box::new(mem), Box::new(fold)];
+    let wired = Wired::new(regions, alloc::vec![0, 1], sigma, Fp::from_u64(5), Fp::from_u64(7));
+    let witness = wired.trace(&[mem_trace, fold_trace]);
+    let proof = stark_prove(&wired, &witness, QUERIES);
+    assert!(stark_verify(&wired, &proof, QUERIES), "a fold bound to its opening was rejected");
+}
+
+#[test]
+fn a_fold_folding_an_uncommitted_value_is_rejected() {
+    // The opening commits a different value than the fold folds. Each is
+    // internally valid, but the wiring forces the fold to fold exactly what was
+    // committed, so the single proof fails.
+    let (beta, a, b, x_inv, dir, final_value, log_layers, n_folds) = trace_fold_data(6);
+    let (mem_trace, mem, cells) = opening_of_scalar(a[0] + Fp::ONE, 2);
+    let mem_h = mem_trace.len() / WIDTH;
+    let fold = TraceFold::new(log_layers, n_folds, x_inv, dir, final_value);
+    let fold_trace = fold.trace(&beta, &a, &b);
+
+    let fold_h = 1usize << log_layers;
+    let (k, span) = (2usize, (mem_h + fold_h).next_power_of_two());
+    let mut sigma: Vec<usize> = (0..span * k).collect();
+    sigma.swap(cells[0].0 * k, mem_h * k + 1);
+
+    let regions: Vec<Box<dyn Air>> = alloc::vec![Box::new(mem), Box::new(fold)];
+    let wired = Wired::new(regions, alloc::vec![0, 1], sigma, Fp::from_u64(5), Fp::from_u64(7));
+    let witness = wired.trace(&[mem_trace, fold_trace]);
+    let proof = stark_prove(&wired, &witness, QUERIES);
+    assert!(!stark_verify(&wired, &proof, QUERIES), "a fold on an uncommitted value verified");
+}


### PR DESCRIPTION
The opening->fold half of the monolith's per-query binding (the challenge->fold half landed in #318).

`MultiMembership::opened_cells()` returns the `(row, column)` of each opening's committed scalar. A Poseidon-committed FRI leaf is `[value, 0, 0, 0]`, so the scalar is lane zero, placed by the first index bit in the low half (column 0) or high half (column `RATE`) of the initial state. The multi-column wiring engine (#319) binds these cells to where a fold consumes the opened value.

With this, a fold is forced to fold exactly the value the Merkle opening committed. Host proofs fuse a real opening region and an in-circuit fold, wire the leaf cell to the fold's opened value, and show it verifies when they agree and is rejected when the opening commits a different value, both regions internally valid. 75 suite tests green, clippy -D warnings clean, cargo fmt clean, kernel x86_64-nonos zero warnings.

Both per-query bindings (challenge->fold, opening->fold) are now demonstrated on real components. Stacked on Stark-Wired-Multi (#319).