### PR TITLE
desktop: present on damage, wake on IPC, and fix multi-window on hardware

### DIFF
--- a/src/userspace/init/instance_spawn/boot_frame.rs
+++ b/src/userspace/init/instance_spawn/boot_frame.rs
@@ -32,18 +32,37 @@ const NCTL_FOCUS_SELF: [u8; 8] = [b'N', b'C', b'T', b'L', 1, 0, 1, 0];
 
 const DESKTOP_SHELL: &str = "desktop_shell";
 
+/// How long to keep retrying the focus-frame delivery before giving up.
+const BOOT_DEADLINE_MS: u64 = 1000;
+
 /// Boot a freshly spawned window instance by delivering the focus frame the
 /// app skeleton waits for. The frame is attributed to the desktop shell, the
 /// only sender the skeleton accepts, because the shell is what asked for this
-/// window. A missing shell or a full inbox just means no window yet, never a
-/// fault, so failures are swallowed.
+/// window. A missing shell just means no window yet, never a fault.
+///
+/// The instance's `proc.<pid>` inbox is created by its install, which can lag the
+/// spawn return by a few scheduler passes on real hardware; a single attempt then
+/// drops the frame and the window never draws. That timing is why a second or
+/// third window opened reliably under QEMU (steady, fast scheduling) yet not on
+/// hardware. Retry until the frame lands or a bounded wall-clock deadline passes,
+/// so the instance has real time to register its inbox while the wait stays
+/// capped and a genuinely missing instance never wedges the init drain.
 pub(super) fn boot(instance_pid: u32) {
     let Some(shell) = lookup_service(DESKTOP_SHELL) else {
         return;
     };
     let from = format!("proc.{}", shell.pid);
     let to = format!("proc.{}", instance_pid);
-    if let Ok(msg) = IpcMessage::new(&from, &to, &NCTL_FOCUS_SELF) {
-        let _ = nonos_inbox::try_enqueue_strict(&to, msg);
+    let deadline = crate::time::timestamp_millis().saturating_add(BOOT_DEADLINE_MS);
+    loop {
+        if let Ok(msg) = IpcMessage::new(&from, &to, &NCTL_FOCUS_SELF) {
+            if nonos_inbox::try_enqueue_strict(&to, msg).is_ok() {
+                return;
+            }
+        }
+        if crate::time::timestamp_millis() >= deadline {
+            return;
+        }
+        crate::sched::yield_now();
     }
 }

--- a/userland/capsule_desktop_shell/src/server/runner/run.rs
+++ b/userland/capsule_desktop_shell/src/server/runner/run.rs
@@ -16,7 +16,7 @@
 
 use alloc::vec;
 
-use nonos_libc::{mk_display_vsync_wait, mk_time_millis};
+use nonos_libc::mk_time_millis;
 
 use super::constants::CLOCK_REFRESH_MS;
 use super::drain::drain;
@@ -62,6 +62,10 @@ pub fn run(mut ctx: Context) -> ! {
             }
             last_clock_ms = now;
         }
-        let _ = mk_display_vsync_wait(0);
+        // No vsync sleep: drain() already blocks on the IPC inbox, waking the
+        // instant an input or notify message arrives and timing out so the clock
+        // still ticks. Parking again on the vsync tick only added up to a frame of
+        // latency to every click, since an inbound event cannot preempt a vsync
+        // wait.
     }
 }

--- a/userland/compositor/src/server/runner/drain.rs
+++ b/userland/compositor/src/server/runner/drain.rs
@@ -22,17 +22,25 @@ use crate::server::respond;
 use crate::state::Context;
 
 const SERVICE_INBOX: u64 = 0;
-const RECV_NOWAIT: u64 = 1;
+/// The first receive of a drain blocks up to one 60 Hz frame. An incoming IPC (a
+/// client's damage or scene commit) resumes the receive immediately, so the
+/// compositor wakes on the actual work instead of on the periodic vsync tick,
+/// which is unreliable on some hardware and left frames unpresented until a stray
+/// input event happened to wake the loop. The rest of the batch polls so a burst
+/// drains in a single pass.
+const RECV_FRAME_MS: u64 = 16;
+const RECV_POLL_MS: u64 = 1;
 const MAX_BATCH: usize = 16;
 
 pub fn drain_ipc(ctx: &mut Context, rx: &mut [u8], tx: &mut [u8]) {
-    for _ in 0..MAX_BATCH {
+    for i in 0..MAX_BATCH {
+        let timeout = if i == 0 { RECV_FRAME_MS } else { RECV_POLL_MS };
         let mut sender_pid = 0u32;
         let n = mk_ipc_recv_from(
             SERVICE_INBOX,
             rx.as_mut_ptr(),
             rx.len(),
-            RECV_NOWAIT,
+            timeout,
             &mut sender_pid,
         );
         if n <= 0 || sender_pid == 0 {

--- a/userland/compositor/src/server/runner/entry.rs
+++ b/userland/compositor/src/server/runner/entry.rs
@@ -18,7 +18,6 @@ use super::drain::drain_ipc;
 use crate::frame_pacer;
 use crate::protocol::{HDR_LEN, IPC_PAYLOAD_MAX};
 use crate::state::Context;
-use nonos_libc::mk_yield;
 
 // Force a full recomposite this often. Damage tracking only repaints the
 // rectangles a client reports; a region that was left stale by a transient
@@ -45,8 +44,10 @@ pub fn run(mut ctx: Context) -> ! {
             }
             Err(_) => {}
         }
-        if frame_pacer::wait_for_vsync().is_err() {
-            mk_yield();
-        }
+        // No vsync sleep: the blocking first receive in drain_ipc paces the loop
+        // to a frame while still waking the instant a client commits damage. The
+        // present already happened in tick(); sleeping on the periodic vsync tick
+        // only reintroduced the unreliable-timer dependency that left updates
+        // stuck until an input event.
     }
 }


### PR DESCRIPTION
Three related fixes so the desktop stays responsive on hardware whose timer tick
is not steady, where sleeping subsystems were only woken by stray input.

- **Compositor** blocks the first receive of each drain on its inbox with a
  frame-length timeout and drops the per-frame vsync sleep, so it presents the
  instant a client commits damage instead of when an input event happens to wake
  it. The present still runs in the frame pacer.
- **Shell** stops re-parking on the vsync wait after each drain; its `drain()`
  already blocks on the IPC inbox, so a click is handled at once rather than
  after up to a frame.
- **Init** retries the window focus frame until the spawned instance has
  registered its inbox (bounded by a monotonic deadline), fixing the second and
  third window of an app that opened under QEMU but not on hardware.

No behaviour change under QEMU, where the tick is steady; the wins are on real
hardware.