### PR TITLE
wifi: bound the EAPOL MIC and skip the CCMP header on receive

### DIFF
--- a/userland/capsule_driver_iwlwifi/src/eapol/mic.rs
+++ b/userland/capsule_driver_iwlwifi/src/eapol/mic.rs
@@ -12,7 +12,7 @@
 //! first 16 bytes of the HMAC-SHA1. The HMAC underneath is checked against RFC
 //! vectors, so a round-trip and a tamper test pin the verify logic exactly.
 
-use super::parse::{MIC_LEN, MIC_OFFSET};
+use super::parse::{HEADER_LEN, MIC_LEN, MIC_OFFSET};
 use crate::wpa::hmac::hmac_sha1_parts;
 
 /// Compute the version-2 MIC of `frame` under `kck`.
@@ -29,11 +29,21 @@ pub fn compute_mic(kck: &[u8], frame: &[u8]) -> [u8; MIC_LEN] {
 
 /// Whether the MIC carried in `frame` matches the one computed under `kck`.
 /// The comparison is constant time.
+///
+/// The MIC covers exactly the EAPOL-Key frame: the fixed header plus the key data
+/// its length field announces. A received MPDU can carry a trailing FCS or padding
+/// past that, which is not part of the MIC input, so the frame is bounded to the
+/// announced length before hashing rather than trusting `frame.len()`.
 pub fn verify_mic(kck: &[u8], frame: &[u8]) -> bool {
-    if frame.len() < MIC_OFFSET + MIC_LEN {
+    if frame.len() < HEADER_LEN {
         return false;
     }
-    let computed = compute_mic(kck, frame);
+    let key_data_len = u16::from_be_bytes([frame[HEADER_LEN - 2], frame[HEADER_LEN - 1]]) as usize;
+    let end = match HEADER_LEN.checked_add(key_data_len) {
+        Some(e) if e <= frame.len() => e,
+        _ => return false,
+    };
+    let computed = compute_mic(kck, &frame[..end]);
     let mut diff = 0u8;
     for (a, b) in frame[MIC_OFFSET..MIC_OFFSET + MIC_LEN].iter().zip(computed.iter()) {
         diff |= a ^ b;

--- a/userland/iwlwifi_proofs/src/eapol_tests.rs
+++ b/userland/iwlwifi_proofs/src/eapol_tests.rs
@@ -66,6 +66,26 @@ fn mic_round_trips_and_rejects_tampering_and_wrong_key() {
 }
 
 #[test]
+fn mic_ignores_trailing_mpdu_bytes_after_the_key_data() {
+    // A received EAPOL-Key frame arrives inside an 802.11 MPDU and can carry a
+    // trailing FCS or padding past its key data. The MIC covers only the key
+    // frame, so those bytes must not enter the hash. This is the four-way failure
+    // seen on hardware: message three carries a group-key KDE, and the four FCS
+    // bytes behind it made the otherwise-correct MIC verify fail.
+    let kck = [0x11u8; 16];
+    let nonce = [0x22u8; 32];
+    let mut f = build_frame(KEY_INFO_MIC, &nonce, &[1, 2, 3, 4, 5, 6, 7, 8]);
+    let mic = compute_mic(&kck, &f);
+    f[MIC_OFFSET..MIC_OFFSET + MIC_LEN].copy_from_slice(&mic);
+    assert!(verify_mic(&kck, &f), "the exact key frame verifies");
+
+    f.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+    assert!(verify_mic(&kck, &f), "a trailing FCS does not break the MIC");
+    *f.last_mut().unwrap() ^= 0xff;
+    assert!(verify_mic(&kck, &f), "trailer contents are outside the MIC input");
+}
+
+#[test]
 fn a_built_frame_verifies_parses_and_rejects_the_wrong_key() {
     let kck = [0x33u8; 16];
     let replay = [0, 0, 0, 0, 0, 0, 0, 2];

--- a/userland/nonos_wifi_core/src/dot11/data.rs
+++ b/userland/nonos_wifi_core/src/dot11/data.rs
@@ -181,7 +181,14 @@ pub fn parse_data(mpdu: &[u8]) -> Option<Vec<u8>> {
     // A QoS data frame carries a longer header; size the body from the frame so
     // the LLC/SNAP shim is found whether or not the AP used QoS.
     let hlen = header_len(fc);
-    if mpdu.len() < hlen + 8 {
+    // A hardware-CCMP chip delivers a decrypted frame with the 802.11 header and
+    // the 8-byte CCMP header (IV and packet number) still in place, and leaves the
+    // Protected bit set in the frame control. The plaintext body begins after both
+    // headers. Skipping the CCMP header when protected is what puts the LLC/SNAP
+    // shim at the expected offset; without it every hardware-decrypted frame, the
+    // DHCP reply included, failed the LLC/SNAP check and was silently dropped.
+    let ccmp = if fc & FC_PROTECTED != 0 { CCMP_HDR_LEN } else { 0 };
+    if mpdu.len() < hlen + ccmp + 8 {
         return None;
     }
     let mut a1 = [0u8; 6];
@@ -190,7 +197,7 @@ pub fn parse_data(mpdu: &[u8]) -> Option<Vec<u8>> {
     a1.copy_from_slice(&mpdu[4..10]);
     a2.copy_from_slice(&mpdu[10..16]);
     a3.copy_from_slice(&mpdu[16..22]);
-    let body = &mpdu[hlen..];
+    let body = &mpdu[hlen + ccmp..];
     if body.len() < 8 || body[0..6] != LLC_SNAP {
         return None;
     }

--- a/userland/nonos_wifi_core/src/eapol/mic.rs
+++ b/userland/nonos_wifi_core/src/eapol/mic.rs
@@ -12,7 +12,7 @@
 //! first 16 bytes of the HMAC-SHA1. The HMAC underneath is checked against RFC
 //! vectors, so a round-trip and a tamper test pin the verify logic exactly.
 
-use super::parse::{MIC_LEN, MIC_OFFSET};
+use super::parse::{HEADER_LEN, MIC_LEN, MIC_OFFSET};
 use crate::wpa::hmac::hmac_sha1_parts;
 
 /// Compute the version-2 MIC of `frame` under `kck`.
@@ -26,11 +26,21 @@ pub fn compute_mic(kck: &[u8], frame: &[u8]) -> [u8; MIC_LEN] {
 
 /// Whether the MIC carried in `frame` matches the one computed under `kck`.
 /// The comparison is constant time.
+///
+/// The MIC covers exactly the EAPOL-Key frame: the fixed header plus the key data
+/// its length field announces. A received MPDU can carry a trailing FCS or padding
+/// past that, which is not part of the MIC input, so the frame is bounded to the
+/// announced length before hashing rather than trusting `frame.len()`.
 pub fn verify_mic(kck: &[u8], frame: &[u8]) -> bool {
-    if frame.len() < MIC_OFFSET + MIC_LEN {
+    if frame.len() < HEADER_LEN {
         return false;
     }
-    let computed = compute_mic(kck, frame);
+    let key_data_len = u16::from_be_bytes([frame[HEADER_LEN - 2], frame[HEADER_LEN - 1]]) as usize;
+    let end = match HEADER_LEN.checked_add(key_data_len) {
+        Some(e) if e <= frame.len() => e,
+        _ => return false,
+    };
+    let computed = compute_mic(kck, &frame[..end]);
     let mut diff = 0u8;
     for (a, b) in frame[MIC_OFFSET..MIC_OFFSET + MIC_LEN].iter().zip(computed.iter()) {
         diff |= a ^ b;


### PR DESCRIPTION
Two frame-handling fixes the WPA2 four-way and the data path need on real
hardware, where a received MPDU carries bytes the software round trip never
produces.

- **MIC**: `verify_mic` hashed the whole received buffer. A received EAPOL-Key
  frame sits inside an 802.11 MPDU and can carry a trailing FCS or padding, so a
  four FCS bytes behind message three's group-key KDE broke an otherwise-correct
  MIC and the handshake stalled at message three. It now covers exactly the
  EAPOL-Key frame the length field announces. Landed in both the `iwlwifi` copy
  and the shared `nonos_wifi_core` copy; a proof (`mic_ignores_trailing_...`)
  pins the trailing-FCS case.
- **CCMP header**: `parse_data` assumed the body followed the 802.11 header
  directly, but a hardware-CCMP chip delivers a decrypted frame with the 8-byte
  CCMP header still present and the Protected bit set. It now skips that header
  when protected, so the DHCP reply and later frames decode instead of failing
  the LLC/SNAP check and being dropped.

Both are pure receive-side framing corrections; no behaviour change for the
software CCMP round trip, which the existing proofs still cover.