### PR TITLE
fix: resolve installer & process_manager endpoint-registration collisions

### DIFF
--- a/src/userspace/capsule_installer/spawn.rs
+++ b/src/userspace/capsule_installer/spawn.rs
@@ -27,7 +27,7 @@ use crate::security::nonos_trust_anchor::{
 
 const SERVICE_NAME: &str = "installer";
 const SERVICE_PORT: u32 = 4112;
-const REPLY_INBOX: &str = "endpoint.4294967313";
+const REPLY_INBOX: &str = "endpoint.installer.reply";
 const REPLY_PORT: u32 = 4113;
 const TARGET_TRIPLE: &str = "x86_64-nonos-user";
 // CoreExec | IPC | Memory | SpawnBroker; kept hand-synced with

--- a/src/userspace/capsule_process_manager/spawn.rs
+++ b/src/userspace/capsule_process_manager/spawn.rs
@@ -29,9 +29,9 @@ use crate::security::nonos_trust_anchor::{
 use crate::kernel_core::process_spawn::capsule_spawn::SpawnError;
 
 const SERVICE_NAME: &str = "app.process_manager";
-const SERVICE_PORT: u32 = 4730;
+const SERVICE_PORT: u32 = 4736;
 const REPLY_INBOX: &str = "endpoint.app.process_manager.reply";
-const REPLY_PORT: u32 = 4731;
+const REPLY_PORT: u32 = 4737;
 const TARGET_TRIPLE: &str = "x86_64-nonos-user";
 
 pub fn spawn_process_manager_capsule() -> Result<(), SpawnError> {

--- a/userland/capsule_installer/Capsule.mk
+++ b/userland/capsule_installer/Capsule.mk
@@ -12,7 +12,7 @@ CAPSULE_BIN_NAME         := installer
 CAPSULE_FEATURE          := nonos-capsule-installer
 CAPSULE_NAMESPACE        := systems.nonos.installer
 CAPSULE_SERVICE_ENDPOINT := service:4112:installer
-CAPSULE_REPLY_ENDPOINT   := reply:4113:endpoint.4294967313
+CAPSULE_REPLY_ENDPOINT   := reply:4113:endpoint.installer.reply
 # CoreExec | IPC | Memory | SpawnBroker = 0x01 | 0x08 | 0x10 | 0x800000 = 0x800019
 # SpawnBroker lets this installer attribute a capsule it loads on a
 # requester's behalf to that requester's pid instead of its own, so the

--- a/userland/capsule_process_manager/Capsule.mk
+++ b/userland/capsule_process_manager/Capsule.mk
@@ -5,8 +5,8 @@ CAPSULE_DIR              := userland/capsule_process_manager
 CAPSULE_BIN_NAME         := process_manager
 CAPSULE_FEATURE          := nonos-capsule-process-manager
 CAPSULE_NAMESPACE        := systems.nonos.app.process_manager
-CAPSULE_SERVICE_ENDPOINT := service:4730:app.process_manager
-CAPSULE_REPLY_ENDPOINT   := reply:4731:endpoint.app.process_manager.reply
+CAPSULE_SERVICE_ENDPOINT := service:4736:app.process_manager
+CAPSULE_REPLY_ENDPOINT   := reply:4737:endpoint.app.process_manager.reply
 # CoreExec|IPC|Memory|GraphicsDisplayQuery|GraphicsSurfaceCreate
 CAPSULE_REQUIRED_CAPS    := 0x1819
 CAPSULE_KERNEL_MIRROR    := src/userspace/capsule_process_manager


### PR DESCRIPTION
## Problem

Two capsules fail endpoint registration at boot because they reuse another capsule's hand-assigned reply endpoint. At `install.rs:36` each capsule's reply inbox is registered under a shared `pid=0` sentinel, where the rule rejects on **same-name-OR-same-port**. The loser hits `EndpointCollision`, never reaches the runqueue, and any service it holds is unreachable.

- **Bug A (installer ↔ nvme):** the `installer` reused NVMe's reply-inbox name `endpoint.4294967313`. Under `microkernel-full-gui` (nvme feature on), `driver.nvme0` spawns first and wins, so the installer loses registration → its **SpawnBroker is unreachable** → every `nox exec` / `nox install` has no broker. This is the `docs/audits/2026-07-11-terminal-capability-map-and-roadmap.md` §7 blocker.
- **Bug B (clock ↔ process_manager):** both hardcoded `SERVICE_PORT=4730 / REPLY_PORT=4731`. `clock` wins, so `process_manager` fails registration in **both** GUI profiles.

## Fix

Same defect class (duplicated reply endpoints); two independent, surgical changes — each updates the kernel spawner and its hand-synced userland manifest together:

| Commit | Change |
|---|---|
| `fix(installer)` | reply inbox `endpoint.4294967313` → `endpoint.installer.reply` (port 4113 kept, globally unique) |
| `fix(process_manager)` | ports `4730/4731` → free pair `4736/4737` |

No capability lines touched; service port 4112 (installer) is unchanged, so callers are unaffected.


