### PR TITLE
readme: document the machine-checked proof stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ i2c and PS/2. One command builds it, proves it and boots it.
 
 - [A microkernel, strictly](#a-microkernel-strictly)
 - [The chain of trust](#the-chain-of-trust)
+- [Proven, not asserted](#proven-not-asserted)
 - [Privacy by architecture](#privacy-by-architecture)
 - [Requirements](#requirements)
 - [Build and run](#build-and-run)
@@ -93,6 +94,35 @@ every arrow below is a cryptographic check that fails closed.
 The proofs bind each capsule's exact hash, its capability mask, its
 epoch and the policy root it was enrolled under. There is no trusted
 setup, proving key or ceremony trapdoor in the capsule attestation path.
+
+## Proven, not asserted
+
+The security-critical paths are not only tested, they are machine-checked,
+and the checks run against the code that actually ships rather than a
+separate model. The layers are documented in full under `verification/`:
+
+- **Runnable proofs.** Host crates include the real capsule and kernel
+  source (`#[path]`, only the syscall clock shimmed) and execute it: the
+  VFS store and path canonicalization, the protocol codec, caller
+  attestation, the Ethernet, IPv4 and UDP parsers, the driver ring walks,
+  the bootloader anti-rollback and the in-kernel STARK. Millions of
+  structured and random inputs assert the parsers never panic and never
+  break their invariants. Writing them found and fixed real bugs.
+- **Kani.** Over every bounded input, the untrusted-input surfaces are
+  proven panic-free and UB-free, together with the no-impersonation and
+  path-canonicalization theorems.
+- **Verus.** Theorems about the kernel's own capability bit operations,
+  page-table permission encoding and IPC length guards.
+- **Lean.** Specification-level theorems for the capability algebra, W^X
+  isolation, anti-rollback and path safety, refined onto the code proofs
+  above, with the capability theorems bound to the extracted Rust through
+  Charon and Aeneas. The Lean layer runs in CI on every push.
+
+Because the specs are the code the kernel runs, there is no
+model-implementation gap. `verification/README.md` and
+`verification/STATUS.md` carry the current status, the exact reproduction
+commands, and an honest account of what runs in CI versus what is
+reproduced locally.
 
 ## Privacy by architecture
 
@@ -259,6 +289,10 @@ claims are advertised again.
                          toolkit, libc
    nonos-data/           trust keystore (submodule): publisher keys,
                          signed manifests and proof trailers
+   verification/         machine-checked proofs and their status: Lean
+                         specifications, Charon/Aeneas extraction and Verus;
+                         the runnable and Kani proof crates live beside the
+                         code they prove, under userland/ and the bootloader
    abi/                  machine-readable contracts: syscalls, wire
                          format, schemas, the mainnet deployment
    nonos-mk/             capsule build include (submodule)


### PR DESCRIPTION
The main README describes the boot chain, the capsule model and the privacy architecture, but says nothing about the verification stack that now lives on main. This adds a "Proven, not asserted" section covering it.

The section mirrors `verification/README.md` word for word in its claims, so it does not overclaim:
- runnable proof crates that include and execute the real capsule and kernel source (VFS store, path canonicalization, protocol codec, caller attestation, the Ethernet/IPv4/UDP parsers, the driver ring walks, bootloader anti-rollback, the in-kernel STARK), with millions of fuzz inputs;
- Kani over the untrusted-input surfaces (panic-free, UB-free, no-impersonation, canonicalization);
- Verus on the kernel capability bit operations, page-permission encoding and IPC length guards;
- Lean specifications refined onto those code proofs, capability theorems bound to the extracted Rust via Charon and Aeneas, running in CI on every push.

The current CI-versus-local-reproducible status is deliberately left to `verification/STATUS.md` (kept current) rather than asserted in the README, so the README cannot go stale. Also adds a table-of-contents entry and the `verification/` tree to the repository map. Docs only.