### PR TITLE
ci: publish lean evidence like the benchmark workflow

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -4,6 +4,12 @@
 # Verifies the Lean 4 specification proofs. `lake build` reports 0 errors only
 # when every theorem checks. elan reads verification/lean/lean-toolchain to pick
 # the pinned Lean version, and lake generates its manifest on first build.
+#
+# A green run also publishes evidence, the same convention as the benchmark
+# and evidence workflows: the theorem inventory, the axiom closure of every
+# flagship theorem as printed by Lean itself, and the toolchain and commit it
+# was checked against. The axiom profile is also a gate: a `sorry` anywhere in
+# a profiled theorem's closure would surface as `sorryAx` and fail the run.
 name: lean
 on:
   push:
@@ -23,3 +29,31 @@ jobs:
       - name: Verify theorems (lake build)
         run: lake build
         working-directory: verification/lean
+      - name: Axiom profile and evidence
+        working-directory: verification/lean
+        run: |
+          set -euo pipefail
+          mkdir -p "$GITHUB_WORKSPACE/lean-evidence"
+          lake env lean AxiomProfile.lean | tee "$GITHUB_WORKSPACE/lean-evidence/axioms.txt"
+          if grep -q sorryAx "$GITHUB_WORKSPACE/lean-evidence/axioms.txt"; then
+            echo "::error::a flagship theorem depends on sorryAx"
+            exit 1
+          fi
+          grep -rn '^theorem ' Nonos/ > "$GITHUB_WORKSPACE/lean-evidence/theorems.txt"
+          {
+            echo "commit: $GITHUB_SHA"
+            echo "toolchain: $(cat lean-toolchain)"
+            echo "theorems: $(grep -rc '^theorem ' Nonos/ --include='*.lean' -h | paste -sd+ - | bc)"
+            echo "escape hatches:"
+            grep -rEn '\bsorry\b|\badmit\b|^axiom ' Nonos.lean Nonos/ \
+              | grep -v 'no sorry anywhere' || echo "  none"
+          } > "$GITHUB_WORKSPACE/lean-evidence/summary.txt"
+          cat "$GITHUB_WORKSPACE/lean-evidence/summary.txt"
+      - name: Upload lean evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: lean-proofs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: lean-evidence/
+          retention-days: 30
+          if-no-files-found: error

--- a/verification/lean/AxiomProfile.lean
+++ b/verification/lean/AxiomProfile.lean
@@ -1,0 +1,38 @@
+/-
+NONOS Operating System
+Copyright (C) 2026 NONOS Contributors
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version. See <https://www.gnu.org/licenses/>.
+
+The axiom profile of the specification layer, checked by Lean itself rather
+than asserted. `#print axioms` prints the exact axiom closure of a theorem:
+for every flagship theorem below the expected output names at most Lean's
+three standard axioms (propext, Classical.choice, Quot.sound) and never
+`sorryAx`, which is what a `sorry` would introduce. The CI lean job runs this
+file and publishes the output as evidence, so a green run leaves a record of
+what was proven and on what foundations, not just an exit code.
+-/
+
+import Nonos
+
+#print axioms Nonos.AntiRollback.no_rollback_after_boot
+#print axioms Nonos.Authorization.empty_token_denied
+#print axioms Nonos.BlockIO.accepted_request_stays_on_disk
+#print axioms Nonos.BootImage.accepted_region_stays_in_bounds
+#print axioms Nonos.Capability.attenuate_confines
+#print axioms Nonos.CapabilityBits.word_chain_never_widens
+#print axioms Nonos.Crypto.wrong_tag_rejected
+#print axioms Nonos.Ipc.zero_length_rejected
+#print axioms Nonos.Isolation.no_wx_page
+#print axioms Nonos.Loader.accepted_entry_inside_file
+#print axioms Nonos.NetParse.a_pointer_ends_the_walk
+#print axioms Nonos.Paging.confined_preserves_no_wx
+#print axioms Nonos.Path.leading_dotdot_neutralized
+#print axioms Nonos.Secure.every_trace_is_secure
+#print axioms Nonos.Stark.Field.mul_distributes_over_add
+#print axioms Nonos.Stark.Merkle.distinct_leaves_give_distinct_roots
+#print axioms Nonos.Syscall.decode_agrees_with_the_registry
+#print axioms Nonos.UsbHid.bindings_never_exceed_the_cap


### PR DESCRIPTION
Answers the question of why a green lean run adds no file while the benchmark run does: lean.yml was written as a bare pass/fail gate and never picked up the artifact convention the benchmark and evidence workflows use.

Now every lean run uploads `lean-proofs-<run>` (same pinned upload-artifact, 30-day retention, error on empty):

- `axioms.txt`: the axiom closure of one flagship theorem per module, printed by `#print axioms`, so the foundations are machine-reported rather than asserted. Current profile: at most propext / Quot.sound / Classical.choice everywhere; `Crypto.wrong_tag_rejected` depends on no axioms at all.
- `theorems.txt`: the full inventory, 111 theorems with file and line.
- `summary.txt`: commit, toolchain, counts, escape-hatch scan.

The profile doubles as a gate: a `sorry` in any profiled closure appears as `sorryAx` and fails the run, which the textual grep alone cannot guarantee.

Dry-run of the evidence block passed locally against main. When #331 (Attestation/Zeroization) lands, `AxiomProfile.lean` gets two more lines.