### PR TITLE
Formal verification: non-interference, confidentiality, attestation binding and fairness

### DIFF
--- a/verification/evidence/EVIDENCE.json
+++ b/verification/evidence/EVIDENCE.json
@@ -49,11 +49,11 @@
       ]
     },
     "lean_specification": {
-      "axiom_profiled_theorems": 168,
+      "axiom_profiled_theorems": 207,
       "mathlib": false,
-      "modules": 120,
+      "modules": 123,
       "sorry_count": 0,
-      "theorems": 887,
+      "theorems": 936,
       "toolchain": "leanprover/lean4:v4.15.0"
     },
     "runnable": {

--- a/verification/lean/AxiomProfile.lean
+++ b/verification/lean/AxiomProfile.lean
@@ -35,6 +35,39 @@ import Nonos
 #print axioms Nonos.Paging.confined_preserves_no_wx
 #print axioms Nonos.Path.leading_dotdot_neutralized
 #print axioms Nonos.Secure.every_trace_is_secure
+#print axioms Nonos.Secure.dma_owned_by_caller
+#print axioms Nonos.Secure.dma_within_class_limit
+#print axioms Nonos.Secure.elf_table_in_bounds
+#print axioms Nonos.Secure.irq_vector_count_bounded
+#print axioms Nonos.Secure.irq_not_already_bound
+#print axioms Nonos.Secure.quota_within_cap
+#print axioms Nonos.NonInterference.step_preserves_token
+#print axioms Nonos.NonInterference.token_locality
+#print axioms Nonos.NonInterference.token_noninterference
+#print axioms Nonos.NonInterference.no_authority_leak
+#print axioms Nonos.NonInterference.step_no_gain
+#print axioms Nonos.NonInterference.no_authority_amplification
+#print axioms Nonos.NonInterference.step_preserves_mapping
+#print axioms Nonos.NonInterference.mapping_locality
+#print axioms Nonos.NonInterference.mapping_noninterference
+#print axioms Nonos.NonInterference.Unwinding.locality
+#print axioms Nonos.NonInterference.Unwinding.noninterference
+#print axioms Nonos.NonInterference.admitted_noninterference
+#print axioms Nonos.NonInterference.dma_noninterference
+#print axioms Nonos.NonInterference.copies_noninterference
+#print axioms Nonos.NonInterference.floor_noninterference
+#print axioms Nonos.NonInterference.elf_noninterference
+#print axioms Nonos.NonInterference.irq_noninterference
+#print axioms Nonos.NonInterference.step_preserves_domain_view
+#print axioms Nonos.NonInterference.domain_noninterference
+#print axioms Nonos.NonInterference.touches_disjoint
+#print axioms Nonos.NonInterference.domain_isolation
+#print axioms Nonos.NonInterference.disjoint_domains_noninterfere
+#print axioms Nonos.AttestBinding.starkAttest_true_iff
+#print axioms Nonos.AttestBinding.admitted_is_enrolled
+#print axioms Nonos.AttestBinding.admitted_enrolled_after_trace
+#print axioms Nonos.AttestBinding.admitted_accepted_after_trace
+#print axioms Nonos.AttestBinding.no_cross_policy_replay
 #print axioms Nonos.Spawn.only_attested_capsules_run
 #print axioms Nonos.Stark.AssociationSet.an_excluded_deposit_cannot_pass
 #print axioms Nonos.Stark.AssociationSet.the_registry_only_grows
@@ -254,3 +287,13 @@ import Nonos
 #print axioms Nonos.ElfPhdr.accepted_table_in_bounds
 #print axioms Nonos.ElfPhdr.accepted_no_overflow
 #print axioms Nonos.ElfPhdr.wrong_size_rejected
+
+
+-- Scheduling fairness / liveness: the ready set is a scheduling invariant, no
+-- admitted task is ever dropped or starved out of the queue.
+#print axioms Nonos.Fairness.rotateN_mem
+#print axioms Nonos.Fairness.rotateN_length
+#print axioms Nonos.Fairness.no_starvation_by_loss
+#print axioms Nonos.Fairness.never_stalls
+#print axioms Nonos.Fairness.rotateN_to_head
+#print axioms Nonos.Fairness.reaches_head

--- a/verification/lean/Nonos.lean
+++ b/verification/lean/Nonos.lean
@@ -69,6 +69,7 @@ import Nonos.Rwlock
 import Nonos.Scheduler
 import Nonos.Secure
 import Nonos.NonInterference
+import Nonos.AttestBinding
 import Nonos.Semaphore
 import Nonos.Seqlock
 import Nonos.ServiceRegistry

--- a/verification/lean/Nonos.lean
+++ b/verification/lean/Nonos.lean
@@ -68,6 +68,7 @@ import Nonos.Rng
 import Nonos.Rwlock
 import Nonos.Scheduler
 import Nonos.Secure
+import Nonos.NonInterference
 import Nonos.Semaphore
 import Nonos.Seqlock
 import Nonos.ServiceRegistry

--- a/verification/lean/Nonos.lean
+++ b/verification/lean/Nonos.lean
@@ -67,6 +67,7 @@ import Nonos.Ring
 import Nonos.Rng
 import Nonos.Rwlock
 import Nonos.Scheduler
+import Nonos.Fairness
 import Nonos.Secure
 import Nonos.NonInterference
 import Nonos.AttestBinding

--- a/verification/lean/Nonos/AttestBinding.lean
+++ b/verification/lean/Nonos/AttestBinding.lean
@@ -1,0 +1,146 @@
+/-
+NONOS Operating System
+Copyright (C) 2026 NONOS Contributors
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version. See <https://www.gnu.org/licenses/>.
+
+Binding the transparent STARK attestation gate to the conjoined security machine.
+
+The conjoined invariant of `Nonos.Secure` carries an abstract attestation oracle
+`attest : Nat -> Bool` and proves that only an attested capsule is ever admitted.
+The STARK modules prove, separately, that the gate accepts an attestation exactly
+when it opens to the enrolled policy root under the bound context with an enrolled
+measurement. This module instantiates the abstract oracle with the STARK gate's
+own accept decision and joins the two results: from a clean start, after any
+adversarial trace, every admitted capsule's measured image is one that was
+enrolled in the policy. Nothing runs whose image the gate did not accept, and the
+gate accepts only enrolled images, so nothing runs whose image was not enrolled.
+-/
+
+import Nonos.Secure
+import Nonos.Stark.AttestSoundness
+
+namespace Nonos.AttestBinding
+
+open Nonos.Secure
+open Nonos.Stark.AttestSoundness
+
+/-- The security machine's attestation oracle, instantiated by the transparent
+    STARK gate: a capsule is attested exactly when its attestation opens to the
+    enrolled policy root, under the bound context, with an enrolled measurement.
+    `attOf` names the attestation each capsule presents. -/
+def starkAttest (pr bc : Nat) (pol : List Nat) (attOf : Nat → Attestation) : Nat → Bool :=
+  fun cap =>
+    let a := attOf cap
+    decide (a.root = pr ∧ a.context = bc ∧ a.measurement ∈ pol)
+
+/-- The instantiated oracle returns `true` exactly when the STARK gate accepts. -/
+theorem starkAttest_true_iff (pr bc : Nat) (pol : List Nat)
+    (attOf : Nat → Attestation) (cap : Nat) :
+    starkAttest pr bc pol attOf cap = true ↔ accept pr bc pol (attOf cap) := by
+  unfold starkAttest accept
+  simp [decide_eq_true_eq]
+
+/-- No transition changes the attestation oracle: it is fixed policy, not mutable
+    state. -/
+theorem step_preserves_attest (s : State) (sc : Syscall) :
+    (step s sc).attest = s.attest := by
+  cases sc with
+  | attenuate pid mask => rfl
+  | transfer src dst b => simp only [step]; split <;> rfl
+  | revoke pid b => rfl
+  | mapPage page p => simp only [step]; split <;> rfl
+  | userCopy addr len => simp only [step]; split <;> rfl
+  | boot v => rfl
+  | spawn cap => simp only [step]; split <;> rfl
+  | dmaMap r c => simp only [step]; split <;> rfl
+  | loadElf e => simp only [step]; split <;> rfl
+  | bindMsix i => simp only [step]; split <;> rfl
+  | acquire pid n => rfl
+
+/-- The attestation oracle is the same after any trace as before it. -/
+theorem attest_locality (s : State) (tr : List Syscall) :
+    (run s tr).attest = s.attest := by
+  induction tr generalizing s with
+  | nil => rfl
+  | cons sc rest ih =>
+    calc (run s (sc :: rest)).attest
+        = (run (step s sc) rest).attest := rfl
+      _ = (step s sc).attest := ih (step s sc)
+      _ = s.attest := step_preserves_attest s sc
+
+/-- Bridge, at a fixed state: if the machine runs the STARK-instantiated oracle,
+    every admitted capsule's attestation is accepted by the gate, so its measured
+    image is enrolled in the policy. -/
+theorem admitted_is_enrolled (pr bc : Nat) (pol : List Nat) (attOf : Nat → Attestation)
+    (s0 s : State) (hsec : Secure s0 s)
+    (hattest : s.attest = starkAttest pr bc pol attOf)
+    (c : Nat) (hc : c ∈ s.admitted) :
+    (attOf c).measurement ∈ pol := by
+  have ht : s.attest c = true := hsec.admitted_attested c hc
+  rw [hattest] at ht
+  exact accept_enrolled pr bc pol (attOf c)
+    ((starkAttest_true_iff pr bc pol attOf c).mp ht)
+
+/-- The end-to-end theorem: from a clean start whose attestation oracle is the
+    STARK gate, after any adversarial trace of any length, every admitted
+    capsule's measured image was enrolled in the policy. This joins the conjoined
+    safety invariant to the gate's soundness: nothing runs whose image the gate
+    did not accept, and the gate accepts only enrolled images. -/
+theorem admitted_enrolled_after_trace (pr bc : Nat) (pol : List Nat)
+    (attOf : Nat → Attestation) (s0 : State) (tr : List Syscall)
+    (hattest0 : s0.attest = starkAttest pr bc pol attOf)
+    (hwx : ∀ page pm, s0.mapped page = some pm →
+      ¬(pm.write = true ∧ pm.execute = true))
+    (hcopies : s0.copies = []) (hadmit : s0.admitted = [])
+    (hdma : s0.dma = []) (helf : s0.elf = []) (hirq : s0.irq = [])
+    (hquota : ∀ p, Quota.ok (s0.quota p))
+    (c : Nat) (hc : c ∈ (run s0 tr).admitted) :
+    (attOf c).measurement ∈ pol := by
+  have hsec := every_trace_is_secure s0 tr hwx hcopies hadmit hdma helf hirq hquota
+  have hattest : (run s0 tr).attest = starkAttest pr bc pol attOf := by
+    rw [attest_locality s0 tr, hattest0]
+  exact admitted_is_enrolled pr bc pol attOf s0 (run s0 tr) hsec hattest c hc
+
+/-- The full gate verdict for every admitted capsule, end to end: from a clean
+    start under the STARK oracle, after any adversarial trace, every admitted
+    capsule's attestation was accepted by the gate. Everything the gate's
+    soundness lemmas conclude about an accepted attestation then holds of every
+    capsule that ran. -/
+theorem admitted_accepted_after_trace (pr bc : Nat) (pol : List Nat)
+    (attOf : Nat → Attestation) (s0 : State) (tr : List Syscall)
+    (hattest0 : s0.attest = starkAttest pr bc pol attOf)
+    (hwx : ∀ page pm, s0.mapped page = some pm →
+      ¬(pm.write = true ∧ pm.execute = true))
+    (hcopies : s0.copies = []) (hadmit : s0.admitted = [])
+    (hdma : s0.dma = []) (helf : s0.elf = []) (hirq : s0.irq = [])
+    (hquota : ∀ p, Quota.ok (s0.quota p))
+    (c : Nat) (hc : c ∈ (run s0 tr).admitted) :
+    accept pr bc pol (attOf c) := by
+  have hsec := every_trace_is_secure s0 tr hwx hcopies hadmit hdma helf hirq hquota
+  have ht : (run s0 tr).attest c = true := hsec.admitted_attested c hc
+  rw [attest_locality s0 tr, hattest0] at ht
+  exact (starkAttest_true_iff pr bc pol attOf c).mp ht
+
+/-- No cross-policy or cross-identity replay: after any adversarial trace from a
+    clean start, every admitted capsule's attestation opened to exactly the
+    enrolled policy root under exactly the bound context. A proof drawn against
+    another policy root, or bound to another identity, admits nothing: it can
+    never carry a capsule into execution. -/
+theorem no_cross_policy_replay (pr bc : Nat) (pol : List Nat)
+    (attOf : Nat → Attestation) (s0 : State) (tr : List Syscall)
+    (hattest0 : s0.attest = starkAttest pr bc pol attOf)
+    (hwx : ∀ page pm, s0.mapped page = some pm →
+      ¬(pm.write = true ∧ pm.execute = true))
+    (hcopies : s0.copies = []) (hadmit : s0.admitted = [])
+    (hdma : s0.dma = []) (helf : s0.elf = []) (hirq : s0.irq = [])
+    (hquota : ∀ p, Quota.ok (s0.quota p))
+    (c : Nat) (hc : c ∈ (run s0 tr).admitted) :
+    (attOf c).root = pr ∧ (attOf c).context = bc := by
+  have hacc := admitted_accepted_after_trace pr bc pol attOf s0 tr hattest0 hwx hcopies hadmit hdma helf hirq hquota c hc
+  exact ⟨accept_root pr bc pol (attOf c) hacc, accept_context pr bc pol (attOf c) hacc⟩
+
+end Nonos.AttestBinding

--- a/verification/lean/Nonos/Fairness.lean
+++ b/verification/lean/Nonos/Fairness.lean
@@ -1,0 +1,108 @@
+/-
+NONOS Operating System
+Copyright (C) 2026 NONOS Contributors
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version. See <https://www.gnu.org/licenses/>.
+
+Scheduling fairness for the round-robin ready queue of `Nonos.Scheduler`.
+
+The safety and security work proves what the system never does. This module
+proves a progress property of the scheduler itself: under any number of
+scheduling steps, the ready set is invariant. Every task that is ready stays
+ready, no task appears from nowhere, and the number of ready tasks is preserved.
+A round-robin step is a left rotation of the queue, so no task can be dropped or
+buried indefinitely by the scheduler: the only way out of the ready queue is to
+be dequeued, never to be silently lost. This is the liveness counterpart to the
+safety invariants, discharged over the real queue operations.
+-/
+
+import Nonos.Scheduler
+
+namespace Nonos.Fairness
+
+open Nonos.Scheduler
+
+/-- `n` round-robin scheduling steps: rotate the ready queue `n` times. -/
+def rotateN : Nat → Queue → Queue
+  | 0, q => q
+  | k + 1, q => rotate (rotateN k q)
+
+@[simp] theorem rotateN_zero (q : Queue) : rotateN 0 q = q := rfl
+
+@[simp] theorem rotateN_succ (k : Nat) (q : Queue) :
+    rotateN (k + 1) q = rotate (rotateN k q) := rfl
+
+/-- No ready task is ever lost or invented: after any number of scheduling
+    steps, a task is ready exactly when it was ready to begin with. -/
+theorem rotateN_mem (k : Nat) (q : Queue) (x : Nat) : x ∈ rotateN k q ↔ x ∈ q := by
+  induction k with
+  | zero => rfl
+  | succ k ih => rw [rotateN_succ, rotate_mem]; exact ih
+
+/-- The number of ready tasks is preserved by scheduling: the round-robin step
+    neither grows nor shrinks the ready queue. -/
+theorem rotateN_length (k : Nat) (q : Queue) : (rotateN k q).length = q.length := by
+  induction k with
+  | zero => rfl
+  | succ k ih => rw [rotateN_succ, rotate_length]; exact ih
+
+/-- No starvation by loss: a task that is ready stays ready under every schedule,
+    however long. The scheduler can never make an admitted task disappear from
+    the ready queue; a task leaves only by being dequeued to run. -/
+theorem no_starvation_by_loss (k : Nat) (q : Queue) (t : Nat) (h : t ∈ q) :
+    t ∈ rotateN k q := (rotateN_mem k q t).mpr h
+
+/-- A non-empty ready queue stays non-empty under scheduling: there is always a
+    task available to run, so the scheduler never stalls a ready system. -/
+theorem never_stalls (k : Nat) (q : Queue) (h : q ≠ []) : rotateN k q ≠ [] := by
+  intro he
+  apply h
+  have : (rotateN k q).length = q.length := rotateN_length k q
+  rw [he] at this
+  exact List.length_eq_zero.mp this.symm
+
+/-! ### Bounded-wait fairness
+
+The invariants above say no ready task is ever lost. The stronger progress
+property is that every ready task is served after a bounded number of steps: a
+task at position `i` reaches the head after exactly `i` round-robin rotations,
+and its position is less than the queue length, so its wait is bounded. No task
+is starved: it is scheduled within one pass over the ready queue. -/
+
+/-- Peeling a rotation from the front of the step count. -/
+theorem rotateN_succ' (k : Nat) (q : Queue) :
+    rotateN (k + 1) q = rotateN k (rotate q) := by
+  induction k generalizing q with
+  | zero => rfl
+  | succ k ih => rw [rotateN_succ, ih, rotateN_succ]
+
+/-- Rotating a queue by the length of a prefix brings the element just past that
+    prefix to the head: `i` round-robin steps schedule the task at position `i`. -/
+theorem rotateN_to_head (pre post : Queue) (t : Nat) :
+    rotateN pre.length (pre ++ t :: post) = t :: (post ++ pre) := by
+  induction pre generalizing post with
+  | nil => simp
+  | cons a pre' ih =>
+    have hlen : (a :: pre').length = pre'.length + 1 := rfl
+    rw [hlen, rotateN_succ']
+    have hr : rotate ((a :: pre') ++ t :: post) = pre' ++ t :: (post ++ [a]) := by
+      simp only [List.cons_append, rotate, List.append_assoc, List.cons_append,
+        List.nil_append]
+    rw [hr, ih (post ++ [a])]
+    simp [List.append_assoc]
+
+/-- Bounded-wait fairness: a ready task is scheduled to the head within fewer
+    steps than the queue length. No task waits more than one pass over the ready
+    queue, so none is starved. -/
+theorem reaches_head (q : Queue) (t : Nat) (h : t ∈ q) :
+    ∃ k, k < q.length ∧ (rotateN k q).head? = some t := by
+  obtain ⟨pre, post, hq⟩ := List.append_of_mem h
+  subst hq
+  refine ⟨pre.length, ?_, ?_⟩
+  · rw [List.length_append, List.length_cons]; omega
+  · rw [rotateN_to_head]; rfl
+
+end Nonos.Fairness

--- a/verification/lean/Nonos/NonInterference.lean
+++ b/verification/lean/Nonos/NonInterference.lean
@@ -1,0 +1,650 @@
+/-
+NONOS Operating System
+Copyright (C) 2026 NONOS Contributors
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version. See <https://www.gnu.org/licenses/>.
+
+Authority non-interference over the conjoined security machine of `Nonos.Secure`.
+
+The conjoined theorem proves the whole system stays inside its safety envelope
+under any adversarial trace. This module proves a complementary, and stronger in
+flavour, property: a capsule's authority is both untouched by, and invisible to,
+the operations it is not part of. A transition can change a domain's capability
+token only if it names that domain as the process whose authority changes; every
+other transition, whatever else it does to memory, DMA, the loader or the
+interrupt table, leaves that token exactly as it was. From this locality the
+non-interference statement follows: two system states that agree on a domain's
+authority still agree after any two traces that never name it, so nothing another
+domain does can be observed in, or leak into, that domain's authority.
+
+This is the integrity backbone of the design. It is the kernel-side analogue of
+the classical non-interference guarantee, discharged here by machine-checked
+case analysis over the real transition relation rather than argued informally.
+-/
+
+import Nonos.Secure
+
+namespace Nonos.NonInterference
+
+open Nonos.Secure
+
+/-! ### The unwinding framework
+
+Non-interference is proved here through an unwinding structure, the standard
+device for such results: an observation `view` of the state and a predicate
+`touches` marking the transitions that may change it, together with the single
+local obligation that a non-touching transition preserves the observation. From
+those local data the global locality and non-interference theorems follow once
+and for all, and every concrete dimension of the machine (authority, memory, the
+admitted-capsule set, the DMA log) is then an instance rather than a fresh
+induction. -/
+
+/-- An unwinding datum: an observation of the state, the transitions that may
+    change it, and the local frame condition that ties them together. -/
+structure Unwinding (V : Type) where
+  view : State → V
+  touches : Syscall → Prop
+  step_frame : ∀ s sc, ¬ touches sc → view (step s sc) = view s
+
+/-- Locality, once for all views: along any trace whose transitions never touch
+    the observation, the observation is exactly its initial value. -/
+theorem Unwinding.locality {V : Type} (u : Unwinding V) (s : State)
+    (tr : List Syscall) (h : ∀ sc ∈ tr, ¬ u.touches sc) :
+    u.view (run s tr) = u.view s := by
+  induction tr generalizing s with
+  | nil => rfl
+  | cons sc rest ih =>
+    have hrest : ∀ x ∈ rest, ¬ u.touches x :=
+      fun x hx => h x (List.mem_cons_of_mem sc hx)
+    calc u.view (run s (sc :: rest))
+        = u.view (run (step s sc) rest) := rfl
+      _ = u.view (step s sc) := ih (step s sc) hrest
+      _ = u.view s := u.step_frame s sc (h sc (List.mem_cons_self sc rest))
+
+/-- Non-interference, once for all views: two states with the same observation
+    keep the same observation after any two traces that never touch it. -/
+theorem Unwinding.noninterference {V : Type} (u : Unwinding V) (s s' : State)
+    (tr tr' : List Syscall) (hagree : u.view s = u.view s')
+    (h : ∀ sc ∈ tr, ¬ u.touches sc) (h' : ∀ sc ∈ tr', ¬ u.touches sc) :
+    u.view (run s tr) = u.view (run s' tr') := by
+  rw [u.locality s tr h, u.locality s' tr' h', hagree]
+
+/-- A transition can modify domain `q`'s capability token only if it names `q` as
+    the process whose authority changes: an attenuation or a revocation of `q`,
+    or a transfer whose destination is `q`. Every other transition leaves every
+    token untouched. -/
+def TouchesToken (q : Nat) : Syscall → Prop
+  | .attenuate pid _ => pid = q
+  | .transfer _ dst _ => dst = q
+  | .revoke pid _ => pid = q
+  | _ => False
+
+/-- A single transition that does not name `q` leaves `q`'s token unchanged, no
+    matter what else it does. This is the per-step frame lemma. -/
+theorem step_preserves_token (q : Nat) (s : State) (sc : Syscall)
+    (h : ¬ TouchesToken q sc) : (step s sc).token q = s.token q := by
+  cases sc with
+  | attenuate pid mask =>
+    have hpq : ¬ (q = pid) := fun he => h he.symm
+    simp only [step]
+    rw [if_neg hpq]
+  | transfer src dst b =>
+    have hdq : ¬ (q = dst) := fun he => h he.symm
+    simp only [step]
+    split
+    · show (if q = dst then Nonos.Capability.grant (s.token q) b else s.token q)
+          = s.token q
+      rw [if_neg hdq]
+    · rfl
+  | revoke pid b =>
+    have hpq : ¬ (q = pid) := fun he => h he.symm
+    simp only [step]
+    rw [if_neg hpq]
+  | mapPage page p => simp only [step]; split <;> rfl
+  | userCopy addr len => simp only [step]; split <;> rfl
+  | boot v => rfl
+  | spawn cap => simp only [step]; split <;> rfl
+  | dmaMap r c => simp only [step]; split <;> rfl
+  | loadElf e => simp only [step]; split <;> rfl
+  | bindMsix i => simp only [step]; split <;> rfl
+  | acquire pid n => rfl
+
+/-- Token locality: along any trace whose transitions never name `q`, domain
+    `q`'s token is exactly the one it started with. Authority is not changed by
+    anything the domain is not part of. -/
+theorem token_locality (q : Nat) (s : State) (tr : List Syscall)
+    (h : ∀ sc ∈ tr, ¬ TouchesToken q sc) : (run s tr).token q = s.token q := by
+  induction tr generalizing s with
+  | nil => rfl
+  | cons sc rest ih =>
+    have hrest : ∀ x ∈ rest, ¬ TouchesToken q x :=
+      fun x hx => h x (List.mem_cons_of_mem sc hx)
+    have hhead : ¬ TouchesToken q sc := h sc (List.mem_cons_self sc rest)
+    calc (run s (sc :: rest)).token q
+        = (run (step s sc) rest).token q := rfl
+      _ = (step s sc).token q := ih (step s sc) hrest
+      _ = s.token q := step_preserves_token q s sc hhead
+
+/-- Authority non-interference: two states that agree on domain `q`'s token still
+    agree on it after any two traces that never name `q`. Whatever the rest of the
+    system does, and however the adversary interleaves it, it cannot be observed
+    in, or leak into, `q`'s authority. -/
+theorem token_noninterference (q : Nat) (s s' : State) (tr tr' : List Syscall)
+    (hagree : s.token q = s'.token q)
+    (h : ∀ sc ∈ tr, ¬ TouchesToken q sc)
+    (h' : ∀ sc ∈ tr', ¬ TouchesToken q sc) :
+    (run s tr).token q = (run s' tr').token q := by
+  rw [token_locality q s tr h, token_locality q s' tr' h', hagree]
+
+/-- A grant a domain does not hold cannot appear in its token through operations
+    that do not name it: the read-side reading of non-interference. -/
+theorem no_authority_leak (q : Nat) (s : State) (tr : List Syscall) (b : Nat)
+    (h : ∀ sc ∈ tr, ¬ TouchesToken q sc)
+    (hno : (s.token q) b = false) : (run s tr).token q b = false := by
+  rw [token_locality q s tr h]; exact hno
+
+/-- A transition can add a right to `q` only by transferring one to it: a
+    transfer whose destination is `q`. Attenuation and revocation only remove
+    rights, and no other transition touches a token. -/
+def GrantsTo (q : Nat) : Syscall → Prop
+  | .transfer _ dst _ => dst = q
+  | _ => False
+
+/-- A single non-granting transition never adds a right to `q`: if `q` did not
+    hold `b` before, it does not hold it after. This is the authorized-flow
+    analogue of the frame lemma: the only permitted increase in authority is an
+    explicit transfer, so every other step preserves the absence of a right. -/
+theorem step_no_gain (q : Nat) (s : State) (sc : Syscall) (b : Nat)
+    (h : ¬ GrantsTo q sc) (hb : s.token q b = false) :
+    (step s sc).token q b = false := by
+  cases sc with
+  | attenuate pid mask =>
+    simp only [step]
+    by_cases hqp : q = pid
+    · rw [if_pos hqp]; simp [Nonos.Capability.attenuate, hb]
+    · rw [if_neg hqp]; exact hb
+  | transfer src dst b' =>
+    have hdq : ¬ (q = dst) := fun he => h he.symm
+    simp only [step]
+    split
+    · show (if q = dst then Nonos.Capability.grant (s.token q) b' else s.token q) b = false
+      rw [if_neg hdq]; exact hb
+    · exact hb
+  | revoke pid b' =>
+    simp only [step]
+    by_cases hqp : q = pid
+    · rw [if_pos hqp]; simp [Nonos.Capability.revoke, hb]
+    · rw [if_neg hqp]; exact hb
+  | mapPage page p => simp only [step]; split <;> exact hb
+  | userCopy addr len => simp only [step]; split <;> exact hb
+  | boot v => exact hb
+  | spawn cap => simp only [step]; split <;> exact hb
+  | dmaMap r c => simp only [step]; split <;> exact hb
+  | loadElf e => simp only [step]; split <;> exact hb
+  | bindMsix i => simp only [step]; split <;> exact hb
+  | acquire pid n => exact hb
+
+/-- No authority amplification: along any trace with no transfer naming `q`, a
+    right `q` did not hold at the start it never comes to hold. Authority does
+    not grow except through an explicit, authorized transfer, whatever else the
+    rest of the system does. This is the intransitive, authorized-flow companion
+    to non-interference. -/
+theorem no_authority_amplification (q : Nat) (b : Nat) :
+    ∀ (tr : List Syscall) (s : State),
+      (∀ sc ∈ tr, ¬ GrantsTo q sc) → s.token q b = false →
+        (run s tr).token q b = false
+  | [], _, _, hb => hb
+  | sc :: rest, s, h, hb =>
+      no_authority_amplification q b rest (step s sc)
+        (fun x hx => h x (List.mem_cons_of_mem sc hx))
+        (step_no_gain q s sc b (h sc (List.mem_cons_self sc rest)) hb)
+
+/-! ### The memory dimension
+
+The lemmas above isolate a domain's *authority*. The same non-interference holds
+of the *memory image* at page granularity: a page's installed permission is
+changed only by a mapping that names that page, so one page's mapping is
+untouched by, and invisible to, operations on any other page. Together the two
+dimensions give a non-interference result over both the authority and the memory
+components of the machine state. -/
+
+/-- A transition can change the permission installed at page `pg` only if it maps
+    that page: a `mapPage pg` transition. Every other transition leaves that
+    page's mapping exactly as it was. -/
+def TouchesPage (pg : Nat) : Syscall → Prop
+  | .mapPage page _ => page = pg
+  | _ => False
+
+/-- The per-step frame lemma for memory: a transition that does not map page `pg`
+    leaves its installed permission unchanged. -/
+theorem step_preserves_mapping (pg : Nat) (s : State) (sc : Syscall)
+    (h : ¬ TouchesPage pg sc) : (step s sc).mapped pg = s.mapped pg := by
+  cases sc with
+  | attenuate pid mask => rfl
+  | transfer src dst b => simp only [step]; split <;> rfl
+  | revoke pid b => rfl
+  | mapPage page p =>
+    have hpg : ¬ (pg = page) := fun he => h he.symm
+    simp only [step]
+    split
+    · rfl
+    · show (if pg = page then some p else s.mapped pg) = s.mapped pg
+      rw [if_neg hpg]
+  | userCopy addr len => simp only [step]; split <;> rfl
+  | boot v => rfl
+  | spawn cap => simp only [step]; split <;> rfl
+  | dmaMap r c => simp only [step]; split <;> rfl
+  | loadElf e => simp only [step]; split <;> rfl
+  | bindMsix i => simp only [step]; split <;> rfl
+  | acquire pid n => rfl
+
+/-- Memory locality: over any trace whose transitions never map page `pg`, that
+    page's installed permission is exactly the one it started with. -/
+theorem mapping_locality (pg : Nat) (s : State) (tr : List Syscall)
+    (h : ∀ sc ∈ tr, ¬ TouchesPage pg sc) : (run s tr).mapped pg = s.mapped pg := by
+  induction tr generalizing s with
+  | nil => rfl
+  | cons sc rest ih =>
+    have hrest : ∀ x ∈ rest, ¬ TouchesPage pg x :=
+      fun x hx => h x (List.mem_cons_of_mem sc hx)
+    calc (run s (sc :: rest)).mapped pg
+        = (run (step s sc) rest).mapped pg := rfl
+      _ = (step s sc).mapped pg := ih (step s sc) hrest
+      _ = s.mapped pg := step_preserves_mapping pg s sc (h sc (List.mem_cons_self sc rest))
+
+/-- Memory non-interference: two states that agree on page `pg`'s mapping still
+    agree after any two traces that never map `pg`. What happens to the rest of
+    the address space cannot be observed in, or leak into, that page. -/
+theorem mapping_noninterference (pg : Nat) (s s' : State) (tr tr' : List Syscall)
+    (hagree : s.mapped pg = s'.mapped pg)
+    (h : ∀ sc ∈ tr, ¬ TouchesPage pg sc)
+    (h' : ∀ sc ∈ tr', ¬ TouchesPage pg sc) :
+    (run s tr).mapped pg = (run s' tr').mapped pg := by
+  rw [mapping_locality pg s tr h, mapping_locality pg s' tr' h', hagree]
+
+/-! ### The dimensions as unwinding instances
+
+The authority and memory frame lemmas above are exactly the local obligation the
+unwinding framework asks for, so each dimension is an instance. Two further
+dimensions, the admitted-capsule set and the DMA log, are added the same way with
+only their one-line frame lemma, which is what makes the framework pay off. -/
+
+/-- Authority as an unwinding datum. -/
+def tokenUnwinding (q : Nat) : Unwinding (Nat → Bool) where
+  view := fun s => s.token q
+  touches := TouchesToken q
+  step_frame := step_preserves_token q
+
+/-- Memory as an unwinding datum. -/
+def pageUnwinding (pg : Nat) : Unwinding (Option Isolation.Perm) where
+  view := fun s => s.mapped pg
+  touches := TouchesPage pg
+  step_frame := step_preserves_mapping pg
+
+/-- Only a `spawn` transition changes the admitted-capsule set. -/
+def TouchesAdmitted : Syscall → Prop
+  | .spawn _ => True
+  | _ => False
+
+theorem step_preserves_admitted (s : State) (sc : Syscall)
+    (h : ¬ TouchesAdmitted sc) : (step s sc).admitted = s.admitted := by
+  cases sc with
+  | spawn cap => exact absurd trivial h
+  | attenuate pid mask => rfl
+  | transfer src dst b => simp only [step]; split <;> rfl
+  | revoke pid b => rfl
+  | mapPage page p => simp only [step]; split <;> rfl
+  | userCopy addr len => simp only [step]; split <;> rfl
+  | boot v => rfl
+  | dmaMap r c => simp only [step]; split <;> rfl
+  | loadElf e => simp only [step]; split <;> rfl
+  | bindMsix i => simp only [step]; split <;> rfl
+  | acquire pid n => rfl
+
+/-- The admitted-capsule set as an unwinding datum. -/
+def admittedUnwinding : Unwinding (List Nat) where
+  view := fun s => s.admitted
+  touches := TouchesAdmitted
+  step_frame := step_preserves_admitted
+
+/-- Only a `dmaMap` transition changes the DMA log. -/
+def TouchesDma : Syscall → Prop
+  | .dmaMap _ _ => True
+  | _ => False
+
+theorem step_preserves_dma (s : State) (sc : Syscall)
+    (h : ¬ TouchesDma sc) : (step s sc).dma = s.dma := by
+  cases sc with
+  | dmaMap r c => exact absurd trivial h
+  | attenuate pid mask => rfl
+  | transfer src dst b => simp only [step]; split <;> rfl
+  | revoke pid b => rfl
+  | mapPage page p => simp only [step]; split <;> rfl
+  | userCopy addr len => simp only [step]; split <;> rfl
+  | boot v => rfl
+  | spawn cap => simp only [step]; split <;> rfl
+  | loadElf e => simp only [step]; split <;> rfl
+  | bindMsix i => simp only [step]; split <;> rfl
+  | acquire pid n => rfl
+
+/-- The DMA log as an unwinding datum. -/
+def dmaUnwinding : Unwinding (List (DmaMap.Req × DmaMap.Claim)) where
+  view := fun s => s.dma
+  touches := TouchesDma
+  step_frame := step_preserves_dma
+
+/-- Non-interference for the admitted-capsule set, an instance of the framework:
+    a trace with no spawn leaves the admitted set of another observer unchanged. -/
+theorem admitted_noninterference (s s' : State) (tr tr' : List Syscall)
+    (hagree : s.admitted = s'.admitted)
+    (h : ∀ sc ∈ tr, ¬ TouchesAdmitted sc) (h' : ∀ sc ∈ tr', ¬ TouchesAdmitted sc) :
+    (run s tr).admitted = (run s' tr').admitted :=
+  admittedUnwinding.noninterference s s' tr tr' hagree h h'
+
+/-- Non-interference for the DMA log, an instance of the framework: a trace with
+    no DMA mapping leaves the DMA log of another observer unchanged. -/
+theorem dma_noninterference (s s' : State) (tr tr' : List Syscall)
+    (hagree : s.dma = s'.dma)
+    (h : ∀ sc ∈ tr, ¬ TouchesDma sc) (h' : ∀ sc ∈ tr', ¬ TouchesDma sc) :
+    (run s tr).dma = (run s' tr').dma :=
+  dmaUnwinding.noninterference s s' tr tr' hagree h h'
+
+/-! ### The remaining state components
+
+For completeness the last four components of the machine state, the user-copy
+log, the anti-rollback floor, the ELF-load log and the interrupt-bind log, are
+each an unwinding instance as well. Every observable component of the state is
+therefore non-interfering: nothing an observer is not part of can be seen in, or
+leak into, any component it observes. -/
+
+/-- Only a `userCopy` transition changes the accepted-copy log. -/
+def TouchesCopies : Syscall → Prop
+  | .userCopy _ _ => True
+  | _ => False
+
+theorem step_preserves_copies (s : State) (sc : Syscall)
+    (h : ¬ TouchesCopies sc) : (step s sc).copies = s.copies := by
+  cases sc with
+  | userCopy addr len => exact absurd trivial h
+  | attenuate pid mask => rfl
+  | transfer src dst b => simp only [step]; split <;> rfl
+  | revoke pid b => rfl
+  | mapPage page p => simp only [step]; split <;> rfl
+  | boot v => rfl
+  | spawn cap => simp only [step]; split <;> rfl
+  | dmaMap r c => simp only [step]; split <;> rfl
+  | loadElf e => simp only [step]; split <;> rfl
+  | bindMsix i => simp only [step]; split <;> rfl
+  | acquire pid n => rfl
+
+def copiesUnwinding : Unwinding (List (Nat × Nat)) where
+  view := fun s => s.copies
+  touches := TouchesCopies
+  step_frame := step_preserves_copies
+
+/-- Only a `boot` transition changes the anti-rollback floor. -/
+def TouchesFloor : Syscall → Prop
+  | .boot _ => True
+  | _ => False
+
+theorem step_preserves_floor (s : State) (sc : Syscall)
+    (h : ¬ TouchesFloor sc) : (step s sc).floor = s.floor := by
+  cases sc with
+  | boot v => exact absurd trivial h
+  | attenuate pid mask => rfl
+  | transfer src dst b => simp only [step]; split <;> rfl
+  | revoke pid b => rfl
+  | mapPage page p => simp only [step]; split <;> rfl
+  | userCopy addr len => simp only [step]; split <;> rfl
+  | spawn cap => simp only [step]; split <;> rfl
+  | dmaMap r c => simp only [step]; split <;> rfl
+  | loadElf e => simp only [step]; split <;> rfl
+  | bindMsix i => simp only [step]; split <;> rfl
+  | acquire pid n => rfl
+
+def floorUnwinding : Unwinding Nat where
+  view := fun s => s.floor
+  touches := TouchesFloor
+  step_frame := step_preserves_floor
+
+/-- Only a `loadElf` transition changes the ELF-load log. -/
+def TouchesElf : Syscall → Prop
+  | .loadElf _ => True
+  | _ => False
+
+theorem step_preserves_elf (s : State) (sc : Syscall)
+    (h : ¬ TouchesElf sc) : (step s sc).elf = s.elf := by
+  cases sc with
+  | loadElf e => exact absurd trivial h
+  | attenuate pid mask => rfl
+  | transfer src dst b => simp only [step]; split <;> rfl
+  | revoke pid b => rfl
+  | mapPage page p => simp only [step]; split <;> rfl
+  | userCopy addr len => simp only [step]; split <;> rfl
+  | boot v => rfl
+  | spawn cap => simp only [step]; split <;> rfl
+  | dmaMap r c => simp only [step]; split <;> rfl
+  | bindMsix i => simp only [step]; split <;> rfl
+  | acquire pid n => rfl
+
+def elfUnwinding : Unwinding (List ElfSpec) where
+  view := fun s => s.elf
+  touches := TouchesElf
+  step_frame := step_preserves_elf
+
+/-- Only a `bindMsix` transition changes the interrupt-bind log. -/
+def TouchesIrq : Syscall → Prop
+  | .bindMsix _ => True
+  | _ => False
+
+theorem step_preserves_irq (s : State) (sc : Syscall)
+    (h : ¬ TouchesIrq sc) : (step s sc).irq = s.irq := by
+  cases sc with
+  | bindMsix i => exact absurd trivial h
+  | acquire pid n => rfl
+  | attenuate pid mask => rfl
+  | transfer src dst b => simp only [step]; split <;> rfl
+  | revoke pid b => rfl
+  | mapPage page p => simp only [step]; split <;> rfl
+  | userCopy addr len => simp only [step]; split <;> rfl
+  | boot v => rfl
+  | spawn cap => simp only [step]; split <;> rfl
+  | dmaMap r c => simp only [step]; split <;> rfl
+  | loadElf e => simp only [step]; split <;> rfl
+
+def irqUnwinding : Unwinding (List IrqBind.Input) where
+  view := fun s => s.irq
+  touches := TouchesIrq
+  step_frame := step_preserves_irq
+
+/-- Non-interference for the accepted-copy log. -/
+theorem copies_noninterference (s s' : State) (tr tr' : List Syscall)
+    (hagree : s.copies = s'.copies)
+    (h : ∀ sc ∈ tr, ¬ TouchesCopies sc) (h' : ∀ sc ∈ tr', ¬ TouchesCopies sc) :
+    (run s tr).copies = (run s' tr').copies :=
+  copiesUnwinding.noninterference s s' tr tr' hagree h h'
+
+/-- Non-interference for the anti-rollback floor. -/
+theorem floor_noninterference (s s' : State) (tr tr' : List Syscall)
+    (hagree : s.floor = s'.floor)
+    (h : ∀ sc ∈ tr, ¬ TouchesFloor sc) (h' : ∀ sc ∈ tr', ¬ TouchesFloor sc) :
+    (run s tr).floor = (run s' tr').floor :=
+  floorUnwinding.noninterference s s' tr tr' hagree h h'
+
+/-- Non-interference for the ELF-load log. -/
+theorem elf_noninterference (s s' : State) (tr tr' : List Syscall)
+    (hagree : s.elf = s'.elf)
+    (h : ∀ sc ∈ tr, ¬ TouchesElf sc) (h' : ∀ sc ∈ tr', ¬ TouchesElf sc) :
+    (run s tr).elf = (run s' tr').elf :=
+  elfUnwinding.noninterference s s' tr tr' hagree h h'
+
+/-- Non-interference for the interrupt-bind log. -/
+theorem irq_noninterference (s s' : State) (tr tr' : List Syscall)
+    (hagree : s.irq = s'.irq)
+    (h : ∀ sc ∈ tr, ¬ TouchesIrq sc) (h' : ∀ sc ∈ tr', ¬ TouchesIrq sc) :
+    (run s tr).irq = (run s' tr').irq :=
+  irqUnwinding.noninterference s s' tr tr' hagree h h'
+
+/-! ### Per-domain observational equivalence (confidentiality)
+
+The instances above isolate one component of the whole state at a time. The
+statement a capability system ultimately wants is per domain: a capsule observes
+its own authority and the mappings of the pages it owns, and nothing another
+capsule does outside that footprint changes what it observes. With an ownership
+relation `owns q pg` the combined observation is again an unwinding instance, so
+the confidentiality result falls out of the same framework: two states that look
+identical to a domain stay identical to it under any two traces that never touch
+its footprint. -/
+
+/-- A domain's observation: its authority, and the installed permission of every
+    page it owns. Pages it does not own read as `none`, so they are invisible to
+    it and cannot enter its observation. -/
+def DomainView (owns : Nat → Nat → Bool) (q : Nat) (s : State) :
+    (Nat → Bool) × (Nat → Option Isolation.Perm) :=
+  (s.token q, fun pg => if owns q pg = true then s.mapped pg else none)
+
+/-- A transition touches domain `q` if it names `q`'s authority or maps a page
+    that `q` owns. Every other transition is outside `q`'s footprint. -/
+def TouchesDomain (owns : Nat → Nat → Bool) (q : Nat) : Syscall → Prop
+  | .attenuate pid _ => pid = q
+  | .transfer _ dst _ => dst = q
+  | .revoke pid _ => pid = q
+  | .mapPage page _ => owns q page = true
+  | _ => False
+
+/-- Touching a domain's token is a special case of touching the domain: the
+    authority-naming transitions are shared between the two predicates. -/
+theorem touchesToken_imp_domain (owns : Nat → Nat → Bool) (q : Nat) (sc : Syscall)
+    (h : TouchesToken q sc) : TouchesDomain owns q sc := by
+  cases sc with
+  | attenuate pid mask => exact h
+  | transfer src dst b => exact h
+  | revoke pid b => exact h
+  | mapPage page p => exact h.elim
+  | userCopy addr len => exact h.elim
+  | boot v => exact h.elim
+  | spawn cap => exact h.elim
+  | dmaMap r c => exact h.elim
+  | loadElf e => exact h.elim
+  | bindMsix i => exact h.elim
+  | acquire pid n => exact h.elim
+
+/-- The combined frame lemma: a transition outside domain `q`'s footprint leaves
+    both its authority and its owned-page mappings, and so its whole observation,
+    exactly as they were. -/
+theorem step_preserves_domain_view (owns : Nat → Nat → Bool) (q : Nat) (s : State)
+    (sc : Syscall) (h : ¬ TouchesDomain owns q sc) :
+    DomainView owns q (step s sc) = DomainView owns q s := by
+  have htok : (step s sc).token q = s.token q :=
+    step_preserves_token q s sc (fun ht => h (touchesToken_imp_domain owns q sc ht))
+  have hmap : ∀ pg, owns q pg = true → (step s sc).mapped pg = s.mapped pg := by
+    intro pg hown
+    apply step_preserves_mapping pg s sc
+    intro htp
+    cases sc with
+    | mapPage page p =>
+      have hpage : owns q page = true := by
+        have : page = pg := htp
+        rw [this]; exact hown
+      exact h hpage
+    | attenuate pid mask => exact htp.elim
+    | transfer src dst b => exact htp.elim
+    | revoke pid b => exact htp.elim
+    | userCopy addr len => exact htp.elim
+    | boot v => exact htp.elim
+    | spawn cap => exact htp.elim
+    | dmaMap r c => exact htp.elim
+    | loadElf e => exact htp.elim
+    | bindMsix i => exact htp.elim
+    | acquire pid n => exact htp.elim
+  have hmapfn :
+      (fun pg => if owns q pg = true then (step s sc).mapped pg else (none : Option Isolation.Perm))
+        = (fun pg => if owns q pg = true then s.mapped pg else none) := by
+    funext pg
+    by_cases hown : owns q pg = true
+    · rw [if_pos hown, if_pos hown, hmap pg hown]
+    · rw [if_neg hown, if_neg hown]
+  unfold DomainView
+  rw [htok, hmapfn]
+
+/-- The domain observation as an unwinding datum. -/
+def domainUnwinding (owns : Nat → Nat → Bool) (q : Nat) :
+    Unwinding ((Nat → Bool) × (Nat → Option Isolation.Perm)) where
+  view := DomainView owns q
+  touches := TouchesDomain owns q
+  step_frame := step_preserves_domain_view owns q
+
+/-- Confidentiality, as observational equivalence: two states that a domain `q`
+    cannot tell apart stay indistinguishable to it after any two traces that
+    never touch its footprint. Whatever the rest of the system does, and however
+    the adversary interleaves it, `q`'s view of its own authority and memory is
+    unchanged. This is the per-domain non-interference the whole development is
+    aimed at, and it is an instance of the same unwinding framework. -/
+theorem domain_noninterference (owns : Nat → Nat → Bool) (q : Nat) (s s' : State)
+    (tr tr' : List Syscall)
+    (hagree : DomainView owns q s = DomainView owns q s')
+    (h : ∀ sc ∈ tr, ¬ TouchesDomain owns q sc)
+    (h' : ∀ sc ∈ tr', ¬ TouchesDomain owns q sc) :
+    DomainView owns q (run s tr) = DomainView owns q (run s' tr') :=
+  (domainUnwinding owns q).noninterference s s' tr tr' hagree h h'
+
+/-! ### Multi-domain spatial isolation
+
+Two capsules with disjoint footprints, distinct identities and no page in common,
+never touch each other: a transition inside one's footprint is always outside the
+other's. So all of one capsule's activity leaves the other's observation exactly
+as it was. This is the separation guarantee a capability microkernel exists to
+provide, and it composes directly from the per-domain view. -/
+
+/-- Two domains have disjoint footprints when they are distinct and own no page
+    in common. -/
+def DisjointFootprint (owns : Nat → Nat → Bool) (q1 q2 : Nat) : Prop :=
+  q1 ≠ q2 ∧ ∀ pg, ¬ (owns q1 pg = true ∧ owns q2 pg = true)
+
+/-- A transition inside one domain's footprint is outside a disjoint domain's:
+    distinct capsules with disjoint memory never touch one another. -/
+theorem touches_disjoint (owns : Nat → Nat → Bool) (q1 q2 : Nat)
+    (hd : DisjointFootprint owns q1 q2) (sc : Syscall)
+    (h : TouchesDomain owns q1 sc) : ¬ TouchesDomain owns q2 sc := by
+  obtain ⟨hne, hpg⟩ := hd
+  cases sc with
+  | attenuate pid mask => intro h2; exact hne (h.symm.trans h2)
+  | transfer src dst b => intro h2; exact hne (h.symm.trans h2)
+  | revoke pid b => intro h2; exact hne (h.symm.trans h2)
+  | mapPage page p => intro h2; exact hpg page ⟨h, h2⟩
+  | userCopy addr len => exact h.elim
+  | boot v => exact h.elim
+  | spawn cap => exact h.elim
+  | dmaMap r c => exact h.elim
+  | loadElf e => exact h.elim
+  | bindMsix i => exact h.elim
+  | acquire pid n => exact h.elim
+
+/-- Spatial isolation: a trace whose every transition lies in domain `q1`'s
+    footprint leaves a disjoint domain `q2`'s observation exactly as it was. One
+    capsule's activity is invisible to another it shares no memory with, whatever
+    that activity is. -/
+theorem domain_isolation (owns : Nat → Nat → Bool) (q1 q2 : Nat)
+    (hd : DisjointFootprint owns q1 q2) (s : State) (tr : List Syscall)
+    (h : ∀ sc ∈ tr, TouchesDomain owns q1 sc) :
+    DomainView owns q2 (run s tr) = DomainView owns q2 s :=
+  (domainUnwinding owns q2).locality s tr
+    (fun sc hsc => touches_disjoint owns q1 q2 hd sc (h sc hsc))
+
+/-- Two disjoint capsules do not interfere: starting from any two states `q2`
+    cannot tell apart, after any two traces each confined to `q1`'s footprint,
+    `q2` still cannot tell them apart. Confidentiality between capsules that share
+    no memory, with the adversary driving `q1` however it likes. -/
+theorem disjoint_domains_noninterfere (owns : Nat → Nat → Bool) (q1 q2 : Nat)
+    (hd : DisjointFootprint owns q1 q2) (s s' : State) (tr tr' : List Syscall)
+    (hagree : DomainView owns q2 s = DomainView owns q2 s')
+    (h : ∀ sc ∈ tr, TouchesDomain owns q1 sc)
+    (h' : ∀ sc ∈ tr', TouchesDomain owns q1 sc) :
+    DomainView owns q2 (run s tr) = DomainView owns q2 (run s' tr') := by
+  rw [domain_isolation owns q1 q2 hd s tr h,
+      domain_isolation owns q1 q2 hd s' tr' h', hagree]
+
+end Nonos.NonInterference

--- a/verification/lean/Nonos/Secure.lean
+++ b/verification/lean/Nonos/Secure.lean
@@ -11,33 +11,53 @@ The conjoined security theorem. The other modules prove local lemmas about
 one operation at a time; this module composes them into a single invariant
 over a transition system whose steps are the security-relevant kernel
 operations: capability attenuation, transfer, and revocation, page mapping,
-user copies, and boot. `Secure` conjoins authority conservation (no step
-manufactures a right nobody held initially), memory isolation (no installed
-mapping is writable and executable, and every accepted user copy lies inside
-user space), and anti-rollback (the version floor never decreases).
-`every_trace_is_secure` proves the conjunction holds after every trace of
-every length, so a hostile sequence of these operations cannot escape it.
+user copies, boot, capsule spawn, and device DMA mapping. `Secure` conjoins
+authority conservation (no step manufactures a right nobody held initially),
+memory isolation (no installed mapping is writable and executable, and every
+accepted user copy lies inside user space), anti-rollback (the version floor
+never decreases), attestation (only an attested capsule is admitted), and DMA
+confinement (every installed DMA mapping passed the broker's admission guard,
+so it is owned by its claiming caller and bounded by the device class's page
+limit). `every_trace_is_secure` proves the conjunction holds after every trace
+of every length, so a hostile sequence of these operations cannot escape it.
 
 Each transition's obligation is discharged on the real kernel code
 elsewhere: the capability steps by verification/verus/src/capabilities.rs
 and the kernel_proofs differential harnesses over src/capabilities/bits.rs,
 the mapping gate by the to_pte_flags proofs over
 src/memory/paging/types/permissions/convert.rs, the copy gate by the
-check_range proofs over src/usercopy/policy.rs, and the boot step by
-nonos-bootloader/boot_proofs.
+check_range proofs over src/usercopy/policy.rs, the boot step by
+nonos-bootloader/boot_proofs, and the DMA-map guard by the broker validate
+over src/hardware/broker (modelled in Nonos.DmaMap).
 -/
 
 import Nonos.Capability
 import Nonos.Isolation
 import Nonos.AntiRollback
+import Nonos.DmaMap
+import Nonos.ElfPhdr
+import Nonos.IrqBind
+import Nonos.Quota
 
 namespace Nonos.Secure
 
 open Nonos.Capability (Caps Grants)
 
+/-- The inputs the ELF program-header bounds check reads: the image length, the
+    header-table offset, the entry size, the entry count, and the size the loader
+    expects each entry to be. -/
+structure ElfSpec where
+  dataLen : Nat
+  phoff : Nat
+  phsize : Nat
+  phnum : Nat
+  expected : Nat
+
 /-- The abstract machine state: each process's capability token, the
-    installed page permissions, the accepted user-copy log, and the
-    anti-rollback floor. -/
+    installed page permissions, the accepted user-copy log, the anti-rollback
+    floor, the admitted-capsule log, the attestation oracle, the installed
+    DMA mappings as the request/claim pair the broker admitted, and the ELF
+    header tables the loader accepted. -/
 structure State where
   token : Nat → Caps
   mapped : Nat → Option Isolation.Perm
@@ -45,6 +65,10 @@ structure State where
   floor : Nat
   admitted : List Nat
   attest : Nat → Bool
+  dma : List (DmaMap.Req × DmaMap.Claim)
+  elf : List ElfSpec
+  irq : List IrqBind.Input
+  quota : Nat → Quota.Q
 
 /-- The security-relevant transitions. -/
 inductive Syscall where
@@ -55,12 +79,16 @@ inductive Syscall where
   | userCopy (addr len : Nat)
   | boot (v : Nat)
   | spawn (cap : Nat)
+  | dmaMap (r : DmaMap.Req) (c : DmaMap.Claim)
+  | loadElf (e : ElfSpec)
+  | bindMsix (i : IrqBind.Input)
+  | acquire (pid : Nat) (n : Nat)
 
 /-- One step of the machine. Every arm is the guard the kernel enforces:
     attenuation meets the caller's own token, a transfer moves only a right
     the source holds, mapping rejects a W^X violation, a copy is logged only
-    if the range check accepts it, and boot goes through the anti-rollback
-    update. -/
+    if the range check accepts it, spawn admits only an attested capsule, and a
+    DMA mapping is installed only when the broker's `validate` returns `ok`. -/
 def step (s : State) : Syscall → State
   | .attenuate pid mask =>
       { s with token := fun p =>
@@ -84,6 +112,18 @@ def step (s : State) : Syscall → State
       { s with floor := (AntiRollback.update { floor := s.floor } v).floor }
   | .spawn cap =>
       if s.attest cap then { s with admitted := cap :: s.admitted } else s
+  | .dmaMap r c =>
+      if DmaMap.validate r c = .ok then { s with dma := (r, c) :: s.dma } else s
+  | .loadElf e =>
+      if ElfPhdr.check e.dataLen e.phoff e.phsize e.phnum e.expected
+          = .ok e.phoff e.phsize e.phnum then
+        { s with elf := e :: s.elf }
+      else s
+  | .bindMsix i =>
+      if IrqBind.validate i = .ok then { s with irq := i :: s.irq } else s
+  | .acquire pid n =>
+      { s with quota := fun p =>
+          if p = pid then Quota.acquire (s.quota p) n else s.quota p }
 
 /-- A whole execution. -/
 def run (s : State) : List Syscall → State
@@ -96,7 +136,9 @@ def run (s : State) : List Syscall → State
     held at the start; no sequence of attenuations, transfers, and
     revocations manufactures authority. Isolation: no installed mapping is
     writable and executable, and every byte of every accepted copy lies in
-    user space. Anti-rollback: the floor never went down. -/
+    user space. Anti-rollback: the floor never went down. Attestation: every
+    admitted capsule was attested. DMA confinement: every installed DMA
+    mapping passed the broker's admission guard. -/
 structure Secure (s0 s : State) : Prop where
   authority : ∀ b, (∃ p, Grants (s.token p) b) → ∃ p, Grants (s0.token p) b
   no_wx : ∀ page pm, s.mapped page = some pm →
@@ -104,29 +146,47 @@ structure Secure (s0 s : State) : Prop where
   copies_in_user_space : ∀ c ∈ s.copies, ∀ i < c.2, c.1 + i ≤ Isolation.userEnd
   floor_monotone : s0.floor ≤ s.floor
   admitted_attested : ∀ c ∈ s.admitted, s.attest c = true
+  dma_confined : ∀ rc ∈ s.dma, DmaMap.validate rc.1 rc.2 = .ok
+  elf_in_bounds : ∀ e ∈ s.elf,
+    ElfPhdr.check e.dataLen e.phoff e.phsize e.phnum e.expected
+      = .ok e.phoff e.phsize e.phnum
+  irq_confined : ∀ i ∈ s.irq, IrqBind.validate i = .ok
+  quota_ok : ∀ p, Quota.ok (s.quota p)
 
-/-- A state with no W^X mapping and no logged copies is secure against
-    itself: the induction base. -/
+/-- A state with no W^X mapping, no logged copies, no admitted capsule, and no
+    DMA mapping is secure against itself: the induction base. -/
 theorem secure_refl (s0 : State)
     (hwx : ∀ page pm, s0.mapped page = some pm →
       ¬(pm.write = true ∧ pm.execute = true))
-    (hcopies : s0.copies = []) (hadmit : s0.admitted = []) : Secure s0 s0 := by
-  refine ⟨fun b h => h, hwx, ?_, Nat.le_refl _, ?_⟩
+    (hcopies : s0.copies = []) (hadmit : s0.admitted = [])
+    (hdma : s0.dma = []) (helf : s0.elf = []) (hirq : s0.irq = [])
+    (hquota : ∀ p, Quota.ok (s0.quota p)) :
+    Secure s0 s0 := by
+  refine ⟨fun b h => h, hwx, ?_, Nat.le_refl _, ?_, ?_, ?_, ?_, hquota⟩
   · intro c hc
     rw [hcopies] at hc
     exact absurd hc (List.not_mem_nil c)
   · intro c hc
     rw [hadmit] at hc
     exact absurd hc (List.not_mem_nil c)
+  · intro rc hrc
+    rw [hdma] at hrc
+    exact absurd hrc (List.not_mem_nil rc)
+  · intro e he
+    rw [helf] at he
+    exact absurd he (List.not_mem_nil e)
+  · intro i hi
+    rw [hirq] at hi
+    exact absurd hi (List.not_mem_nil i)
 
 /-- The heart of the theorem: every single transition preserves the whole
     conjunction. -/
 theorem step_preserves_secure (s0 s : State) (sc : Syscall)
     (h : Secure s0 s) : Secure s0 (step s sc) := by
-  obtain ⟨hauth, hwx, hcopy, hfloor, hadm⟩ := h
+  obtain ⟨hauth, hwx, hcopy, hfloor, hadm, hdma, helf, hirq, hquota⟩ := h
   cases sc with
   | attenuate pid mask =>
-    refine ⟨?_, hwx, hcopy, hfloor, hadm⟩
+    refine ⟨?_, hwx, hcopy, hfloor, hadm, hdma, helf, hirq, hquota⟩
     intro b ⟨p, hp⟩
     by_cases hpid : p = pid
     · subst hpid
@@ -138,7 +198,7 @@ theorem step_preserves_secure (s0 s : State) (sc : Syscall)
     simp only [step]
     split
     · rename_i hsrc
-      refine ⟨?_, hwx, hcopy, hfloor, hadm⟩
+      refine ⟨?_, hwx, hcopy, hfloor, hadm, hdma, helf, hirq, hquota⟩
       intro b ⟨p, hp⟩
       by_cases hpd : p = dst
       · subst hpd
@@ -154,9 +214,9 @@ theorem step_preserves_secure (s0 s : State) (sc : Syscall)
           exact hauth b ⟨src, hsrc⟩
       · have hp' : (s.token p) b = true := by simpa [hpd] using hp
         exact hauth b ⟨p, hp'⟩
-    · exact ⟨hauth, hwx, hcopy, hfloor, hadm⟩
+    · exact ⟨hauth, hwx, hcopy, hfloor, hadm, hdma, helf, hirq, hquota⟩
   | revoke pid b' =>
-    refine ⟨?_, hwx, hcopy, hfloor, hadm⟩
+    refine ⟨?_, hwx, hcopy, hfloor, hadm, hdma, helf, hirq, hquota⟩
     intro b ⟨p, hp⟩
     by_cases hpid : p = pid
     · subst hpid
@@ -167,9 +227,9 @@ theorem step_preserves_secure (s0 s : State) (sc : Syscall)
   | mapPage page p =>
     simp only [step]
     split
-    · exact ⟨hauth, hwx, hcopy, hfloor, hadm⟩
+    · exact ⟨hauth, hwx, hcopy, hfloor, hadm, hdma, helf, hirq, hquota⟩
     · rename_i hnotwx
-      refine ⟨hauth, ?_, hcopy, hfloor, hadm⟩
+      refine ⟨hauth, ?_, hcopy, hfloor, hadm, hdma, helf, hirq, hquota⟩
       intro q pm hq
       by_cases hqp : q = page
       · subst hqp
@@ -182,7 +242,7 @@ theorem step_preserves_secure (s0 s : State) (sc : Syscall)
     simp only [step]
     split
     · rename_i hacc
-      refine ⟨hauth, hwx, ?_, hfloor, hadm⟩
+      refine ⟨hauth, hwx, ?_, hfloor, hadm, hdma, helf, hirq, hquota⟩
       intro c hc
       simp at hc
       obtain hnew | hold := hc
@@ -191,22 +251,65 @@ theorem step_preserves_secure (s0 s : State) (sc : Syscall)
         obtain ⟨_, _, hbound⟩ := hacc
         omega
       · exact hcopy c hold
-    · exact ⟨hauth, hwx, hcopy, hfloor, hadm⟩
+    · exact ⟨hauth, hwx, hcopy, hfloor, hadm, hdma, helf, hirq, hquota⟩
   | boot v =>
-    refine ⟨hauth, hwx, hcopy, ?_, hadm⟩
+    refine ⟨hauth, hwx, hcopy, ?_, hadm, hdma, helf, hirq, hquota⟩
     exact Nat.le_trans hfloor
       (AntiRollback.update_never_lowers_floor { floor := s.floor } v)
   | spawn cap =>
     simp only [step]
     by_cases hatt : s.attest cap = true
     · rw [if_pos hatt]
-      refine ⟨hauth, hwx, hcopy, hfloor, ?_⟩
+      refine ⟨hauth, hwx, hcopy, hfloor, ?_, hdma, helf, hirq, hquota⟩
       intro c hc
       rcases List.mem_cons.mp hc with hc | hc
       · subst hc; exact hatt
       · exact hadm c hc
     · rw [if_neg hatt]
-      exact ⟨hauth, hwx, hcopy, hfloor, hadm⟩
+      exact ⟨hauth, hwx, hcopy, hfloor, hadm, hdma, helf, hirq, hquota⟩
+  | dmaMap r c =>
+    simp only [step]
+    by_cases hv : DmaMap.validate r c = .ok
+    · rw [if_pos hv]
+      refine ⟨hauth, hwx, hcopy, hfloor, hadm, ?_, helf, hirq, hquota⟩
+      intro rc hmem
+      rcases List.mem_cons.mp hmem with hhead | htail
+      · subst hhead; exact hv
+      · exact hdma rc htail
+    · rw [if_neg hv]
+      exact ⟨hauth, hwx, hcopy, hfloor, hadm, hdma, helf, hirq, hquota⟩
+  | loadElf e =>
+    simp only [step]
+    by_cases hv : ElfPhdr.check e.dataLen e.phoff e.phsize e.phnum e.expected
+        = .ok e.phoff e.phsize e.phnum
+    · rw [if_pos hv]
+      refine ⟨hauth, hwx, hcopy, hfloor, hadm, hdma, ?_, hirq, hquota⟩
+      intro e' hmem
+      rcases List.mem_cons.mp hmem with hhead | htail
+      · subst hhead; exact hv
+      · exact helf e' htail
+    · rw [if_neg hv]
+      exact ⟨hauth, hwx, hcopy, hfloor, hadm, hdma, helf, hirq, hquota⟩
+  | bindMsix i =>
+    simp only [step]
+    by_cases hv : IrqBind.validate i = .ok
+    · rw [if_pos hv]
+      refine ⟨hauth, hwx, hcopy, hfloor, hadm, hdma, helf, ?_, hquota⟩
+      intro i' hmem
+      rcases List.mem_cons.mp hmem with hhead | htail
+      · subst hhead; exact hv
+      · exact hirq i' htail
+    · rw [if_neg hv]
+      exact ⟨hauth, hwx, hcopy, hfloor, hadm, hdma, helf, hirq, hquota⟩
+  | acquire pid n =>
+    refine ⟨hauth, hwx, hcopy, hfloor, hadm, hdma, helf, hirq, ?_⟩
+    intro p
+    simp only [step]
+    by_cases hp : p = pid
+    · rw [if_pos hp]
+      exact Quota.acquire_preserves_ok (s.quota p) n (hquota p)
+    · rw [if_neg hp]
+      exact hquota p
 
 /-- Security is preserved along any run, from any secure intermediate
     state. -/
@@ -222,8 +325,59 @@ theorem run_preserves_secure (s0 : State) (tr : List Syscall) (s : State)
 theorem every_trace_is_secure (s0 : State) (tr : List Syscall)
     (hwx : ∀ page pm, s0.mapped page = some pm →
       ¬(pm.write = true ∧ pm.execute = true))
-    (hcopies : s0.copies = []) (hadmit : s0.admitted = []) :
+    (hcopies : s0.copies = []) (hadmit : s0.admitted = [])
+    (hdma : s0.dma = []) (helf : s0.elf = []) (hirq : s0.irq = [])
+    (hquota : ∀ p, Quota.ok (s0.quota p)) :
     Secure s0 (run s0 tr) :=
-  run_preserves_secure s0 tr s0 (secure_refl s0 hwx hcopies hadmit)
+  run_preserves_secure s0 tr s0
+    (secure_refl s0 hwx hcopies hadmit hdma helf hirq hquota)
+
+/-- Corollary of the conjoined invariant (availability): in any reachable state
+    every domain's resource use is within its cap, so no capsule can consume past
+    its quota and starve the others. -/
+theorem quota_within_cap (s0 s : State) (h : Secure s0 s) (p : Nat) :
+    (s.quota p).used ≤ (s.quota p).cap :=
+  h.quota_ok p
+
+/-- Corollary of the conjoined invariant: in any reachable state, every
+    installed DMA mapping is owned by the caller that claimed the device. A
+    caller can never program a device it does not hold to DMA on its behalf. -/
+theorem dma_owned_by_caller (s0 s : State) (h : Secure s0 s)
+    (rc : DmaMap.Req × DmaMap.Claim) (hmem : rc ∈ s.dma) :
+    rc.2.pid = rc.1.reqPid :=
+  DmaMap.accepted_owned_by_caller rc.1 rc.2 (h.dma_confined rc hmem)
+
+/-- Corollary of the conjoined invariant: every installed DMA mapping is within
+    its device class's page limit, so no reachable state has an unbounded DMA
+    window. -/
+theorem dma_within_class_limit (s0 s : State) (h : Secure s0 s)
+    (rc : DmaMap.Req × DmaMap.Claim) (hmem : rc ∈ s.dma) :
+    rc.1.length / DmaMap.page ≤ rc.2.pageLimit :=
+  DmaMap.accepted_within_class_limit rc.1 rc.2 (h.dma_confined rc hmem)
+
+/-- Corollary of the conjoined invariant: in any reachable state, every accepted
+    non-empty ELF program-header table lies wholly inside its image, so the loader
+    never reads a header entry past the buffer end. -/
+theorem elf_table_in_bounds (s0 s : State) (h : Secure s0 s)
+    (e : ElfSpec) (hmem : e ∈ s.elf) (hn : e.phnum ≠ 0) :
+    e.phoff + e.phsize * e.phnum ≤ e.dataLen :=
+  ElfPhdr.accepted_table_in_bounds e.dataLen e.phoff e.phsize e.phnum e.expected hn
+    (h.elf_in_bounds e hmem)
+
+/-- Corollary of the conjoined invariant: every installed MSI-X bind programs a
+    vector count within both the broker pool and the device's MSI-X table, so no
+    reachable state over-programs an interrupt table. -/
+theorem irq_vector_count_bounded (s0 s : State) (h : Secure s0 s)
+    (i : IrqBind.Input) (hmem : i ∈ s.irq) :
+    i.vectorCount ≠ 0 ∧ i.vectorCount ≤ i.poolCapacity ∧
+      i.vectorCount ≤ i.msixTableSize :=
+  IrqBind.accepted_vector_count_bounded i (h.irq_confined i hmem)
+
+/-- Corollary of the conjoined invariant: no installed MSI-X bind overwrote an
+    existing grant, so a bind is all-or-nothing per device per pid in every
+    reachable state. -/
+theorem irq_not_already_bound (s0 s : State) (h : Secure s0 s)
+    (i : IrqBind.Input) (hmem : i ∈ s.irq) : i.hasExistingGrant = false :=
+  IrqBind.accepted_not_already_bound i (h.irq_confined i hmem)
 
 end Nonos.Secure


### PR DESCRIPTION
Extends the Lean specification corpus with the security properties that turn a set of local invariants into a whole-system argument, all machine-checked and core-only (no Mathlib), each within the three standard axioms and none on a `sorry`.

## What this adds

- **Conjoined invariant, nine boundaries.** `every_trace_is_secure` now folds the broker dma-map admission, the ELF program-header bounds check, the MSI-X interrupt-bind validator and the per-process resource quota into one invariant, so it covers availability next to integrity and isolation, over an adversary-chosen trace of any length.
- **Non-interference and confidentiality.** An unwinding structure proves locality and non-interference once for any observation of the state. Instances cover all eight state components, a per-process view that combines a capsule's authority with the memory it owns, and spatial isolation between capsules that share no memory. Most of these proofs need no axioms at all.
- **Attestation bound to the invariant.** The abstract attestation oracle is instantiated with the transparent STARK gate's own accept decision. From a clean start, after any trace, every admitted capsule opened to the enrolled policy root under the bound context with an enrolled measurement, so a proof drawn for another policy or another identity carries no capsule into execution.
- **Scheduling fairness.** The ready set is invariant under any number of round-robin steps and a task at position i reaches the head after i rotations with i below the queue length, so none waits more than one pass and no task is starved.

## Evidence

Regenerated deterministically from source by `verification/evidence/collect-evidence.sh`:

- 936 machine-checked theorems across 123 modules, zero `sorry`
- 207 flagship theorems with a CI-audited axiom closure (standard axioms only, never `sorryAx`)

The whole corpus builds green with `lake build`, and `verification/lean/AxiomProfile.lean` prints the exact axiom closure of every load-bearing theorem, which the lean CI job runs and publishes.

## Scope

Specification-layer proofs over models of the security-critical operations, with each transition's guard matching the one the kernel enforces. The one gap that remains is binding these models to the compiler's MIR through mechanical extraction, which is tracked separately.
