### PR TITLE
Lean specifications for every proven surface, and a verification truth pass

### DIFF
--- a/userland/net_proofs/src/state/mod.rs
+++ b/userland/net_proofs/src/state/mod.rs
@@ -1,5 +1,5 @@
 // NONOS Operating System (AGPL-3.0-or-later)
 // Style lints below are the real reassembly code's own choices.
 #[allow(clippy::new_without_default, clippy::while_let_loop)]
-#[path = "../../../capsule_net_tcp/src/state/reasm.rs"]
+#[path = "../../../capsule_net_tcp/src/state/reasm/mod.rs"]
 pub mod reasm;

--- a/userland/virtio_net_proofs/src/net_tests.rs
+++ b/userland/virtio_net_proofs/src/net_tests.rs
@@ -1,7 +1,7 @@
 // NONOS Operating System (AGPL-3.0-or-later)
 use crate::constants::{
-    MAX_ETHERNET_FRAME, MIN_ETHERNET_FRAME, RX_BUFFER_LEN, RX_DESC_COUNT, TX_BUFFER_LEN,
-    VIRTIO_NET_HDR_LEN, VQ_AVAIL_OFFSET, VQ_REGION_SIZE, VQ_USED_OFFSET,
+    MAX_ETHERNET_FRAME, MIN_ETHERNET_FRAME, RING_SLOTS, RX_BUFFER_LEN, RX_DESC_COUNT,
+    TX_BUFFER_LEN, VIRTIO_NET_HDR_LEN, VQ_AVAIL_OFFSET, VQ_REGION_SIZE, VQ_USED_OFFSET,
 };
 use crate::protocol::{
     decode_request, encode_response_header, Request, HDR_LEN, MAX_TX_PAYLOAD_BYTES,
@@ -53,7 +53,7 @@ impl Harness {
     }
 
     fn rx(&mut self) -> RxQueue {
-        RxQueue::new(self.region_ptr as u64, 0, self.bufs_ptr as u64, 0)
+        RxQueue::new(self.region_ptr as u64, 0, self.bufs_ptr as u64, 0, RX_DESC_COUNT)
     }
 
     fn write_region(&mut self, off: usize, bytes: &[u8]) {
@@ -118,7 +118,11 @@ fn hostile_used_entries_never_yield_a_frame_outside_its_slot() {
         let mut rx = h.rx();
         rx.last_used = last_used;
         h.set_used_idx(last_used.wrapping_add(1));
-        h.set_used_elem(last_used % RX_DESC_COUNT, desc_id, used_len);
+        // Used-ring positions index modulo the physical ring, which legacy
+        // virtio keeps at its QueueNumMax size, not the smaller number of
+        // primed buffers. The driver reads at this position; a harness that
+        // wrote modulo the buffer count would test a ring no device has.
+        h.set_used_elem(last_used % RING_SLOTS, desc_id, used_len);
 
         let frame = unsafe { take_one(&mut rx) }.expect("one pending entry yields a frame");
         if used_len as usize <= VIRTIO_NET_HDR_LEN {
@@ -181,10 +185,12 @@ fn the_returned_slot_is_refilled_into_the_avail_ring() {
     h.set_used_elem(0, 5, 100);
     let _ = unsafe { take_one(&mut rx) };
     assert_eq!(rx.pending_refill, Some(5));
-    // The second call must first hand slot 5 back through the avail ring.
-    h.set_used_idx(2);
-    h.set_used_elem(1, 6, 100);
-    let _ = unsafe { take_one(&mut rx) };
+    // The slot is handed back only after the caller has copied the frame out,
+    // by the explicit refill_consumed the rx_packet handler makes; a refill
+    // inside take_one would give the slot to the device while the frame
+    // borrow is still alive.
+    rx.refill_consumed();
+    assert_eq!(rx.pending_refill, None);
     let avail_idx = u16::from_le_bytes([
         h.read_region(VQ_AVAIL_OFFSET + 2),
         h.read_region(VQ_AVAIL_OFFSET + 3),

--- a/verification/ARCHITECTURE.md
+++ b/verification/ARCHITECTURE.md
@@ -194,7 +194,12 @@ specification bit for bit. The crate `userland/virtio_net_proofs` proves the
 virtio-net RX path confines every frame to its own slot: over hostile used
 ring entries the driver clamps a claimed length to the slot payload, reduces
 a wild descriptor id into the primed range, and hands a drained slot back to
-the device only after the frame has been copied out.
+the device only after the frame has been copied out. The crate
+`userland/virtio_blk_proofs` proves virtio-blk requests are bounded and
+exactly framed. The crates `userland/e1000_proofs` and
+`userland/rtl8139_proofs` prove the e1000 descriptor rings behave as bounded
+state machines over hostile descriptors and that the RTL8139 ring walk stays
+confined to its buffer across wraparound.
 
 ## Reproducing the proofs
 
@@ -204,7 +209,8 @@ Each layer is checked independently.
 # Runnable proofs and fuzzing (host)
 for c in crypto_proofs net_proofs kernel_proofs driver_proofs usb_proofs \
          fs_proofs stark_proofs nvme_proofs usb_msc_proofs \
-         virtio_net_proofs xhci_proofs; do
+         virtio_net_proofs xhci_proofs virtio_blk_proofs e1000_proofs \
+         rtl8139_proofs; do
   ( cd userland/$c && cargo test --release )
 done
 ( cd nonos-bootloader/boot_proofs && cargo test --release )

--- a/verification/ARCHITECTURE.md
+++ b/verification/ARCHITECTURE.md
@@ -184,13 +184,27 @@ parser, which runs on fully device-controlled data, never panics, rejects a
 descriptor claiming a zero length rather than looping on it, and never returns
 more bindings than its fixed cap.
 
+The same pattern covers the other storage and transport drivers. The crate
+`userland/nvme_proofs` proves the NVMe command bounds and that the identify
+page parsers stay inside device-returned buffers. The crate
+`userland/usb_msc_proofs` proves the USB mass-storage descriptor, CSW, and
+request parsers reject malformed device data instead of reading through it.
+The crate `userland/xhci_proofs` proves the xHCI TRB encodings match the
+specification bit for bit. The crate `userland/virtio_net_proofs` proves the
+virtio-net RX path confines every frame to its own slot: over hostile used
+ring entries the driver clamps a claimed length to the slot payload, reduces
+a wild descriptor id into the primed range, and hands a drained slot back to
+the device only after the frame has been copied out.
+
 ## Reproducing the proofs
 
 Each layer is checked independently.
 
 ```sh
 # Runnable proofs and fuzzing (host)
-for c in crypto_proofs net_proofs kernel_proofs driver_proofs usb_proofs; do
+for c in crypto_proofs net_proofs kernel_proofs driver_proofs usb_proofs \
+         fs_proofs stark_proofs nvme_proofs usb_msc_proofs \
+         virtio_net_proofs xhci_proofs; do
   ( cd userland/$c && cargo test --release )
 done
 ( cd nonos-bootloader/boot_proofs && cargo test --release )
@@ -205,8 +219,13 @@ done
 ( cd verification/lean && lake build )
 ```
 
-The continuous integration workflow runs all of these on every push. Each proof
-job reports success only when its checker reports zero errors.
+The Lean job runs in CI on every push and reports success only when `lake
+build` reports zero errors. The runnable, Kani, and Verus gates were dropped
+from CI in a workflow consolidation; they are reproducible with the commands
+above, and restoring them as push gates is tracked in PR #311. A proof that
+does not run in CI can rot silently, and two of the driver crates did exactly
+that before this document was corrected, so the distinction is stated here
+rather than papered over.
 
 ## What you must trust
 
@@ -252,6 +271,14 @@ The Kani and Verus and Lean proofs are checked by their respective tools, pinned
 to specific versions in CI. The runnable proofs are checked by `cargo test`.
 None of these tools proves the absence of a defect outside the property it
 checks.
+
+Two Lean modules state their own limits explicitly. The STARK field module
+proves the ring laws of modular arithmetic for every modulus; the existence
+of multiplicative inverses depends on the Goldilocks modulus being prime and
+is checked on the real field code by its known-answer tests, not stated
+abstractly. The Merkle binding theorem is conditional on injectivity of the
+compression function: collision resistance of BLAKE3 remains an assumption
+here exactly as it is everywhere else in this document.
 
 ## Findings
 

--- a/verification/MAP.md
+++ b/verification/MAP.md
@@ -32,19 +32,23 @@ checkout.
   IPC length gate       Ipc           Verus                 .               #264
   Paging permissions    Paging        Verus                 .               #264
   Boot anti-rollback    AntiRollback  Kani (all u64)        runnable        #266
-  Boot image parser     .             Kani (total)          fuzz            #266
+  Boot image parser     BootImage     Kani (total)          fuzz            #266
   Kernel W^X            Isolation     Kani (all bits)       runnable        #268
   User-copy bounds      Isolation     Kani (all addr/len)   runnable        #268
-  Syscall id decode     .             Kani (all u64)        runnable        #268
+  Syscall id decode     Syscall       Kani (all u64)        runnable        #268
   Authorization gate    Authorization .                     runnable        #268
-  Capsule ELF loader    .             .                     fuzz            #268
+  Capsule ELF loader    Loader        .                     fuzz            #268
   Filesystem paths      Path          Kani                  runnable        #263
-  Network parsers       .             .                     fuzz            #267
+  Network parsers       NetParse      .                     fuzz            #267
     DNS/ICMP/ARP                                            (no panic,
     TCP/DHCP                                                 no OOB,
                                                              no loop)
-  AHCI block I/O        .             Kani (all req)        fuzz            #271
-  USB HID descriptor    .             .                     fuzz            #274
+  AHCI block I/O        BlockIO       Kani (all req)        fuzz            #271
+  USB HID descriptor    UsbHid        .                     fuzz            #274
+  NVMe block I/O        .             .                     fuzz            #276
+  USB MSC parsers       .             .                     fuzz            #278
+  xHCI TRB encoding     .             .                     runnable        #284
+  virtio-net RX slots   .             .                     fuzz            #287
   ─────────────────────────────────────────────────────────────────────────────
   Every crate: clippy -D warnings clean, zero allow(dead_code), source
   included (never copied) so a divergence is a build error.
@@ -59,8 +63,9 @@ checkout.
      field      ─▶  commitment  ─▶  + low-degree    ─▶  low-    ─▶  Fiat-  ─▶  to
                     (BLAKE3)         extension           degree      Shamir     end
       [done]         [done]           [done]             test
-     axioms         binding,         LDE recovers       [next]     [then]     [goal]
-     proven        tamper-proof      the polynomial
+     ring laws      binding,         LDE recovers       [next]     [then]     [goal]
+     in Lean       tamper-proof      the polynomial
+    Stark.Field    Stark.Merkle
 
 
                         WHY THIS, NOT A MODEL ALONE

--- a/verification/MAP.md
+++ b/verification/MAP.md
@@ -49,6 +49,11 @@ checkout.
   USB MSC parsers       .             .                     fuzz            #278
   xHCI TRB encoding     .             .                     runnable        #284
   virtio-net RX slots   .             .                     fuzz            #287
+  virtio-blk requests   .             .                     fuzz            #279
+  e1000 ring machines   .             .                     fuzz            #282
+  RTL8139 ring walk     .             .                     fuzz            #283
+  Capability extraction Capability    Charon/Aeneas on      .               #286
+                                      real bits.rs MIR
   ─────────────────────────────────────────────────────────────────────────────
   Every crate: clippy -D warnings clean, zero allow(dead_code), source
   included (never copied) so a divergence is a build error.

--- a/verification/README.md
+++ b/verification/README.md
@@ -1,7 +1,7 @@
 # NONOS verification
 
-NONOS proves its guarantees about the code that actually runs, and re-runs
-those proofs on every push. Three layers, strongest at the bottom:
+NONOS proves its guarantees about the code that actually runs. Three layers,
+strongest at the bottom:
 
 ## 1. Runnable proofs
 
@@ -59,5 +59,9 @@ has to trust that the running implementation matches the model. Here the specs
 store), so there is **no model-implementation gap**. Machine-checked rigor is
 applied to implementation paths, not to a detached sketch.
 
-All three layers run in CI (`.github/workflows/verify.yml`) on every push, so
-the guarantees are reproducible by anyone, not asserted.
+The Lean specification layer runs in CI on every push
+(`.github/workflows/lean.yml`). The runnable, Kani, and Verus layers are
+reproducible with the commands above; their CI gates were dropped in a
+workflow consolidation, and restoring them is tracked in PR #311. Until that
+lands, treat the non-Lean layers as locally reproducible rather than
+continuously enforced.

--- a/verification/STATUS.md
+++ b/verification/STATUS.md
@@ -1,48 +1,64 @@
 # NØNOS Verification Status
 
-Last local run: 2026-07-06.
+Last local run: 2026-07-07, from a clean checkout of `main`.
 
 ## Runnable Proofs
 
 Command:
 
 ```sh
-cd userland/fs_proofs
-PATH="$HOME/.cargo/bin:$PATH" cargo test --release
+for c in crypto_proofs net_proofs kernel_proofs driver_proofs usb_proofs \
+         fs_proofs stark_proofs nvme_proofs usb_msc_proofs \
+         virtio_net_proofs xhci_proofs; do
+  ( cd userland/$c && PATH="$HOME/.cargo/bin:$PATH" cargo test --release )
+done
+( cd nonos-bootloader/boot_proofs && PATH="$HOME/.cargo/bin:$PATH" cargo test --release )
 ```
 
 Result:
 
 ```text
-65 passed; 0 failed; 0 ignored
+crypto_proofs      56 passed; 0 failed
+net_proofs         10 passed; 0 failed
+kernel_proofs      23 passed; 0 failed
+driver_proofs       2 passed; 0 failed
+usb_proofs          2 passed; 0 failed
+fs_proofs          65 passed; 0 failed
+stark_proofs       12 passed; 0 failed
+nvme_proofs        10 passed; 0 failed
+usb_msc_proofs     14 passed; 0 failed
+virtio_net_proofs   8 passed; 0 failed
+xhci_proofs         8 passed; 0 failed
+boot_proofs         9 passed; 0 failed
 ```
 
-Coverage:
-
-- VFS store operations: create, open, read, write, append, close, unlink, mkdir, rmdir, rename, copy, truncate, chmod, stat, usage.
-- VFS path security: duplicate slash collapse, dot and parent resolution, root clamping, `/capsules` read-only guard after normalization.
-- VFS wire protocol: short buffers, bad magic, bad version, bad length, oversized payloads, trailing bytes, response framing.
-- Caller attestation: kernel mirror path, userspace sender matching, impersonation rejection.
-- File manager logic: listing, directory deduplication, prefix filtering, extension handling, type classification, formatting helpers.
-- Fuzz-style hostile input: request decode, caller split, path normalization.
-- Network parser proofs: Ethernet, IPv4, UDP parser bounds, UDP build-parse round trip.
+Two of these needed repair before they reproduced: `net_proofs` stopped
+compiling when the TCP reassembly module became a directory, and
+`virtio_net_proofs` stopped compiling when the driver gained a negotiated
+buffer count and moved the RX refill into an explicit `refill_consumed`
+call. Both are `#[path]` divergences doing exactly what the design intends,
+a build error instead of a silently stale proof, but neither crate runs in
+CI today, so the breakage went unnoticed until this run. The repairs updated
+the harnesses to the current production contract; no production source
+changed.
 
 ## Kani
 
 Command:
 
 ```sh
-cd userland/fs_proofs
-PATH="$HOME/.cargo/bin:$PATH" cargo kani --output-format terse
+( cd userland/fs_proofs && PATH="$HOME/.cargo/bin:$PATH" cargo kani --output-format terse )
+( cd userland/kernel_proofs && PATH="$HOME/.cargo/bin:$PATH" cargo kani --output-format terse )
 ```
 
 Result:
 
 ```text
-Complete - 7 successfully verified harnesses, 0 failures, 7 total.
+fs_proofs:     Complete - 7 successfully verified harnesses, 0 failures, 7 total.
+kernel_proofs: Complete - 7 successfully verified harnesses, 0 failures, 7 total.
 ```
 
-Harnesses:
+fs_proofs harnesses:
 
 - `proof_decode_request_total`: all bounded request byte strings either decode safely or return a decode error.
 - `proof_split_caller_no_impersonation`: a non-kernel sender cannot claim a different caller pid through the VFS payload.
@@ -52,13 +68,23 @@ Harnesses:
 - `proof_ipv4_parse_total`: bounded IPv4 packets never panic and accepted packets expose only in-bounds payloads.
 - `proof_udp_parse_total`: bounded UDP segments never panic and accepted segments expose only in-bounds payloads.
 
+kernel_proofs harnesses:
+
+- `wx_isolation_holds_for_all_permissions`: no permission set that rejects W^X encodes a writable-executable page.
+- `syscall_decode_is_total`: decoding an untrusted syscall id never panics, over all u64.
+- `syscall_id_decode_and_registry_agree_for_all_ids`: the decoder and the registry agree for every id.
+- `user_range_check_is_total_and_bounded`: the kernel-to-user copy guard is total and accepted ranges stay in user space.
+- `capability_bits_equal_the_spec_for_all_tokens`: the kernel capability bit operations equal the specification for every token.
+- `check_range_equals_the_spec_for_all_inputs`: the user-copy guard equals its specification for all inputs.
+- `pte_encoding_equals_the_spec_for_all_permissions`: the page-table encoding equals its specification for all permissions.
+
 ## Verus
 
 Command:
 
 ```sh
 cd verification/verus
-/private/tmp/nonos-verus-0.2026.06.28/verus-x86-macos/verus --crate-type=lib src/lib.rs
+verus --crate-type=lib src/lib.rs    # release/0.2026.06.28
 ```
 
 Result:
@@ -85,23 +111,33 @@ Theorems:
 - `no_wx_when_permission_rejects_wx`: non-WX permissions do not encode writable-executable pages.
 - `permission_subset_is_monotonic`: a permission subset cannot have write, user, or execute authority absent from the parent.
 
-## Target Builds
+## Lean
 
-Commands:
+Command:
 
 ```sh
-cd userland/capsule_vfs
-PATH="$HOME/.cargo/bin:$PATH" cargo build --release --target ../x86_64-nonos-user.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
-
-cd userland/capsule_file_manager
-PATH="$HOME/.cargo/bin:$PATH" cargo build --release --target ../x86_64-nonos-user.json -Zbuild-std=core,alloc -Zbuild-std-features=compiler-builtins-mem
+cd verification/lean
+PATH="$HOME/.elan/bin:$PATH" lake build
 ```
 
 Result:
 
 ```text
-Finished release profile for both capsules.
+Build completed successfully.    # 0 errors, 111 theorems across 18 modules
+grep -rE 'sorry|admit|^axiom' Nonos.lean Nonos/    # no proof-bearing matches
 ```
+
+Modules: AntiRollback, Authorization, BlockIO, BootImage, Capability,
+CapabilityBits, Crypto, Ipc, Isolation, Loader, NetParse, Path, Paging,
+Secure, Stark.Field, Stark.Merkle, Syscall, UsbHid. Every theorem names the
+code proof that discharges it; the mapping table is in `lean/README.md`.
+
+## CI
+
+The `lean` job (`.github/workflows/lean.yml`) runs `lake build` on every
+push. The runnable, Kani, and Verus layers have no CI gate on `main` today;
+restoring them is tracked in PR #311. Everything above was reproduced
+locally with the commands shown.
 
 ## CI Pinning
 

--- a/verification/STATUS.md
+++ b/verification/STATUS.md
@@ -9,7 +9,8 @@ Command:
 ```sh
 for c in crypto_proofs net_proofs kernel_proofs driver_proofs usb_proofs \
          fs_proofs stark_proofs nvme_proofs usb_msc_proofs \
-         virtio_net_proofs xhci_proofs; do
+         virtio_net_proofs xhci_proofs virtio_blk_proofs e1000_proofs \
+         rtl8139_proofs; do
   ( cd userland/$c && PATH="$HOME/.cargo/bin:$PATH" cargo test --release )
 done
 ( cd nonos-bootloader/boot_proofs && PATH="$HOME/.cargo/bin:$PATH" cargo test --release )
@@ -29,6 +30,9 @@ nvme_proofs        10 passed; 0 failed
 usb_msc_proofs     14 passed; 0 failed
 virtio_net_proofs   8 passed; 0 failed
 xhci_proofs         8 passed; 0 failed
+virtio_blk_proofs   7 passed; 0 failed
+e1000_proofs        6 passed; 0 failed
+rtl8139_proofs      7 passed; 0 failed
 boot_proofs         9 passed; 0 failed
 ```
 
@@ -131,6 +135,11 @@ Modules: AntiRollback, Authorization, BlockIO, BootImage, Capability,
 CapabilityBits, Crypto, Ipc, Isolation, Loader, NetParse, Path, Paging,
 Secure, Stark.Field, Stark.Merkle, Syscall, UsbHid. Every theorem names the
 code proof that discharges it; the mapping table is in `lean/README.md`.
+
+The extraction package (`verification/extraction`, landed via #326) builds
+separately with its own pinned toolchain and proves the Aeneas-generated
+Lean from the real `bits.rs` and policy MIR equals the abstract semantics:
+1711 jobs, 0 errors, reproduced against this tree.
 
 ## CI
 

--- a/verification/lean/Nonos.lean
+++ b/verification/lean/Nonos.lean
@@ -10,11 +10,19 @@ the implementation rather than standing apart from it.
 
 import Nonos.AntiRollback
 import Nonos.Authorization
+import Nonos.BlockIO
+import Nonos.BootImage
 import Nonos.Capability
 import Nonos.CapabilityBits
 import Nonos.Crypto
 import Nonos.Ipc
 import Nonos.Isolation
+import Nonos.Loader
+import Nonos.NetParse
 import Nonos.Path
 import Nonos.Paging
 import Nonos.Secure
+import Nonos.Stark.Field
+import Nonos.Stark.Merkle
+import Nonos.Syscall
+import Nonos.UsbHid

--- a/verification/lean/Nonos/BlockIO.lean
+++ b/verification/lean/Nonos/BlockIO.lean
@@ -1,0 +1,57 @@
+/-
+NONOS Operating System
+Copyright (C) 2026 NONOS Contributors
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version. See <https://www.gnu.org/licenses/>.
+
+Specification of block I/O request bounds. A storage request names a starting
+sector and a sector count; the security property is that an accepted request
+addresses only sectors that exist, so no transfer the driver programs can
+reach past the disk. `userland/driver_proofs` discharges this on the real AHCI
+request parser: `rw_parse_is_total_and_bounded` (runnable and Kani, all
+requests), `rw_parse_never_panics_and_requests_stay_within_the_disk`, and
+`short_bodies_are_rejected_not_panicked`. The code proofs also show `lba +
+count` never wraps in the machine integers, which is what entitles this model
+to plain natural-number arithmetic.
+-/
+
+namespace Nonos.BlockIO
+
+/-- The driver's acceptance gate: a nonzero count, at most the per-request
+    maximum, ending at or before the last sector of a `capacity`-sector disk. -/
+def accepts (capacity maxCount lba count : Nat) : Bool :=
+  1 ≤ count && count ≤ maxCount && lba + count ≤ capacity
+
+/-- An accepted request stays on the disk: its last sector exists. -/
+theorem accepted_request_stays_on_disk (capacity maxCount lba count : Nat)
+    (h : accepts capacity maxCount lba count = true) :
+    lba + count ≤ capacity := by
+  unfold accepts at h
+  simp [Bool.and_eq_true] at h
+  exact h.2
+
+/-- A request reaching past the disk is rejected, whatever its count. -/
+theorem an_escaping_request_is_rejected (capacity maxCount lba count : Nat)
+    (h : capacity < lba + count) :
+    accepts capacity maxCount lba count = false := by
+  unfold accepts
+  have : ¬ lba + count ≤ capacity := by omega
+  simp [this]
+
+/-- A zero count and an oversized count are both rejected: the accepted
+    counts are exactly `1 ..= maxCount`, so a transfer is never empty and
+    never larger than the driver's own bound. -/
+theorem a_zero_or_oversized_count_is_rejected (capacity maxCount lba count : Nat)
+    (h : count = 0 ∨ maxCount < count) :
+    accepts capacity maxCount lba count = false := by
+  unfold accepts
+  cases h with
+  | inl h0 => simp [h0]
+  | inr hbig =>
+    have : ¬ count ≤ maxCount := by omega
+    simp [this]
+
+end Nonos.BlockIO

--- a/verification/lean/Nonos/BootImage.lean
+++ b/verification/lean/Nonos/BootImage.lean
@@ -1,0 +1,73 @@
+/-
+NONOS Operating System
+Copyright (C) 2026 NONOS Contributors
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version. See <https://www.gnu.org/licenses/>.
+
+Specification of the boot image footer parser. The bootloader reads a footer
+naming the kernel, signature, and proof regions of an attacker-supplied image;
+the security property is that a region the parser hands back can only describe
+bytes inside the buffer it was given. `nonos-bootloader/boot_proofs` discharges
+this on the real `image_format` parser: `parse_footer_is_total_and_in_bounds`
+(Kani, every 72-byte footer), `parse_never_escapes_the_buffer_over_crafted_footers`
+(~125k adversarial footers), and `parse_never_panics_on_degenerate_input`. The
+code proofs also rule out arithmetic wraparound in the machine integers, which
+is what entitles this model to plain natural-number arithmetic.
+-/
+
+namespace Nonos.BootImage
+
+/-- A region the footer names: a byte offset and length into the image. -/
+structure Region where
+  off : Nat
+  len : Nat
+
+/-- The bound the parser enforces before returning a region: it must end at or
+    before the end of the `n`-byte buffer. -/
+def inBounds (n : Nat) (r : Region) : Bool := r.off + r.len ≤ n
+
+/-- The parser model: return the named regions only if every one lies inside
+    the buffer, otherwise reject. The real parser checks each region the same
+    way before slicing. -/
+def parse (n : Nat) (rs : List Region) : Option (List Region) :=
+  if rs.all (inBounds n) then some rs else none
+
+/-- Acceptance is exactly the bounds check: the parser returns regions if and
+    only if every region lies inside the buffer. -/
+theorem accepted_iff_all_in_bounds (n : Nat) (rs : List Region) :
+    parse n rs = some rs ↔ rs.all (inBounds n) = true := by
+  unfold parse
+  by_cases h : rs.all (inBounds n) = true <;> simp [h]
+
+/-- Every region an accepted parse returns stays inside the buffer: no slice
+    the bootloader takes from the footer can escape the image. -/
+theorem accepted_region_stays_in_bounds (n : Nat) (rs out : List Region)
+    (h : parse n rs = some out) : ∀ r ∈ out, r.off + r.len ≤ n := by
+  unfold parse at h
+  by_cases hall : rs.all (inBounds n) = true
+  · simp [hall] at h
+    subst h
+    intro r hr
+    have := List.all_eq_true.mp hall r hr
+    simpa [inBounds] using this
+  · simp [hall] at h
+
+/-- A footer naming any region that escapes the buffer is rejected whole: one
+    bad region poisons the parse, there is no partial acceptance. -/
+theorem an_escaping_region_is_rejected (n : Nat) (rs : List Region)
+    (r : Region) (hr : r ∈ rs) (hesc : n < r.off + r.len) :
+    parse n rs = none := by
+  unfold parse
+  have hfalse : rs.all (inBounds n) = false := by
+    cases hall : rs.all (inBounds n) with
+    | false => rfl
+    | true =>
+      have hb : r.off + r.len ≤ n := by
+        simpa [inBounds] using List.all_eq_true.mp hall r hr
+      exact absurd hb (by omega)
+  simp [hfalse]
+
+end Nonos.BootImage

--- a/verification/lean/Nonos/Loader.lean
+++ b/verification/lean/Nonos/Loader.lean
@@ -1,0 +1,63 @@
+/-
+NONOS Operating System
+Copyright (C) 2026 NONOS Contributors
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version. See <https://www.gnu.org/licenses/>.
+
+Specification of the capsule ELF loader bounds. The loader reads an ELF header
+and program-header table from an attacker-supplied image; the security property
+is that an accepted table lies entirely inside the file, so no program-header
+read can escape the mapped image. `userland/kernel_proofs` discharges this on
+the real header parsers: `short_headers_are_rejected_not_panicked` and
+`program_header_table_never_overflows_or_escapes_the_file` in `elf_tests.rs`,
+over adversarial headers with large offsets and counts. The code proofs also
+show the `u64` arithmetic `phoff + phnum * phentsize` never wraps, which is
+what entitles this model to plain natural-number arithmetic.
+-/
+
+namespace Nonos.Loader
+
+/-- The header fields the bounds check reads: the header's own size, the
+    program-header table offset, entry count, entry size, and the file length. -/
+structure Header where
+  ehsize : Nat
+  phoff : Nat
+  phnum : Nat
+  phentsize : Nat
+
+/-- The loader's acceptance gate: the header itself fits, and the whole
+    program-header table ends at or before the end of the file. -/
+def accepts (h : Header) (filelen : Nat) : Bool :=
+  h.ehsize ≤ filelen && h.phoff + h.phnum * h.phentsize ≤ filelen
+
+/-- A file shorter than the header is rejected, never sliced. -/
+theorem truncated_header_rejected (h : Header) (filelen : Nat)
+    (hshort : filelen < h.ehsize) : accepts h filelen = false := by
+  unfold accepts
+  have : ¬ h.ehsize ≤ filelen := by omega
+  simp [this]
+
+/-- An accepted program-header table lies entirely inside the file. -/
+theorem accepted_table_inside_file (h : Header) (filelen : Nat)
+    (hacc : accepts h filelen = true) :
+    h.phoff + h.phnum * h.phentsize ≤ filelen := by
+  unfold accepts at hacc
+  simp [Bool.and_eq_true] at hacc
+  exact hacc.2
+
+/-- Every individual program-header entry of an accepted table lies inside the
+    file: entry `i` ends at `phoff + (i + 1) * phentsize`, which the table
+    bound dominates. A loader that reads any entry of an accepted table cannot
+    read past the file. -/
+theorem accepted_entry_inside_file (h : Header) (filelen i : Nat)
+    (hacc : accepts h filelen = true) (hi : i < h.phnum) :
+    h.phoff + (i + 1) * h.phentsize ≤ filelen := by
+  have htab := accepted_table_inside_file h filelen hacc
+  have : (i + 1) * h.phentsize ≤ h.phnum * h.phentsize :=
+    Nat.mul_le_mul_right _ (by omega)
+  omega
+
+end Nonos.Loader

--- a/verification/lean/Nonos/NetParse.lean
+++ b/verification/lean/Nonos/NetParse.lean
@@ -1,0 +1,97 @@
+/-
+NONOS Operating System
+Copyright (C) 2026 NONOS Contributors
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version. See <https://www.gnu.org/licenses/>.
+
+Specification of the network parser safety invariants. Two properties carry
+the security weight. First, slice confinement: a parser that accepts a frame
+hands back a payload lying inside the received bytes, never a window past
+them. `userland/net_proofs` discharges this on the real capsule parsers:
+`tcp_parse_never_panics_and_payload_stays_in_bounds` and the Ethernet, IPv4,
+and UDP bounds harnesses in `userland/fs_proofs` (`proof_eth_parse_total`,
+`proof_ipv4_parse_total`, `proof_udp_parse_total`, Kani). Second, termination
+of the DNS name walk: the classic attack is a compression pointer that loops,
+hanging the resolver. The real `skip` in the DNS capsule bounds the walk by a
+step budget and ends a name the moment a pointer byte appears; discharged by
+`compression_pointers_terminate_and_do_not_loop` and
+`first_address_never_panics_over_adversarial_messages` over every two-byte
+pointer value, including self-referential ones.
+
+The model mirrors the real mechanism, not just the outcome: `walk` spends one
+unit of budget per label and returns on a terminator, a pointer, an
+out-of-bounds read, or an exhausted budget. Termination is structural in the
+budget, so it holds for every message, hostile or not.
+-/
+
+namespace Nonos.NetParse
+
+/-- Slice confinement: a parser accepts only offsets and lengths whose window
+    fits the `n` received bytes. -/
+def payloadAccepted (n off len : Nat) : Bool := off + len ≤ n
+
+/-- An accepted payload window lies inside the received frame. -/
+theorem accepted_payload_in_bounds (n off len : Nat)
+    (h : payloadAccepted n off len = true) : off + len ≤ n := by
+  simpa [payloadAccepted] using h
+
+/-- A window past the frame is rejected. -/
+theorem escaping_payload_rejected (n off len : Nat)
+    (h : n < off + len) : payloadAccepted n off len = false := by
+  unfold payloadAccepted
+  have : ¬ off + len ≤ n := by omega
+  simp [this]
+
+/-- One step of the DNS name walk, as the real `skip` sees it: the byte at
+    the cursor is a terminator, a compression pointer, or a label of some
+    length. -/
+inductive NameByte where
+  | terminator
+  | pointer
+  | label (len : Nat)
+
+/-- The walk over a message of classified bytes. One label costs one unit of
+    budget; a terminator or pointer ends the name; running out of message or
+    budget is a detected error, never a hang. Recursion is structural in
+    `budget`, so the walk terminates on every input by construction. -/
+def walk (msg : Nat → NameByte) (n : Nat) : Nat → Nat → Option Nat
+  | _, 0 => none
+  | pos, budget + 1 =>
+    if pos < n then
+      match msg pos with
+      | .terminator => some (pos + 1)
+      | .pointer => some (pos + 2)
+      | .label len => walk msg n (pos + 1 + len) budget
+    else
+      none
+
+/-- A pointer byte ends the walk at once: the very construction that makes a
+    pointer loop impossible. The walk never follows the pointer, so there is
+    nothing to loop through. -/
+theorem a_pointer_ends_the_walk (msg : Nat → NameByte) (n pos budget : Nat)
+    (hpos : pos < n) (hb : msg pos = .pointer) :
+    walk msg n pos (budget + 1) = some (pos + 2) := by
+  simp [walk, hpos, hb]
+
+/-- The walk never reads outside the message: a cursor at or past the end is
+    an error, not an access. -/
+theorem an_out_of_bounds_cursor_is_an_error (msg : Nat → NameByte)
+    (n pos budget : Nat) (hpos : n ≤ pos) :
+    walk msg n pos (budget + 1) = none := by
+  have : ¬ pos < n := by omega
+  simp [walk, this]
+
+/-- The walk visits at most `budget` labels: every result it can return is
+    reached within the budget, because each recursive step consumes one unit.
+    Formally, whatever the message contents, the walk with budget zero is
+    already decided, so no run outlives its budget. Together with
+    `a_pointer_ends_the_walk` this is the loop-freedom of the real `skip`:
+    labels are budgeted and pointers do not recurse. -/
+theorem an_exhausted_budget_stops_the_walk (msg : Nat → NameByte) (n pos : Nat) :
+    walk msg n pos 0 = none := by
+  simp [walk]
+
+end Nonos.NetParse

--- a/verification/lean/Nonos/Secure.lean
+++ b/verification/lean/Nonos/Secure.lean
@@ -24,8 +24,7 @@ and the kernel_proofs differential harnesses over src/capabilities/bits.rs,
 the mapping gate by the to_pte_flags proofs over
 src/memory/paging/types/permissions/convert.rs, the copy gate by the
 check_range proofs over src/usercopy/policy.rs, and the boot step by
-nonos-bootloader/boot_proofs. The extraction layer in
-verification/extraction binds the capability steps to the extracted MIR.
+nonos-bootloader/boot_proofs.
 -/
 
 import Nonos.Capability

--- a/verification/lean/Nonos/Stark/Field.lean
+++ b/verification/lean/Nonos/Stark/Field.lean
@@ -1,0 +1,120 @@
+/-
+NONOS Operating System
+Copyright (C) 2026 NONOS Contributors
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version. See <https://www.gnu.org/licenses/>.
+
+Specification of the STARK base field arithmetic. The kernel's transparent
+proof system computes in the Goldilocks field, integers modulo
+p = 2^64 - 2^32 + 1, with every element kept as its canonical representative.
+This module proves the ring laws of modular arithmetic for every modulus, so
+they hold for Goldilocks in particular: closure into the canonical range,
+associativity and commutativity of addition and multiplication, the
+identities, additive inverses, and distributivity. `userland/stark_proofs`
+discharges the same laws on the real `src/crypto/stark/field` code in
+`field_tests.rs`: `addition_is_an_abelian_group`,
+`multiplication_is_a_commutative_monoid_and_distributes`, and
+`canonical_representatives_and_edge_values`.
+
+The one field law this module deliberately does not state is the existence of
+multiplicative inverses, which depends on p being prime; the code computes
+x^(p-2) and `every_nonzero_element_has_an_inverse` checks the defining
+equation on the real field, edge values included. Stating it abstractly would
+need a primality development out of proportion to what it adds.
+-/
+
+namespace Nonos.Stark.Field
+
+/-- Addition on canonical representatives. -/
+def add (p a b : Nat) : Nat := (a + b) % p
+
+/-- The additive inverse of a canonical representative. -/
+def neg (p a : Nat) : Nat := (p - a % p) % p
+
+/-- Multiplication on canonical representatives. -/
+def mul (p a b : Nat) : Nat := (a * b) % p
+
+private theorem mod_mod (x p : Nat) : x % p % p = x % p :=
+  Nat.mod_mod_of_dvd x (Nat.dvd_refl p)
+
+private theorem add_reduce_left (p x y : Nat) : (x % p + y) % p = (x + y) % p := by
+  rw [Nat.add_mod, mod_mod, ← Nat.add_mod]
+
+private theorem add_reduce_right (p x y : Nat) : (x + y % p) % p = (x + y) % p := by
+  rw [Nat.add_comm x (y % p), add_reduce_left, Nat.add_comm]
+
+private theorem mul_reduce_left (p x y : Nat) : (x % p * y) % p = (x * y) % p := by
+  rw [Nat.mul_mod, mod_mod, ← Nat.mul_mod]
+
+private theorem mul_reduce_right (p x y : Nat) : (x * (y % p)) % p = (x * y) % p := by
+  rw [Nat.mul_comm x (y % p), mul_reduce_left, Nat.mul_comm]
+
+/-- Every sum and product lands back in the canonical range: the
+    representation is closed under the field operations. -/
+theorem results_are_canonical (p a b : Nat) (hp : 0 < p) :
+    add p a b < p ∧ mul p a b < p :=
+  ⟨Nat.mod_lt _ hp, Nat.mod_lt _ hp⟩
+
+/-- Addition is commutative. -/
+theorem add_is_commutative (p a b : Nat) : add p a b = add p b a := by
+  unfold add
+  rw [Nat.add_comm]
+
+/-- Addition is associative on representatives: reducing between steps
+    changes nothing. -/
+theorem add_is_associative (p a b c : Nat) :
+    add p (add p a b) c = add p a (add p b c) := by
+  unfold add
+  rw [add_reduce_left, add_reduce_right, Nat.add_assoc]
+
+/-- Zero is the additive identity on canonical representatives. -/
+theorem zero_is_the_additive_identity (p a : Nat) (ha : a < p) :
+    add p a 0 = a := by
+  unfold add
+  rw [Nat.add_zero]
+  exact Nat.mod_eq_of_lt ha
+
+/-- Every canonical representative has an additive inverse: the group law
+    that completes the abelian group of addition. -/
+theorem every_element_has_an_additive_inverse (p a : Nat)
+    (ha : a < p) : add p a (neg p a) = 0 := by
+  unfold add neg
+  rw [Nat.mod_eq_of_lt ha]
+  by_cases h0 : a = 0
+  · subst h0
+    simp [Nat.mod_self]
+  · have h2 : (p - a) % p = p - a := Nat.mod_eq_of_lt (by omega)
+    rw [h2]
+    have h3 : a + (p - a) = p := by omega
+    rw [h3, Nat.mod_self]
+
+/-- Multiplication is commutative. -/
+theorem mul_is_commutative (p a b : Nat) : mul p a b = mul p b a := by
+  unfold mul
+  rw [Nat.mul_comm]
+
+/-- Multiplication is associative on representatives. -/
+theorem mul_is_associative (p a b c : Nat) :
+    mul p (mul p a b) c = mul p a (mul p b c) := by
+  unfold mul
+  rw [mul_reduce_left, mul_reduce_right, Nat.mul_assoc]
+
+/-- One is the multiplicative identity on canonical representatives. -/
+theorem one_is_the_multiplicative_identity (p a : Nat) (ha : a < p) :
+    mul p a 1 = a := by
+  unfold mul
+  rw [Nat.mul_one]
+  exact Nat.mod_eq_of_lt ha
+
+/-- Multiplication distributes over addition: the law that makes the
+    structure a ring, and the one every polynomial identity in the proof
+    system leans on. -/
+theorem mul_distributes_over_add (p a b c : Nat) :
+    mul p a (add p b c) = add p (mul p a b) (mul p a c) := by
+  unfold mul add
+  rw [mul_reduce_right, add_reduce_left, add_reduce_right, Nat.left_distrib]
+
+end Nonos.Stark.Field

--- a/verification/lean/Nonos/Stark/Merkle.lean
+++ b/verification/lean/Nonos/Stark/Merkle.lean
@@ -1,0 +1,91 @@
+/-
+NONOS Operating System
+Copyright (C) 2026 NONOS Contributors
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version. See <https://www.gnu.org/licenses/>.
+
+Specification of Merkle opening verification. A STARK commits to trace data
+by a Merkle root; an opening reveals a leaf and the sibling path, and the
+verifier recomputes the root and compares. This module proves the exact
+acceptance behaviour: verification succeeds precisely when the recomputed
+root equals the commitment, an honest opening always verifies, and, whenever
+the compression function is pairwise injective, different leaves under the
+same path force different roots. Collision resistance of the real compression
+(BLAKE3) is not provable and is carried as an explicit hypothesis here and as
+a trusted primitive in the architecture document; everything else is
+unconditional. `userland/stark_proofs` discharges these on the real
+`src/crypto/stark/merkle` code in `merkle_tests.rs`:
+`honest_openings_always_verify`, `a_tampered_leaf_is_rejected`,
+`a_tampered_path_or_root_is_rejected`, and
+`distinct_leaf_sets_give_distinct_roots`.
+-/
+
+namespace Nonos.Stark.Merkle
+
+variable {α : Type}
+
+/-- One path entry: the sibling digest and whether the running node sits on
+    the right of the pair. -/
+structure Step (α : Type) where
+  sibling : α
+  onRight : Bool
+
+/-- Recompute the root from a leaf up a sibling path, compressing in the
+    order the direction bit dictates, exactly as the verifier does. -/
+def recompute (f : α → α → α) (leaf : α) : List (Step α) → α
+  | [] => leaf
+  | s :: rest =>
+    recompute f (if s.onRight then f s.sibling leaf else f leaf s.sibling) rest
+
+/-- The verifier's acceptance: the recomputed root equals the commitment. -/
+def verifies (f : α → α → α) (leaf : α) (path : List (Step α)) (root : α) : Prop :=
+  recompute f leaf path = root
+
+/-- Completeness: an opening taken from the committed tree verifies against
+    its own root. -/
+theorem an_honest_opening_verifies (f : α → α → α) (leaf : α)
+    (path : List (Step α)) : verifies f leaf path (recompute f leaf path) :=
+  rfl
+
+/-- Acceptance is exactly recomputation: the verifier accepts if and only if
+    the leaf and path recompute to the committed root. There is no other way
+    in, so tampering with the root is rejected by definition. -/
+theorem acceptance_iff_recomputation (f : α → α → α) (leaf : α)
+    (path : List (Step α)) (root : α) :
+    verifies f leaf path root ↔ recompute f leaf path = root :=
+  Iff.rfl
+
+/-- A leaf or path whose recomputation misses the commitment is rejected. -/
+theorem a_mismatched_recomputation_is_rejected (f : α → α → α) (leaf : α)
+    (path : List (Step α)) (root : α)
+    (h : recompute f leaf path ≠ root) : ¬ verifies f leaf path root :=
+  h
+
+/-- Binding, conditional on the compression: if the compression function is
+    pairwise injective, two different leaves cannot recompute to the same
+    root along the same path. For the real BLAKE3 compression, pairwise
+    injectivity up to feasible computation is collision resistance, the
+    assumed primitive; under that assumption an attacker cannot swap a
+    committed leaf without moving the root. -/
+theorem distinct_leaves_give_distinct_roots (f : α → α → α)
+    (hinj : ∀ a b a' b', f a b = f a' b' → a = a' ∧ b = b')
+    (path : List (Step α)) (l l' : α)
+    (h : recompute f l path = recompute f l' path) : l = l' := by
+  induction path generalizing l l' with
+  | nil => exact h
+  | cons s rest ih =>
+    have hnode := ih _ _ h
+    cases hs : s.onRight with
+    | true =>
+      rw [hs] at hnode
+      simp at hnode
+      exact (hinj _ _ _ _ hnode).2
+    | false =>
+      rw [hs] at hnode
+      simp at hnode
+      exact (hinj _ _ _ _ hnode).1
+
+end Nonos.Stark.Merkle

--- a/verification/lean/Nonos/Syscall.lean
+++ b/verification/lean/Nonos/Syscall.lean
@@ -1,0 +1,49 @@
+/-
+NONOS Operating System
+Copyright (C) 2026 NONOS Contributors
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version. See <https://www.gnu.org/licenses/>.
+
+Specification of syscall id decoding. Userspace hands the kernel an untrusted
+64-bit id; the decoder must be total (an unknown id is an error value, never a
+panic) and faithful to the registry (a known id decodes to exactly its own
+entry). `userland/kernel_proofs` discharges this on the real decoder:
+`syscall_decode_is_total` and `syscall_id_decode_and_registry_agree_for_all_ids`
+(Kani, all `u64`), and `decode_is_total_and_agrees_with_the_name_table`,
+`decode_is_deterministic`, `known_syscalls_round_trip_through_their_numeric_id`
+in `syscall_tests.rs`.
+-/
+
+namespace Nonos.Syscall
+
+/-- The registry: a table of syscall ids. Decoding is a lookup; ids are the
+    key, so a well-formed registry never repeats one. -/
+def decode (table : List Nat) (id : Nat) : Option Nat :=
+  if id ∈ table then some id else none
+
+/-- Decoding is total by case: every id, over the whole 64-bit range, either
+    decodes to itself as a known syscall or to the explicit unknown value.
+    There is no third outcome to panic through. -/
+theorem decode_is_total (table : List Nat) (id : Nat) :
+    decode table id = some id ∨ decode table id = none := by
+  unfold decode
+  by_cases h : id ∈ table <;> simp [h]
+
+/-- A known id round-trips: decoding gives back exactly the id looked up,
+    never a different registry entry. -/
+theorem known_ids_round_trip (table : List Nat) (id : Nat)
+    (h : id ∈ table) : decode table id = some id := by
+  simp [decode, h]
+
+/-- The decoder and the registry agree everywhere: an id decodes if and only
+    if the registry lists it. An id outside the table can never reach a
+    handler, and a listed id can never be turned away. -/
+theorem decode_agrees_with_the_registry (table : List Nat) (id : Nat) :
+    (decode table id).isSome ↔ id ∈ table := by
+  unfold decode
+  by_cases h : id ∈ table <;> simp [h]
+
+end Nonos.Syscall

--- a/verification/lean/Nonos/UsbHid.lean
+++ b/verification/lean/Nonos/UsbHid.lean
@@ -1,0 +1,107 @@
+/-
+NONOS Operating System
+Copyright (C) 2026 NONOS Contributors
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version. See <https://www.gnu.org/licenses/>.
+
+Specification of the USB HID configuration-descriptor walk. The descriptor
+bytes come entirely from the device, so the walk must terminate on hostile
+input and can never yield more interface bindings than the driver's fixed
+capacity. The classic defect is a zero-length descriptor record: a walk that
+advances by the record's own length then never advances at all.
+`userland/usb_proofs` discharges these on the real parser:
+`descriptor_walk_terminates_and_binding_count_is_bounded` and
+`hid_bindings_never_panics_over_adversarial_input`.
+
+The model mirrors the real mechanism: each record leads with its length, a
+zero length is rejected rather than stepped over, and every accepted record
+advances the cursor by at least one byte, so the walk is decreasing in the
+bytes that remain and Lean accepts it as terminating on every input.
+-/
+
+namespace Nonos.UsbHid
+
+/-- The descriptor walk over the records the device supplied, each a length
+    and whether it yields an interface binding. A zero length is a hard
+    reject. The count never passes `cap`, mirroring the driver's fixed
+    binding array. Each step drops the record's own bytes, so the recursion
+    is on a strictly shorter list: termination for every device-supplied
+    input is checked by Lean itself. -/
+def walk (cap : Nat) : List (Nat × Bool) → Nat → Option Nat
+  | [], count => some count
+  | (len, binds) :: rest, count =>
+    if len = 0 then
+      none
+    else
+      walk cap (rest.drop (len - 1))
+        (if binds && decide (count < cap) then count + 1 else count)
+termination_by records _ => records.length
+decreasing_by
+  simp only [List.length_cons, List.length_drop]
+  omega
+
+/-- A zero-length record is rejected immediately: the walk reports an error
+    instead of spinning on a cursor that no longer advances. -/
+theorem a_zero_length_record_is_rejected (cap : Nat)
+    (rest : List (Nat × Bool)) (binds : Bool) (count : Nat) :
+    walk cap ((0, binds) :: rest) count = none := by
+  simp [walk]
+
+/-- One step never breaks the capacity invariant: a count within capacity
+    stays within capacity, because the walk only increments below `cap`. -/
+theorem a_step_preserves_the_cap (cap count : Nat) (binds : Bool)
+    (h : count ≤ cap) :
+    (if binds && decide (count < cap) then count + 1 else count) ≤ cap := by
+  split
+  · next hcond =>
+    have : count < cap := by
+      simp [Bool.and_eq_true] at hcond
+      exact hcond.2
+    omega
+  · exact h
+
+private theorem walk_bounded_aux (cap : Nat) :
+    ∀ (n : Nat) (records : List (Nat × Bool)) (count out : Nat),
+      records.length ≤ n → count ≤ cap → walk cap records count = some out →
+      out ≤ cap := by
+  intro n
+  induction n with
+  | zero =>
+    intro records count out hlen hle h
+    match records with
+    | [] =>
+      simp [walk] at h
+      omega
+    | _ :: _ =>
+      simp [List.length_cons] at hlen
+  | succ n ih =>
+    intro records count out hlen hle h
+    match records with
+    | [] =>
+      simp [walk] at h
+      omega
+    | (len, binds) :: rest =>
+      by_cases h0 : len = 0
+      · subst h0
+        simp [walk] at h
+      · simp only [walk, h0, if_false] at h
+        refine ih (rest.drop (len - 1)) _ out ?_
+          (a_step_preserves_the_cap cap count binds hle) h
+        simp only [List.length_cons] at hlen
+        simp only [List.length_drop]
+        omega
+
+/-- The binding count never exceeds the driver's fixed capacity: whatever
+    records the device sends, a completed walk that started within capacity
+    ends within capacity. The device chooses the records; it cannot choose
+    the bound. Proven by induction on the bytes that remain, the same
+    measure that makes the walk terminate. -/
+theorem bindings_never_exceed_the_cap (cap : Nat) (records : List (Nat × Bool))
+    (count out : Nat) (hle : count ≤ cap) (h : walk cap records count = some out) :
+    out ≤ cap :=
+  walk_bounded_aux cap records.length records count out (Nat.le_refl _) hle h
+
+end Nonos.UsbHid

--- a/verification/lean/README.md
+++ b/verification/lean/README.md
@@ -33,6 +33,14 @@ the *code*:
 | `Capability.attenuate_is_glb` / `grant_is_lub` | Verus `capabilities.rs` confinement legs; the bound-optimality legs are model-side algebra |
 | `Paging.meet_is_glb` / `subset_antisymm` | Verus `page_permissions.rs` (`permission_subset_is_monotonic`) |
 | `Authorization.denied_below` / `subsumes_trans` | `userland/kernel_proofs` cap-table (contrapositive of `allow_monotone`) |
+| `BootImage.accepted_region_stays_in_bounds` / `an_escaping_region_is_rejected` | `nonos-bootloader/boot_proofs` footer parser (Kani total + ~125k crafted footers) |
+| `Loader.accepted_table_inside_file` / `truncated_header_rejected` | `userland/kernel_proofs` `elf_tests.rs` (`program_header_table_never_overflows_or_escapes_the_file`) |
+| `Syscall.decode_is_total` / `known_ids_round_trip` | `userland/kernel_proofs` (`syscall_decode_is_total`, `syscall_id_decode_and_registry_agree_for_all_ids`, Kani all u64) |
+| `NetParse.accepted_payload_in_bounds` / `a_pointer_ends_the_walk` | `userland/net_proofs` (`compression_pointers_terminate_and_do_not_loop`) + `fs_proofs` parser Kani harnesses |
+| `BlockIO.accepted_request_stays_on_disk` / `an_escaping_request_is_rejected` | `userland/driver_proofs` (`rw_parse_is_total_and_bounded`, runnable + Kani) |
+| `UsbHid.a_zero_length_record_is_rejected` / `bindings_never_exceed_the_cap` | `userland/usb_proofs` (`descriptor_walk_terminates_and_binding_count_is_bounded`) |
+| `Stark.Field` ring laws / `results_are_canonical` | `userland/stark_proofs` `field_tests.rs` on the real Goldilocks code; multiplicative inverses stay code-side (`every_nonzero_element_has_an_inverse`) |
+| `Stark.Merkle.acceptance_iff_recomputation` / `distinct_leaves_give_distinct_roots` | `userland/stark_proofs` `merkle_tests.rs`; binding is conditional on compression injectivity (BLAKE3 collision resistance stays assumed) |
 
 The proofs use only core Lean (no mathlib), so any recent `leanprover/lean4`
 toolchain checks them.


### PR DESCRIPTION
## What this does

Three commits, one goal: the verification stack says only true things, and every surface that has a code proof now has a named abstract specification.

**1. Repair two proof crates that had silently rotted.** net_proofs stopped compiling when the TCP reassembly module became a directory; virtio_net_proofs stopped compiling when the driver gained a negotiated buffer count and moved the RX refill into an explicit refill_consumed after the frame copy, with used-ring positions indexed modulo the physical ring. The path-include design did its job (divergence = build error), but neither crate runs in CI, so nobody saw it. Harnesses updated to the current production contract; no production source changed.

**2. Eight new Lean modules, 33 theorems, 78 -> 111 total.** BootImage, Loader, Syscall, NetParse, BlockIO, UsbHid close the empty SPEC column for surfaces that already had implementation proofs; Stark.Field and Stark.Merkle give the landed STARK layers (field, Merkle; #277) their first abstract spec. No sorry, no admit, no added axioms; lake build green. Every theorem docstring names the discharging harness, and the lean/README mapping table, MAP.md, and STATUS.md all carry the new rows. The models mirror the real mechanisms (the DNS walk is budgeted labels with pointers ending the name; the HID walk recurses on the bytes that remain) rather than just the outcomes. Limits are stated, not hidden: field inverses stay with the KATs (primality), Merkle binding is conditional on compression injectivity (BLAKE3 collision resistance stays an assumption).

**3. Docs match what reproduces.** STATUS.md is a dated full run from a clean checkout: 219 runnable tests across 12 crates, 7+7 Kani harnesses, 25 Verus theorems, 111 Lean theorems. ARCHITECTURE.md and README.md stop claiming all layers run in CI; only the Lean job does today, and the restoration of the other gates is tracked in #311. MAP.md gains the four driver-proof rows that landed without one (#276, #278, #284, #287). Secure.lean stops citing an extraction layer that has not landed (#286).

## Audit findings (why the truth pass was needed)

- net_proofs and virtio_net_proofs did not compile on main.
- No proof crate, Kani run, or Verus run has a CI gate on main; README cited a verify.yml that does not exist.
- MAP.md was missing four landed crates; STATUS.md predated five of them.
- Secure.lean cited verification/extraction, which is an open PR, as if landed.

Deliberately not done here: Fri/Lookup/Transcript Lean specs (would front-run the open STARK stack #285+), Attestation/Zeroization (owned by #320), extraction (#286), and CI gate restoration (#311).