### PR TITLE
net: bind the interface with carrier and re-evaluate

### DIFF
--- a/userland/capsule_net_core/src/main.rs
+++ b/userland/capsule_net_core/src/main.rs
@@ -46,7 +46,9 @@ fn wait_for_setup() {
     loop {
         match setup::run() {
             Ok(()) => return,
-            Err(SetupError::NicNotFound | SetupError::LinkDown) => {
+            // No NIC has an up link yet; keep retrying so the interface is bound
+            // the moment one gains carrier.
+            Err(SetupError::NicNotFound) => {
                 for _ in 0..64 {
                     mk_yield();
                 }

--- a/userland/capsule_net_core/src/server/runner/run.rs
+++ b/userland/capsule_net_core/src/server/runner/run.rs
@@ -16,14 +16,27 @@
 
 use alloc::vec;
 
+use nonos_libc::mk_time_millis;
+
 use crate::server::parse_req::{parse, HDR_LEN, IPC_BUF_MAX};
 use crate::server::runner::{dispatch, receive};
+
+// How often to re-check whether a better interface has come up. A link can gain
+// carrier after boot, and the stack should follow it rather than stay on the one
+// it happened to bind first.
+const REEVAL_INTERVAL_MS: i64 = 1000;
 
 pub fn run() -> ! {
     let mut rx = vec![0u8; HDR_LEN + IPC_BUF_MAX];
     let mut tx = vec![0u8; HDR_LEN + IPC_BUF_MAX];
+    let mut last_reeval: i64 = 0;
     loop {
         crate::iface::poll::pump();
+        let now = mk_time_millis();
+        if now.wrapping_sub(last_reeval) >= REEVAL_INTERVAL_MS {
+            crate::setup::reevaluate();
+            last_reeval = now;
+        }
         let mut sender_pid = 0u32;
         let n = receive::receive(&mut rx, &mut sender_pid);
         if n <= 0 || sender_pid == 0 {

--- a/userland/capsule_net_core/src/setup.rs
+++ b/userland/capsule_net_core/src/setup.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use core::sync::atomic::{AtomicU32, Ordering};
+
 use nonos_libc::mk_service_lookup;
 
 use crate::device;
@@ -23,20 +25,32 @@ use crate::state;
 const NIC_CANDIDATES: &[&str] =
     &["driver.virtio_net0", "driver.e1000_0", "driver.rtl8169_0", "driver.rtl8139_0"];
 
+// The broker port of the NIC the stack is currently bound to. A periodic
+// re-evaluation compares against this to notice when a better link (a NIC that
+// gained carrier after boot) should replace the one bound at startup.
+static BOUND_PORT: AtomicU32 = AtomicU32::new(0);
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum SetupError {
     NicNotFound,
-    LinkDown,
-    LinkFailed,
     MacFailed,
     BuildFailed,
 }
 
+// Return the first candidate whose link is actually up. A driver registers its
+// service name at spawn, before it probes, so a NIC with no chip present or no
+// cable attached still resolves through the lookup and, worse, can report no
+// carrier; binding the first name that merely exists stranded the stack on that
+// dead interface. Requiring an up link, and re-checking on a timer, means the
+// stack binds the interface that has carrier and follows it if that changes.
+// A racing, dying capsule answers link_up with None, treated as not-up.
 fn discover_nic() -> Option<u32> {
     for name in NIC_CANDIDATES {
         let mut port: u32 = 0;
         let mut pid: u32 = 0;
-        if mk_service_lookup(name.as_ptr(), name.len(), &mut port, &mut pid) == 0 {
+        if mk_service_lookup(name.as_ptr(), name.len(), &mut port, &mut pid) == 0
+            && device::link_up(port) == Some(true)
+        {
             return Some(port);
         }
     }
@@ -45,12 +59,31 @@ fn discover_nic() -> Option<u32> {
 
 pub fn run() -> Result<(), SetupError> {
     let port = discover_nic().ok_or(SetupError::NicNotFound)?;
-    let link_up = device::link_up(port).ok_or(SetupError::LinkFailed)?;
-    if !link_up {
-        return Err(SetupError::LinkDown);
-    }
     let mac = device::mac(port).ok_or(SetupError::MacFailed)?;
     let net_state = build::build(mac, port).ok_or(SetupError::BuildFailed)?;
     state::store(net_state);
+    BOUND_PORT.store(port, Ordering::Release);
     Ok(())
+}
+
+/// Re-check the interface picture after the initial bind. When the best up link
+/// differs from the one currently bound - a NIC gaining carrier after boot, or
+/// the bound link going down - rebuild the stack on the new interface so DHCP
+/// runs where traffic can actually flow. A no-op once bound to the best link, so
+/// it is cheap to call on a timer from the server loop.
+pub fn reevaluate() {
+    let Some(best) = discover_nic() else {
+        return;
+    };
+    if best == BOUND_PORT.load(Ordering::Acquire) {
+        return;
+    }
+    let Some(mac) = device::mac(best) else {
+        return;
+    };
+    let Some(net_state) = build::build(mac, best) else {
+        return;
+    };
+    state::store(net_state);
+    BOUND_PORT.store(best, Ordering::Release);
 }


### PR DESCRIPTION
net-core picked the first NIC whose service name merely resolved. A driver
registers its service name at spawn, before it probes hardware, so a board with
no such chip or no cable attached still matched. The stack then sat on that dead
interface: `run()` saw the link down and retried, but `discover_nic` returned the
same port every time, so it never moved to a NIC that did have carrier.

- `discover_nic` now returns the first candidate whose link is actually up, and
  the dead-end `LinkDown` / `LinkFailed` paths are gone (a racing, dying capsule
  answers `link_up` with `None`, treated as not-up and skipped).
- The server loop calls a new `reevaluate()` on a one-second timer, which rebuilds
  the stack on a better interface when one gains carrier after boot, or the bound
  link goes down. It is a no-op once bound to the best link.

No behaviour change under QEMU, where virtio-net is up from the start. On real
hardware it stops the stack stranding on a NIC that has no carrier.