### PR TITLE
verification/lean: record the mechanism_proofs code bindings

### DIFF
--- a/verification/lean/Nonos/Bitmap.lean
+++ b/verification/lean/Nonos/Bitmap.lean
@@ -12,6 +12,13 @@ The theorems below show setting a bit allocates its index, clearing frees it,
 set-then-clear frees the index, and setting or clearing one index leaves every
 other unchanged, so bit operations affect exactly their own index and no
 neighbour.
+
+The kernel's frame bitmap keeps the bit-index arithmetic in
+`src/memory/phys/bitmap/index.rs`, which `bit_ops.rs` calls. The
+`mechanism_proofs` crate includes that file and checks, with differential tests
+and Kani, that a mask selects exactly one bit and that the byte and in-byte
+position reconstruct the index, so the addressing this model relies on is proven
+of the code the allocator runs.
 -/
 
 namespace Nonos.Bitmap

--- a/verification/lean/Nonos/Bounds.lean
+++ b/verification/lean/Nonos/Bounds.lean
@@ -12,6 +12,12 @@ buffer of `size` bytes is safe when it stays inside the buffer. The theorems
 below show a safe access's first and last bytes are in range, every index of a
 safe access lands inside the buffer, shrinking a safe access stays safe, and an
 oversized access is refused, the spatial-safety facts the copy paths rely on.
+
+The kernel's ELF relocator gates each write with the range test in
+`src/elf/reloc/apply/range.rs`, which `in_segment` delegates to. The
+`mechanism_proofs` crate includes that file and proves with Kani that an
+in-range access sits wholly inside the segment with neither end overflowing, so
+this spatial check is proven of the code the loader runs.
 -/
 
 namespace Nonos.Bounds

--- a/verification/lean/Nonos/Interval.lean
+++ b/verification/lean/Nonos/Interval.lean
@@ -13,6 +13,13 @@ every memory-safety argument in the kernel rests on, paging, the IOMMU, the
 heap, capsule isolation. The theorems below are the full algebra: containment
 is a partial order, disjoint regions share no address, a subregion never
 exceeds its parent, and adjacency composes. All machine-checked.
+
+The kernel's `MemRegion` keeps this range algebra in
+`src/memory/region/overlap.rs`, which its `overlaps`, `contains` and
+`contains_range` methods delegate to. The `mechanism_proofs` crate includes that
+file and checks, with differential tests and Kani, that overlap is symmetric and
+is exactly the negation of disjointness, so the core of this algebra is proven
+of the code the memory manager runs.
 -/
 
 namespace Nonos.Interval

--- a/verification/lean/Nonos/Mmio.lean
+++ b/verification/lean/Nonos/Mmio.lean
@@ -12,6 +12,12 @@ windows; a register access is permitted only if it lands in a granted window.
 The theorems below show a driver with no grant can touch no register, a
 permitted access lies inside a granted window, and an access outside every
 window is denied, so a driver never pokes a device it was not handed.
+
+The kernel admits a window through `validate_mmio_region`, whose validity
+arithmetic lives in `src/drivers/security/mmio_range.rs`. The `mechanism_proofs`
+crate includes that file and proves with Kani that an admitted window is
+non-empty and does not wrap the address space, so the well-formedness this model
+assumes of a window is proven of the code that admits it.
 -/
 
 namespace Nonos.Mmio

--- a/verification/lean/Nonos/Nonce.lean
+++ b/verification/lean/Nonos/Nonce.lean
@@ -11,6 +11,12 @@ Nonce freshness. A nonce generator hands out a strictly increasing sequence.
 The theorems below show each issue advances the counter, an issued nonce is
 strictly below the next one, and two successive issues are distinct, so a
 nonce is never reused, the freshness the attestation and replay defenses need.
+
+The kernel's resource tokens build a nonce with the composition in
+`src/capabilities/resource/nonce_compose.rs`, which `next_nonce` delegates to.
+The `mechanism_proofs` crate includes that file and proves with Kani that the
+monotonic counter is recoverable from the low 32 bits, so distinct counters
+never collide, the no-reuse property proven of the code the token runs.
 -/
 
 namespace Nonos.Nonce

--- a/verification/lean/Nonos/Priority.lean
+++ b/verification/lean/Nonos/Priority.lean
@@ -11,6 +11,12 @@ Scheduling priority. A higher priority preempts a lower one. The theorems below
 show preemption is a strict order, irreflexive, transitive, asymmetric, and
 total up to equal priority, and that a maximal-priority task is preempted by no
 one, so the highest-priority runnable task always runs.
+
+The kernel assigns each task a numeric order with
+`SchedAttr::effective_priority` in `src/process/scheduler/policy_types.rs`. The
+`mechanism_proofs` crate calls that method directly and proves with Kani that
+deadline tops the order and idle bottoms it, so the strict stratification this
+model relies on is proven of the code the scheduler runs.
 -/
 
 namespace Nonos.Priority

--- a/verification/lean/Nonos/Quota.lean
+++ b/verification/lean/Nonos/Quota.lean
@@ -11,6 +11,12 @@ Resource quotas. A quota tracks used units against a cap. Acquire succeeds only
 if it keeps use within the cap; release lowers use. The theorems below show the
 in-bounds invariant survives any single operation and any whole sequence of
 acquires, a capsule can never be charged past its quota.
+
+The kernel's resource token gates a charge with the check in
+`src/capabilities/resource/limits.rs`, which `has_bytes` and `has_ops` delegate
+to. The `mechanism_proofs` crate includes that file and proves with Kani that a
+request is admitted exactly when it is within the remaining budget, so the gate
+this model relies on is proven of the code the token runs.
 -/
 
 namespace Nonos.Quota

--- a/verification/lean/Nonos/Refcount.lean
+++ b/verification/lean/Nonos/Refcount.lean
@@ -12,6 +12,12 @@ increment always leaves it live, decrement of a zero count cannot underflow
 (saturating at zero, matching the kernel's checked decrement), a count of one
 decrements to dead exactly, and increment/decrement round-trips, so an object
 is freed exactly when its last reference drops.
+
+The kernel's page table runs the checked decrement in
+`src/memory/page_info/manager/refcount.rs`, which `decrement_ref_count`
+delegates to. The `mechanism_proofs` crate includes that file and proves with
+Kani that a decrement never underflows, so the no-underflow property is proven
+of the code the page table runs.
 -/
 
 namespace Nonos.Refcount

--- a/verification/lean/Nonos/Ring.lean
+++ b/verification/lean/Nonos/Ring.lean
@@ -12,6 +12,13 @@ adds one only if there is room; pop removes one. The theorems below show the
 count never exceeds the capacity, a full ring refuses a push, and the in-bounds
 invariant survives any sequence of pushes and pops, so a DMA or IPC ring never
 overruns its backing memory.
+
+The kernel's input ring runs the index arithmetic from
+`src/kernel_core/surface_registry/ring_math.rs` at its post and drain sites. The
+`mechanism_proofs` crate includes that file and proves with Kani that a wrapped
+index stays within the capacity and that a full ring is detected when the head
+would reach the tail, so the addressing this model relies on is proven of the
+code the ring runs.
 -/
 
 namespace Nonos.Ring

--- a/verification/lean/Nonos/Timer.lean
+++ b/verification/lean/Nonos/Timer.lean
@@ -12,6 +12,12 @@ tick never moves time backward, a positive tick moves it strictly forward, and
 any sequence of ticks is monotone, so a timestamp read later is never earlier
 than one read before, the property scheduling and anti-rollback deadlines rely
 on.
+
+The load balancer's elapsed-tick test in `src/process/scheduler/smp/interval.rs`,
+which `should_balance` delegates to, is the same monotone comparison over a
+saturating subtraction. The `mechanism_proofs` crate includes that file and
+proves with Kani that it saturates on a tick wraparound, so the elapsed
+computation is proven of the code the scheduler runs.
 -/
 
 namespace Nonos.Timer

--- a/verification/lean/Nonos/Vma.lean
+++ b/verification/lean/Nonos/Vma.lean
@@ -12,6 +12,11 @@ base for a size. Two areas are disjoint when one ends at or before the other
 begins. The theorems below show disjoint areas do not overlap and share no
 address, overlap is symmetric, and an address inside an area lies within its
 bounds, so a mapping placed in a disjoint hole cannot alias an existing one.
+
+The kernel's `MemRegion` runs this range algebra from
+`src/memory/region/overlap.rs`, and the `mechanism_proofs` crate checks the
+symmetry and the disjointness negation against it with differential tests and
+Kani, so the aliasing argument is proven of the code the memory manager runs.
 -/
 
 namespace Nonos.Vma

--- a/verification/lean/REFINEMENT.md
+++ b/verification/lean/REFINEMENT.md
@@ -37,6 +37,8 @@ contract the code owes. Moving an entry to level 2 or 1 is tracked work.
 | `Buddy` | `src/memory/buddy_alloc` | `userland/mechanism_proofs` (differential tests and Kani over the order and buddy-address arithmetic in `constants/helpers.rs`) |
 | `Bitmap` | `src/memory/phys/bitmap` | `userland/mechanism_proofs` (differential tests and Kani over the bit-index arithmetic in `index.rs`) |
 | `Interval`, `Vma` | `src/memory/region` | `userland/mechanism_proofs` (differential tests and Kani over the range algebra in `overlap.rs`) |
+| `Timer` | `src/process/scheduler/smp` | `userland/mechanism_proofs` (differential tests and Kani over the elapsed-tick test in `interval.rs`) |
+| `Quota` | `src/capabilities/resource` | `userland/mechanism_proofs` (differential tests and Kani over the check in `limits.rs`) |
 | `Isolation`, `Paging` | `src/memory/paging` | `userland/kernel_proofs` (page permission W xor X, over all bit patterns) |
 | `Loader` | `src/elf` loader | `userland/kernel_proofs` (segment bounds) |
 | `Syscall` | `src/syscall` numbers | `userland/kernel_proofs` (decode totality and registry agreement) |
@@ -55,11 +57,11 @@ kernel subsystem it abstracts. The mechanical tie to that code is the backlog.
 | `Rwlock` | `src/sys/sync/irq_rwlock` |
 | `Spinlock` | `spin::Mutex` wrappers in `src/sys/sync` |
 | `PageTable`, `Bounds` | `src/memory` address space and paging |
-| `MemGrant`, `Quota`, `Refcount`, `Heap`, `Zeroize` | `src/memory` grants and allocation |
+| `MemGrant`, `Refcount`, `Heap`, `Zeroize` | `src/memory` grants and allocation |
 | `Iommu`, `Mmio` | device DMA and register windows under `src/hardware` |
 | `Tlb` | TLB shootdown under `src/memory` |
 | `CapTable`, `Dispatch` | capability tables and the syscall dispatch under `src/syscall` |
-| `Scheduler`, `Priority`, `Timer`, `Ring` | `src/process/scheduler` |
+| `Scheduler`, `Priority`, `Ring` | `src/process/scheduler` |
 | `Epoch` | RCU-style reclamation across the kernel |
 | `Signal` | signal delivery |
 | `Reaper` | the process table |

--- a/verification/lean/REFINEMENT.md
+++ b/verification/lean/REFINEMENT.md
@@ -36,6 +36,7 @@ contract the code owes. Moving an entry to level 2 or 1 is tracked work.
 | `Seqlock` | `src/sys/sync/seqlock` | `userland/sync_proofs` (differential tests and Kani over the sequence discipline in `pure.rs`) |
 | `Buddy` | `src/memory/buddy_alloc` | `userland/mechanism_proofs` (differential tests and Kani over the order and buddy-address arithmetic in `constants/helpers.rs`) |
 | `Bitmap` | `src/memory/phys/bitmap` | `userland/mechanism_proofs` (differential tests and Kani over the bit-index arithmetic in `index.rs`) |
+| `Interval`, `Vma` | `src/memory/region` | `userland/mechanism_proofs` (differential tests and Kani over the range algebra in `overlap.rs`) |
 | `Isolation`, `Paging` | `src/memory/paging` | `userland/kernel_proofs` (page permission W xor X, over all bit patterns) |
 | `Loader` | `src/elf` loader | `userland/kernel_proofs` (segment bounds) |
 | `Syscall` | `src/syscall` numbers | `userland/kernel_proofs` (decode totality and registry agreement) |
@@ -53,7 +54,7 @@ kernel subsystem it abstracts. The mechanical tie to that code is the backlog.
 | `Mutex` | `src/sys/sync/irq_mutex` |
 | `Rwlock` | `src/sys/sync/irq_rwlock` |
 | `Spinlock` | `spin::Mutex` wrappers in `src/sys/sync` |
-| `Vma`, `Interval`, `PageTable`, `Bounds` | `src/memory` address space and paging |
+| `PageTable`, `Bounds` | `src/memory` address space and paging |
 | `MemGrant`, `Quota`, `Refcount`, `Heap`, `Zeroize` | `src/memory` grants and allocation |
 | `Iommu`, `Mmio` | device DMA and register windows under `src/hardware` |
 | `Tlb` | TLB shootdown under `src/memory` |

--- a/verification/lean/REFINEMENT.md
+++ b/verification/lean/REFINEMENT.md
@@ -35,6 +35,7 @@ contract the code owes. Moving an entry to level 2 or 1 is tracked work.
 | `Semaphore` | `src/sys/sync/semaphore` | `userland/sync_proofs` (differential tests and Kani over the permit arithmetic in `pure.rs`) |
 | `Seqlock` | `src/sys/sync/seqlock` | `userland/sync_proofs` (differential tests and Kani over the sequence discipline in `pure.rs`) |
 | `Buddy` | `src/memory/buddy_alloc` | `userland/mechanism_proofs` (differential tests and Kani over the order and buddy-address arithmetic in `constants/helpers.rs`) |
+| `Bitmap` | `src/memory/phys/bitmap` | `userland/mechanism_proofs` (differential tests and Kani over the bit-index arithmetic in `index.rs`) |
 | `Isolation`, `Paging` | `src/memory/paging` | `userland/kernel_proofs` (page permission W xor X, over all bit patterns) |
 | `Loader` | `src/elf` loader | `userland/kernel_proofs` (segment bounds) |
 | `Syscall` | `src/syscall` numbers | `userland/kernel_proofs` (decode totality and registry agreement) |
@@ -64,7 +65,7 @@ kernel subsystem it abstracts. The mechanical tie to that code is the backlog.
 | `Nonce`, `Rng` | entropy and nonce issuance under `src/crypto` |
 | `Endpoint`, `Fd`, `Vfs` | IPC endpoints, descriptor tables, and the VFS |
 | `TokenBucket` | rate limiting in the network path |
-| `Cow`, `Bitmap` | copy-on-write pages and allocation bitmaps |
+| `Cow` | copy-on-write pages |
 
 `Futex` already has a code-bound proof: the wait-queue discipline in
 `src/syscall/microkernel/futex/queue.rs`, which `wait.rs` and `wake.rs` call, is

--- a/verification/lean/REFINEMENT.md
+++ b/verification/lean/REFINEMENT.md
@@ -44,6 +44,7 @@ contract the code owes. Moving an entry to level 2 or 1 is tracked work.
 | `Refcount` | `src/memory/page_info` | `userland/mechanism_proofs` (differential tests and Kani over the decrement in `refcount.rs`) |
 | `Nonce` | `src/capabilities/resource` | `userland/mechanism_proofs` (differential tests and Kani over the composition in `nonce_compose.rs`) |
 | `Bounds` | `src/elf/reloc` | `userland/mechanism_proofs` (differential tests and Kani over the range test in `range.rs`) |
+| `Priority` | `src/process/scheduler` | `userland/mechanism_proofs` (differential tests and Kani over `SchedAttr::effective_priority`) |
 | `Isolation`, `Paging` | `src/memory/paging` | `userland/kernel_proofs` (page permission W xor X, over all bit patterns) |
 | `Loader` | `src/elf` loader | `userland/kernel_proofs` (segment bounds) |
 | `Syscall` | `src/syscall` numbers | `userland/kernel_proofs` (decode totality and registry agreement) |
@@ -66,7 +67,7 @@ kernel subsystem it abstracts. The mechanical tie to that code is the backlog.
 | `Iommu` | device DMA windows under `src/hardware` |
 | `Tlb` | TLB shootdown under `src/memory` |
 | `CapTable`, `Dispatch` | capability tables and the syscall dispatch under `src/syscall` |
-| `Scheduler`, `Priority` | `src/process/scheduler` |
+| `Scheduler` | `src/process/scheduler` |
 | `Epoch` | RCU-style reclamation across the kernel |
 | `Signal` | signal delivery |
 | `Reaper` | the process table |

--- a/verification/lean/REFINEMENT.md
+++ b/verification/lean/REFINEMENT.md
@@ -41,6 +41,9 @@ contract the code owes. Moving an entry to level 2 or 1 is tracked work.
 | `Quota` | `src/capabilities/resource` | `userland/mechanism_proofs` (differential tests and Kani over the check in `limits.rs`) |
 | `Ring` | `src/kernel_core/surface_registry` | `userland/mechanism_proofs` (differential tests and Kani over the index wrap in `ring_math.rs`) |
 | `Mmio` | `src/drivers/security` | `userland/mechanism_proofs` (differential tests and Kani over the window check in `mmio_range.rs`) |
+| `Refcount` | `src/memory/page_info` | `userland/mechanism_proofs` (differential tests and Kani over the decrement in `refcount.rs`) |
+| `Nonce` | `src/capabilities/resource` | `userland/mechanism_proofs` (differential tests and Kani over the composition in `nonce_compose.rs`) |
+| `Bounds` | `src/elf/reloc` | `userland/mechanism_proofs` (differential tests and Kani over the range test in `range.rs`) |
 | `Isolation`, `Paging` | `src/memory/paging` | `userland/kernel_proofs` (page permission W xor X, over all bit patterns) |
 | `Loader` | `src/elf` loader | `userland/kernel_proofs` (segment bounds) |
 | `Syscall` | `src/syscall` numbers | `userland/kernel_proofs` (decode totality and registry agreement) |
@@ -58,8 +61,8 @@ kernel subsystem it abstracts. The mechanical tie to that code is the backlog.
 | `Mutex` | `src/sys/sync/irq_mutex` |
 | `Rwlock` | `src/sys/sync/irq_rwlock` |
 | `Spinlock` | `spin::Mutex` wrappers in `src/sys/sync` |
-| `PageTable`, `Bounds` | `src/memory` address space and paging |
-| `MemGrant`, `Refcount`, `Heap`, `Zeroize` | `src/memory` grants and allocation |
+| `PageTable` | `src/memory` address space and paging |
+| `MemGrant`, `Heap`, `Zeroize` | `src/memory` grants and allocation |
 | `Iommu` | device DMA windows under `src/hardware` |
 | `Tlb` | TLB shootdown under `src/memory` |
 | `CapTable`, `Dispatch` | capability tables and the syscall dispatch under `src/syscall` |
@@ -67,7 +70,7 @@ kernel subsystem it abstracts. The mechanical tie to that code is the backlog.
 | `Epoch` | RCU-style reclamation across the kernel |
 | `Signal` | signal delivery |
 | `Reaper` | the process table |
-| `Nonce`, `Rng` | entropy and nonce issuance under `src/crypto` |
+| `Rng` | entropy under `src/crypto` |
 | `Endpoint`, `Fd`, `Vfs` | IPC endpoints, descriptor tables, and the VFS |
 | `TokenBucket` | rate limiting in the network path |
 | `Cow` | copy-on-write pages |

--- a/verification/lean/REFINEMENT.md
+++ b/verification/lean/REFINEMENT.md
@@ -39,6 +39,8 @@ contract the code owes. Moving an entry to level 2 or 1 is tracked work.
 | `Interval`, `Vma` | `src/memory/region` | `userland/mechanism_proofs` (differential tests and Kani over the range algebra in `overlap.rs`) |
 | `Timer` | `src/process/scheduler/smp` | `userland/mechanism_proofs` (differential tests and Kani over the elapsed-tick test in `interval.rs`) |
 | `Quota` | `src/capabilities/resource` | `userland/mechanism_proofs` (differential tests and Kani over the check in `limits.rs`) |
+| `Ring` | `src/kernel_core/surface_registry` | `userland/mechanism_proofs` (differential tests and Kani over the index wrap in `ring_math.rs`) |
+| `Mmio` | `src/drivers/security` | `userland/mechanism_proofs` (differential tests and Kani over the window check in `mmio_range.rs`) |
 | `Isolation`, `Paging` | `src/memory/paging` | `userland/kernel_proofs` (page permission W xor X, over all bit patterns) |
 | `Loader` | `src/elf` loader | `userland/kernel_proofs` (segment bounds) |
 | `Syscall` | `src/syscall` numbers | `userland/kernel_proofs` (decode totality and registry agreement) |
@@ -58,10 +60,10 @@ kernel subsystem it abstracts. The mechanical tie to that code is the backlog.
 | `Spinlock` | `spin::Mutex` wrappers in `src/sys/sync` |
 | `PageTable`, `Bounds` | `src/memory` address space and paging |
 | `MemGrant`, `Refcount`, `Heap`, `Zeroize` | `src/memory` grants and allocation |
-| `Iommu`, `Mmio` | device DMA and register windows under `src/hardware` |
+| `Iommu` | device DMA windows under `src/hardware` |
 | `Tlb` | TLB shootdown under `src/memory` |
 | `CapTable`, `Dispatch` | capability tables and the syscall dispatch under `src/syscall` |
-| `Scheduler`, `Priority`, `Ring` | `src/process/scheduler` |
+| `Scheduler`, `Priority` | `src/process/scheduler` |
 | `Epoch` | RCU-style reclamation across the kernel |
 | `Signal` | signal delivery |
 | `Reaper` | the process table |


### PR DESCRIPTION
## What

Records, on the Lean side, the code bindings added by the `mechanism_proofs` crate. Each model moves from a specification to a code-bound proof in `REFINEMENT.md`, and its `Nonos/*.lean` header cites the real file the proof runs against.

Models moved to level-2 (differential tests + Kani against real kernel code):

- `Bitmap` -> `src/memory/phys/bitmap/index.rs`
- `Interval`, `Vma` -> `src/memory/region/overlap.rs`
- `Timer` -> `src/process/scheduler/smp/interval.rs`
- `Quota` -> `src/capabilities/resource/limits.rs`
- `Ring` -> `src/kernel_core/surface_registry/ring_math.rs`
- `Mmio` -> `src/drivers/security/mmio_range.rs`
- `Refcount` -> `src/memory/page_info/manager/refcount.rs`
- `Nonce` -> `src/capabilities/resource/nonce_compose.rs`
- `Bounds` -> `src/elf/reloc/apply/range.rs`
- `Priority` -> `SchedAttr::effective_priority`

The proof crate that discharges these lives in the `mechanism-code-binding` PR. `lake build` stays green with no `sorry`.
