### PR TITLE
extraction: regenerate for the TimeSet capability

### DIFF
--- a/verification/extraction/lean/NonosExtraction/Caps.lean
+++ b/verification/extraction/lean/NonosExtraction/Caps.lean
@@ -15,7 +15,7 @@ set_option maxRecDepth 2048
 namespace nonos_caps
 
 /-- [nonos_caps::capabilities::types::Capability]
-    Source: 'src/capabilities/../../../../../src/capabilities/types.rs', lines 18:0-50:1
+    Source: 'src/capabilities/../../../../../src/capabilities/types.rs', lines 18:0-51:1
     Visibility: public -/
 @[discriminant isize]
 inductive capabilities.types.Capability where
@@ -41,9 +41,10 @@ inductive capabilities.types.Capability where
 | Dma : capabilities.types.Capability
 | Pio : capabilities.types.Capability
 | InputSource : capabilities.types.Capability
+| TimeSet : capabilities.types.Capability
 
 /-- [nonos_caps::capabilities::types::{nonos_caps::capabilities::types::Capability}::bit]:
-    Source: 'src/capabilities/../../../../../src/capabilities/types.rs', lines 54:4-79:5 -/
+    Source: 'src/capabilities/../../../../../src/capabilities/types.rs', lines 55:4-81:5 -/
 def capabilities.types.Capability.bit
   (self : capabilities.types.Capability) : Result Std.U64 := do
   match self with
@@ -69,6 +70,7 @@ def capabilities.types.Capability.bit
   | capabilities.types.Capability.Dma => ok 524288#u64
   | capabilities.types.Capability.Pio => ok 1048576#u64
   | capabilities.types.Capability.InputSource => ok 2097152#u64
+  | capabilities.types.Capability.TimeSet => ok 4194304#u64
 
 /-- [nonos_caps::capabilities::bits::has_capability]:
     Source: 'src/capabilities/../../../../../src/capabilities/bits.rs', lines 34:0-36:1

--- a/verification/extraction/lean/NonosExtraction/Refinement.lean
+++ b/verification/extraction/lean/NonosExtraction/Refinement.lean
@@ -54,6 +54,7 @@ def idx : capabilities.types.Capability → Nat
   | .Dma => 19
   | .Pio => 20
   | .InputSource => 21
+  | .TimeSet => 22
 
 theorem idx_lt_64 (cap : capabilities.types.Capability) : idx cap < 64 := by
   cases cap <;> decide


### PR DESCRIPTION
The verify.yml drift gate failed on main because c2af93db8 added a TimeSet capability (bit 22) after Caps.lean was generated. Regenerated with the pinned toolchain (charon 0.1.218 / aeneas nightly-2026.07.06): the enum gains the variant and its bit mapping; has/add/remove are unchanged. idx gets the TimeSet arm and every refinement theorem covers the new case through the existing uniform case split, with no proof body changed. Policy regenerates with zero drift. Extraction package rebuilt locally: 1703 jobs, 0 errors.

With this and #324 (virtio_net_proofs repair) merged, every job in the restored verify.yml is green.