### PR TITLE
fix(installer): correct SpawnBroker cap literal after bit move (0x400019 → 0x800019)

### DIFF
--- a/src/userspace/capsule_installer/spawn.rs
+++ b/src/userspace/capsule_installer/spawn.rs
@@ -32,7 +32,7 @@ const REPLY_PORT: u32 = 4113;
 const TARGET_TRIPLE: &str = "x86_64-nonos-user";
 // CoreExec | IPC | Memory | SpawnBroker; kept hand-synced with
 // userland/capsule_installer/Capsule.mk's CAPSULE_REQUIRED_CAPS.
-const REQUIRED_CAPS: u64 = 0x400019;
+const REQUIRED_CAPS: u64 = 0x800019;
 
 pub fn spawn_installer_capsule() -> Result<(), SpawnError> {
     let trust_anchor = decode_trust_anchor(BAKED_TRUST_ANCHOR_POLICY)

--- a/userland/capsule_installer/Capsule.mk
+++ b/userland/capsule_installer/Capsule.mk
@@ -13,11 +13,11 @@ CAPSULE_FEATURE          := nonos-capsule-installer
 CAPSULE_NAMESPACE        := systems.nonos.installer
 CAPSULE_SERVICE_ENDPOINT := service:4112:installer
 CAPSULE_REPLY_ENDPOINT   := reply:4113:endpoint.4294967313
-# CoreExec | IPC | Memory | SpawnBroker = 0x01 | 0x08 | 0x10 | 0x400000 = 0x400019
+# CoreExec | IPC | Memory | SpawnBroker = 0x01 | 0x08 | 0x10 | 0x800000 = 0x800019
 # SpawnBroker lets this installer attribute a capsule it loads on a
 # requester's behalf to that requester's pid instead of its own, so the
 # requester can mk_wait/mk_kill/mk_proc_input/mk_proc_output the child.
-CAPSULE_REQUIRED_CAPS    := 0x400019
+CAPSULE_REQUIRED_CAPS    := 0x800019
 CAPSULE_KERNEL_MIRROR    := src/userspace/capsule_installer
 
 include nonos-mk/capsule.mk


### PR DESCRIPTION
## Bug

The main-merge in #341 resolved a capability-bit collision by moving `SpawnBroker` from bit `0x400000` to `0x800000` (main's new `TimeSet` kept `0x400000`). But the installer's required-caps literals were left at the old `0x400019` in **both** hand-synced sites:

- `userland/capsule_installer/Capsule.mk` → `CAPSULE_REQUIRED_CAPS := 0x400019` (feeds the signed manifest)
- `src/userspace/capsule_installer/spawn.rs` → `REQUIRED_CAPS = 0x400019` (kernel-side spawner check)

Since `0x400000` is now `TimeSet`, the installer is granted **TimeSet instead of SpawnBroker**. `AttestedParent::attest()` checks the caller holds `SpawnBroker` (`0x800000`), which the installer no longer has, so `on_behalf_of` attribution fails closed to caller-as-parent — regressing `nox exec` (external-capsule jobs): the child is re-parented to the installer, and the terminal's `mk_wait`/`mk_kill`/`mk_proc_input` return EPERM/ECHILD. This is exactly the bug #341's T21a work fixed, silently reintroduced by an incomplete merge commit (the two non-conflicted hand-sync edits were made in the working tree but never staged).

## Fix

Set both literals to `0x800019` = `CoreExec | IPC | Memory | SpawnBroker` = `0x1 | 0x8 | 0x10 | 0x800000`.

## Why CI didn't catch it

The source compiles either way — the value only matters at capability-grant time during a live boot, and there is no CI boot lane exercising the installer's SpawnBroker grant (PR #227 removed the tests job). Verified locally: a full `nonos-mk-terminal-sign` build with the seeded installer re-signs its manifest with `required_caps` = `0x800019` (byte-checked at manifest offset 120, big-endian).

