### PR TITLE
stark: restore the Poseidon preimage AIR and the forgery fuzz

### DIFF
--- a/src/crypto/stark/air/mod.rs
+++ b/src/crypto/stark/air/mod.rs
@@ -34,6 +34,7 @@ mod multi_membership;
 mod permutation;
 mod permutation2;
 mod poseidon;
+mod poseidon_preimage;
 mod power_chain;
 mod prove;
 mod recursive_verifier;
@@ -55,6 +56,7 @@ pub use multi_membership::{MultiMembership, Opening};
 pub use permutation::Permutation;
 pub use permutation2::Permutation2;
 pub use poseidon::{Poseidon, RATE, WIDTH};
+pub use poseidon_preimage::{poseidon_preimage_trace, PoseidonPreimage};
 pub use power_chain::PowerChain;
 pub use prove::stark_prove;
 pub use recursive_verifier::{

--- a/src/crypto/stark/air/poseidon_preimage.rs
+++ b/src/crypto/stark/air/poseidon_preimage.rs
@@ -1,0 +1,206 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! A STARK proof of knowledge of a Poseidon-Goldilocks preimage. The trace is
+//! the permutation state, one row per round: row 0 is the input, row r+1 is the
+//! state after round r, so the thirty rounds occupy rows 0 through 30. Each
+//! transition enforces one real Poseidon round, `next = MDS(sbox(state + rc))`,
+//! with the round constants and the full-versus-partial S-box supplied as
+//! public periodic columns, so the constraint is the published permutation and
+//! not a stand-in. The boundary pins the input capacity lanes to zero, the
+//! sponge initialization, and the output rate lanes to a public digest. A
+//! satisfying trace is a preimage the proof never reveals.
+
+use super::super::field::Fp;
+use super::super::poseidon::constants::{
+    FULL_ROUNDS, MDS_CIRC, MDS_DIAG, N_ROUNDS, PARTIAL_ROUNDS, ROUND_CONSTANTS, WIDTH,
+};
+use super::spec::Air;
+use alloc::vec;
+use alloc::vec::Vec;
+
+/// Log2 of the padded trace length. Thirty rounds need thirty-one state rows,
+/// so the trace is padded to thirty-two.
+pub(crate) const LOG_TRACE: u32 = 5;
+const TRACE_LEN: usize = 1 << LOG_TRACE;
+/// The sponge rate; the first `RATE` lanes carry the absorbed input and, at the
+/// output, the digest.
+pub(crate) const RATE: usize = 8;
+/// The digest width pinned as public output.
+pub(crate) const DIGEST: usize = 4;
+
+/// Which rounds apply the S-box to every lane. The schedule is
+/// `FULL_ROUNDS / 2` full, then all partial, then `FULL_ROUNDS / 2` full, so a
+/// round is full exactly when it is outside the partial-round span.
+fn is_full_round(round: usize) -> bool {
+    let partial = FULL_ROUNDS / 2..FULL_ROUNDS / 2 + PARTIAL_ROUNDS;
+    !partial.contains(&round)
+}
+
+/// Prove knowledge of a Poseidon preimage whose output rate lanes are `digest`.
+pub struct PoseidonPreimage {
+    pub digest: [Fp; DIGEST],
+}
+
+impl PoseidonPreimage {
+    fn sbox(x: Fp) -> Fp {
+        let x2 = x.square();
+        let x4 = x2.square();
+        x * x2 * x4
+    }
+}
+
+/// One real Poseidon round applied to a state row, used to build the trace so
+/// the trace and the AIR transition are the same round function by
+/// construction.
+fn round(state: &[Fp; WIDTH], r: usize) -> [Fp; WIDTH] {
+    let full = is_full_round(r);
+    let mut post = [Fp::ZERO; WIDTH];
+    for i in 0..WIDTH {
+        let added = state[i] + Fp::from_u64(ROUND_CONSTANTS[r * WIDTH + i]);
+        post[i] = if i == 0 || full { PoseidonPreimage::sbox(added) } else { added };
+    }
+    let mut out = [Fp::ZERO; WIDTH];
+    for (r2, o) in out.iter_mut().enumerate() {
+        let mut acc = Fp::ZERO;
+        for (i, &c) in MDS_CIRC.iter().enumerate() {
+            acc = acc + post[(i + r2) % WIDTH] * Fp::from_u64(c);
+        }
+        acc = acc + post[r2] * Fp::from_u64(MDS_DIAG[r2]);
+        *o = acc;
+    }
+    out
+}
+
+/// Build the execution trace and the resulting digest for a rate input. The
+/// capacity lanes are initialized to zero, each round advances one row, and the
+/// padding rows repeat the output. Row-major, `WIDTH` columns.
+pub fn poseidon_preimage_trace(rate_input: [Fp; RATE]) -> (Vec<Fp>, [Fp; DIGEST]) {
+    let mut state = [Fp::ZERO; WIDTH];
+    state[..RATE].copy_from_slice(&rate_input);
+
+    let mut rows: Vec<[Fp; WIDTH]> = Vec::with_capacity(TRACE_LEN);
+    rows.push(state);
+    for r in 0..N_ROUNDS {
+        state = round(&state, r);
+        rows.push(state);
+    }
+    while rows.len() < TRACE_LEN {
+        rows.push(state);
+    }
+
+    let mut flat = Vec::with_capacity(TRACE_LEN * WIDTH);
+    for row in &rows {
+        flat.extend_from_slice(row);
+    }
+    let mut digest = [Fp::ZERO; DIGEST];
+    digest.copy_from_slice(&rows[N_ROUNDS][..DIGEST]);
+    (flat, digest)
+}
+
+impl Air for PoseidonPreimage {
+    fn log_trace_len(&self) -> u32 {
+        LOG_TRACE
+    }
+
+    fn trace_width(&self) -> usize {
+        WIDTH
+    }
+
+    fn window_size(&self) -> usize {
+        2
+    }
+
+    fn constraint_degree(&self) -> usize {
+        // The S-box is degree seven; the selector and constants are periodic
+        // scalars, so they do not raise the degree in the trace variables.
+        7
+    }
+
+    fn num_transition(&self) -> usize {
+        WIDTH
+    }
+
+    /// The periodic columns, one per row of the padded trace: the twelve round
+    /// constants, a full-round selector, and an active selector that is zero on
+    /// the padding rows so their transition is the identity.
+    fn periodic_columns(&self) -> Vec<Vec<Fp>> {
+        let mut cols: Vec<Vec<Fp>> = vec![vec![Fp::ZERO; TRACE_LEN]; WIDTH + 2];
+        for round in 0..N_ROUNDS {
+            for lane in 0..WIDTH {
+                cols[lane][round] = Fp::from_u64(ROUND_CONSTANTS[round * WIDTH + lane]);
+            }
+            cols[WIDTH][round] = if is_full_round(round) { Fp::ONE } else { Fp::ZERO };
+            cols[WIDTH + 1][round] = Fp::ONE;
+        }
+        cols
+    }
+
+    fn transition(&self, window: &[Fp], periodic: &[Fp]) -> Vec<Fp> {
+        let cur = &window[0..WIDTH];
+        let next = &window[WIDTH..2 * WIDTH];
+        let rc = &periodic[0..WIDTH];
+        let is_full = periodic[WIDTH];
+        let is_active = periodic[WIDTH + 1];
+
+        // Post S-box lane: on a full round every lane, on a partial round lane
+        // zero only. `is_full` selects between the two arms without a branch,
+        // matching the real permutation.
+        let mut post = [Fp::ZERO; WIDTH];
+        for i in 0..WIDTH {
+            let added = cur[i] + rc[i];
+            post[i] = if i == 0 {
+                Self::sbox(added)
+            } else {
+                is_full * Self::sbox(added) + (Fp::ONE - is_full) * added
+            };
+        }
+
+        // The MDS mix, `out[r] = sum_i post[(i + r) % W] * CIRC[i] + post[r] *
+        // DIAG[r]`, the same circulant plus diagonal the permutation uses.
+        let mut mixed = [Fp::ZERO; WIDTH];
+        for (r, m) in mixed.iter_mut().enumerate() {
+            let mut acc = Fp::ZERO;
+            for (i, &c) in MDS_CIRC.iter().enumerate() {
+                acc = acc + post[(i + r) % WIDTH] * Fp::from_u64(c);
+            }
+            acc = acc + post[r] * Fp::from_u64(MDS_DIAG[r]);
+            *m = acc;
+        }
+
+        // On active rows the next state is the round output; on padding rows it
+        // is the identity, so the padded tail carries no constraint of its own.
+        let mut out = Vec::with_capacity(WIDTH);
+        for i in 0..WIDTH {
+            let target = is_active * mixed[i] + (Fp::ONE - is_active) * cur[i];
+            out.push(next[i] - target);
+        }
+        out
+    }
+
+    fn boundary(&self) -> Vec<(usize, usize, Fp)> {
+        let mut b = Vec::with_capacity((WIDTH - RATE) + DIGEST);
+        // The input capacity lanes start at zero: the sponge initialization.
+        for lane in RATE..WIDTH {
+            b.push((lane, 0, Fp::ZERO));
+        }
+        // The output rate lanes at row N_ROUNDS are the public digest.
+        for (i, d) in self.digest.iter().enumerate() {
+            b.push((i, N_ROUNDS, *d));
+        }
+        b
+    }
+}

--- a/src/crypto/stark/air/types.rs
+++ b/src/crypto/stark/air/types.rs
@@ -27,6 +27,7 @@ use alloc::vec::Vec;
 /// One consistency query at position `p`: the DEEP polynomial value (opened
 /// against the FRI layer-zero commitment), each trace column at `p`, and the
 /// composition at `p`, each with a Merkle path to its commitment.
+#[derive(Clone)]
 pub struct StarkQuery {
     pub deep: Fp,
     pub deep_path: Vec<[u8; 32]>,
@@ -37,6 +38,7 @@ pub struct StarkQuery {
 }
 
 /// A complete STARK proof.
+#[derive(Clone)]
 pub struct StarkProof {
     pub trace_roots: Vec<[u8; 32]>,
     pub comp_root: [u8; 32],

--- a/userland/stark_proofs/src/forgery_tests.rs
+++ b/userland/stark_proofs/src/forgery_tests.rs
@@ -1,0 +1,285 @@
+// NONOS Operating System (AGPL-3.0-or-later)
+use crate::crypto::stark::air::{
+    poseidon_preimage_trace, stark_prove, stark_verify, PoseidonPreimage,
+};
+use crate::crypto::stark::field::Fp;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+// The STARK verifier makes two promises: it never accepts a forgery, and it
+// never panics on any input, however malformed. It reads an attacker-supplied
+// proof, so both must hold for every mutation of a valid proof and for wholly
+// arbitrary proof structures. These fuzzes exercise both over adversarial
+// input, the way the ZK verifier fuzz found real soundness bugs elsewhere in
+// the tree. The proof shape is the current DEEP-sampling one: a composition
+// commitment, an out-of-domain frame, and per-query DEEP, trace, and
+// composition openings.
+
+const QUERIES: usize = 24;
+
+fn xorshift(s: &mut u64) -> u64 {
+    *s ^= *s << 13;
+    *s ^= *s >> 7;
+    *s ^= *s << 17;
+    *s
+}
+
+fn honest() -> (PoseidonPreimage, crate::crypto::stark::air::StarkProof) {
+    let input: [Fp; 8] = core::array::from_fn(|i| Fp::from_u64(7 * i as u64 + 3));
+    let (trace, digest) = poseidon_preimage_trace(input);
+    let air = PoseidonPreimage { digest };
+    let proof = stark_prove(&air, &trace, QUERIES);
+    (air, proof)
+}
+
+// The honest proof must verify, so the rejections below are meaningful.
+#[test]
+fn the_reference_proof_verifies() {
+    let (air, proof) = honest();
+    assert!(stark_verify(&air, &proof, QUERIES), "the reference proof was rejected");
+}
+
+// Every single-field mutation of a valid proof must be rejected, and the
+// verifier must return rather than panic on each. The mutation space covers
+// each committed root byte, the composition commitment, the out-of-domain
+// frame, each opened field element (DEEP, trace, composition), and each
+// Merkle path node, plus the FRI openings.
+#[test]
+fn every_single_field_mutation_is_rejected_without_panic() {
+    let (air, base) = honest();
+    let mut s = 0x9e3779b97f4a7c15u64;
+    let mut checked = 0u64;
+
+    for _ in 0..7_000 {
+        let mut p = base.clone();
+        match xorshift(&mut s) % 12 {
+            0 => {
+                // Flip a bit in a trace column commitment.
+                let r = (xorshift(&mut s) as usize) % p.trace_roots.len();
+                let b = (xorshift(&mut s) as usize) % 32;
+                p.trace_roots[r][b] ^= 1 << (xorshift(&mut s) % 8);
+            }
+            1 => {
+                // Flip a bit in the composition commitment.
+                let b = (xorshift(&mut s) as usize) % 32;
+                p.comp_root[b] ^= 1 << (xorshift(&mut s) % 8);
+            }
+            2 => {
+                // Perturb an out-of-domain frame value.
+                if p.ood_frame.is_empty() {
+                    continue;
+                }
+                let f = (xorshift(&mut s) as usize) % p.ood_frame.len();
+                p.ood_frame[f] = p.ood_frame[f] + Fp::ONE;
+            }
+            3 => {
+                // Perturb a committed composition value at a query.
+                if p.queries.is_empty() {
+                    continue;
+                }
+                let q = (xorshift(&mut s) as usize) % p.queries.len();
+                p.queries[q].comp = p.queries[q].comp + Fp::ONE;
+            }
+            4 => {
+                // Perturb the DEEP opening value at a query.
+                let q = (xorshift(&mut s) as usize) % p.queries.len();
+                p.queries[q].deep = p.queries[q].deep + Fp::ONE;
+            }
+            5 => {
+                // Perturb a trace opening value at a query.
+                let q = (xorshift(&mut s) as usize) % p.queries.len();
+                if p.queries[q].trace.is_empty() {
+                    continue;
+                }
+                let w = (xorshift(&mut s) as usize) % p.queries[q].trace.len();
+                p.queries[q].trace[w] = p.queries[q].trace[w] + Fp::ONE;
+            }
+            6 => {
+                // Corrupt a Merkle path node on a trace opening.
+                let q = (xorshift(&mut s) as usize) % p.queries.len();
+                if p.queries[q].trace_paths.is_empty() {
+                    continue;
+                }
+                let wp = (xorshift(&mut s) as usize) % p.queries[q].trace_paths.len();
+                if p.queries[q].trace_paths[wp].is_empty() {
+                    continue;
+                }
+                let node = (xorshift(&mut s) as usize) % p.queries[q].trace_paths[wp].len();
+                let b = (xorshift(&mut s) as usize) % 32;
+                p.queries[q].trace_paths[wp][node][b] ^= 1;
+            }
+            7 => {
+                // Corrupt the composition Merkle path.
+                let q = (xorshift(&mut s) as usize) % p.queries.len();
+                if p.queries[q].comp_path.is_empty() {
+                    continue;
+                }
+                let node = (xorshift(&mut s) as usize) % p.queries[q].comp_path.len();
+                let b = (xorshift(&mut s) as usize) % 32;
+                p.queries[q].comp_path[node][b] ^= 1;
+            }
+            8 => {
+                // Corrupt the DEEP Merkle path.
+                let q = (xorshift(&mut s) as usize) % p.queries.len();
+                if p.queries[q].deep_path.is_empty() {
+                    continue;
+                }
+                let node = (xorshift(&mut s) as usize) % p.queries[q].deep_path.len();
+                let b = (xorshift(&mut s) as usize) % 32;
+                p.queries[q].deep_path[node][b] ^= 1;
+            }
+            9 => {
+                // Flip a bit in a FRI layer root.
+                if p.fri.roots.is_empty() {
+                    continue;
+                }
+                let r = (xorshift(&mut s) as usize) % p.fri.roots.len();
+                let b = (xorshift(&mut s) as usize) % 32;
+                p.fri.roots[r][b] ^= 1;
+            }
+            10 => {
+                // Perturb a FRI final-layer coefficient.
+                if p.fri.final_layer.is_empty() {
+                    continue;
+                }
+                let f = (xorshift(&mut s) as usize) % p.fri.final_layer.len();
+                p.fri.final_layer[f] = p.fri.final_layer[f] + Fp::ONE;
+            }
+            _ => {
+                // Perturb a FRI layer opening value.
+                if p.fri.queries.is_empty() {
+                    continue;
+                }
+                let q = (xorshift(&mut s) as usize) % p.fri.queries.len();
+                if p.fri.queries[q].layers.is_empty() {
+                    continue;
+                }
+                let l = (xorshift(&mut s) as usize) % p.fri.queries[q].layers.len();
+                p.fri.queries[q].layers[l].a = p.fri.queries[q].layers[l].a + Fp::ONE;
+            }
+        }
+        assert!(!stark_verify(&air, &p, QUERIES), "a mutated proof verified");
+        checked += 1;
+    }
+    assert!(checked > 4_000, "too few mutations exercised the verifier");
+}
+
+// Structurally malformed proofs, with truncated, extended, or reordered
+// vectors, must be rejected without panic. These exercise the verifier's
+// length and bounds guards, not just its algebra.
+#[test]
+fn structural_mutations_never_panic_and_never_verify() {
+    let (air, base) = honest();
+    let mut s = 0x1234_5678_9abc_def0u64;
+
+    for _ in 0..4_000 {
+        let mut p = base.clone();
+        match xorshift(&mut s) % 9 {
+            0 => {
+                p.trace_roots.pop();
+            }
+            1 => {
+                p.trace_roots.push([0u8; 32]);
+            }
+            2 => {
+                p.queries.pop();
+            }
+            3 => {
+                if let Some(q) = p.queries.first().cloned() {
+                    p.queries.push(q);
+                }
+            }
+            4 => {
+                if let Some(q) = p.queries.first_mut() {
+                    q.trace.pop();
+                }
+            }
+            5 => {
+                if let Some(q) = p.queries.first_mut() {
+                    q.trace_paths.pop();
+                }
+            }
+            6 => {
+                p.ood_frame.pop();
+            }
+            7 => {
+                p.fri.roots.pop();
+            }
+            _ => {
+                p.fri.final_layer.clear();
+            }
+        }
+        // No assertion on the value beyond not panicking, except that an
+        // accept would be a soundness break; a malformed proof must never
+        // verify.
+        assert!(!stark_verify(&air, &p, QUERIES), "a malformed proof verified");
+    }
+}
+
+// A proof assembled from arbitrary bytes must be rejected and must not panic.
+#[test]
+fn arbitrary_proofs_are_rejected_without_panic() {
+    use crate::crypto::stark::air::{StarkProof, StarkQuery};
+    use crate::crypto::stark::fri::{FriProof, LayerOpening, QueryProof};
+
+    let (air, _) = honest();
+    let mut s = 0xdead_beef_cafe_babeu64;
+
+    for _ in 0..2_000 {
+        let n_roots = (xorshift(&mut s) % 6) as usize;
+        let trace_roots: Vec<[u8; 32]> = (0..n_roots)
+            .map(|_| {
+                let mut r = [0u8; 32];
+                for b in r.iter_mut() {
+                    *b = (xorshift(&mut s) & 0xff) as u8;
+                }
+                r
+            })
+            .collect();
+
+        let mut comp_root = [0u8; 32];
+        for b in comp_root.iter_mut() {
+            *b = (xorshift(&mut s) & 0xff) as u8;
+        }
+
+        let ood_frame: Vec<Fp> =
+            (0..(xorshift(&mut s) % 30) as usize).map(|_| Fp::from_u64(xorshift(&mut s))).collect();
+
+        let n_fri_roots = (xorshift(&mut s) % 6) as usize;
+        let fri = FriProof {
+            roots: (0..n_fri_roots).map(|_| [0u8; 32]).collect(),
+            final_layer: (0..(xorshift(&mut s) % 8) as usize)
+                .map(|_| Fp::from_u64(xorshift(&mut s)))
+                .collect(),
+            queries: (0..(xorshift(&mut s) % 6) as usize)
+                .map(|_| QueryProof {
+                    layers: (0..(xorshift(&mut s) % 6) as usize)
+                        .map(|_| LayerOpening {
+                            a: Fp::from_u64(xorshift(&mut s)),
+                            a_path: Vec::new(),
+                            b: Fp::from_u64(xorshift(&mut s)),
+                            b_path: Vec::new(),
+                        })
+                        .collect(),
+                })
+                .collect(),
+        };
+
+        let queries: Vec<StarkQuery> = (0..(xorshift(&mut s) % 6) as usize)
+            .map(|_| StarkQuery {
+                deep: Fp::from_u64(xorshift(&mut s)),
+                deep_path: Vec::new(),
+                trace: (0..(xorshift(&mut s) % 30) as usize)
+                    .map(|_| Fp::from_u64(xorshift(&mut s)))
+                    .collect(),
+                trace_paths: Vec::new(),
+                comp: Fp::from_u64(xorshift(&mut s)),
+                comp_path: Vec::new(),
+            })
+            .collect();
+
+        let p = StarkProof { trace_roots, comp_root, ood_frame, fri, queries };
+        assert!(!stark_verify(&air, &p, QUERIES), "an arbitrary proof verified");
+    }
+}

--- a/userland/stark_proofs/src/lib.rs
+++ b/userland/stark_proofs/src/lib.rs
@@ -11,6 +11,8 @@ mod air_tests;
 #[cfg(test)]
 mod field_tests;
 #[cfg(test)]
+mod forgery_tests;
+#[cfg(test)]
 mod fri_poseidon_tests;
 #[cfg(test)]
 mod fri_tests;


### PR DESCRIPTION
The final piece of the STARK landing. When the stack merged as #336, two parts of the original Poseidon work (#300) could not come along:

- the width-12 Poseidon-Goldilocks **preimage AIR** shared the `air/poseidon.rs` filename with the width-8 recursion gadget, and
- the verifier **forgery fuzz** was written against the pre-DEEP proof structs (it referenced `StarkQuery.window` / `window_paths` and a `StarkProof` without `comp_root` / `ood_frame`), so it no longer compiled.

Both are restored here rather than dropped:

- **`air/poseidon_preimage.rs`** — the preimage AIR over the width-12 Poseidon constants already on main, exported as `PoseidonPreimage` and `poseidon_preimage_trace` (no collision with the width-8 `Poseidon`).
- **`forgery_tests.rs`** — modernized to the current `StarkProof` / `StarkQuery` shape. The mutation space is now broader than the original: it also perturbs the composition commitment (`comp_root`), the out-of-domain frame (`ood_frame`), and the per-query DEEP opening and its Merkle path, none of which existed when the fuzz was first written. ~13k mutations per run, all rejected without panic.
- `StarkProof` and `StarkQuery` gain a `Clone` derive, which the mutation fuzz needs to perturb a base proof.

Verified: 132 stark_proofs tests green (up from 128), clippy -D warnings clean, fmt clean, kernel x86_64-nonos builds warning-free.

With this, every line of the original 34-PR stack is accounted for on main. Nothing deferred, nothing lost.