### PR TITLE
stark: all-cores prover (bit-exact with serial)

### DIFF
--- a/nonos-stark/Cargo.toml
+++ b/nonos-stark/Cargo.toml
@@ -10,3 +10,9 @@ name = "nonos_stark"
 
 [dependencies]
 blake3 = { version = "1.0", default-features = false }
+rayon = { version = "1", optional = true }
+
+[features]
+# Host emit tooling only. Parallelizes the prover across all cores; never
+# enabled for the kernel or bootloader build, which stay no_std and serial.
+parallel = ["dep:rayon"]

--- a/nonos-stark/src/air/periodic_root.rs
+++ b/nonos-stark/src/air/periodic_root.rs
@@ -47,8 +47,12 @@ pub(super) fn periodic_lde_tree<A: AirExt>(
     let g = root_of_unity(log_t);
     let omega = root_of_unity(log_n);
     let shift = Fp::from_u64(SHIFT);
-    let periodic_d: Vec<Vec<Fp>> =
-        air.periodic_columns().iter().map(|col| lde(col, g, shift, omega, n)).collect();
+    // The per-column coset extension is independent, so the 444-column LDE — the
+    // dominant cost of a deep-domain emit — parallelizes over columns; the tree
+    // then commits with the parallel leaf layer. Serial and parallel produce the
+    // identical root by construction.
+    let cols = air.periodic_columns();
+    let periodic_d: Vec<Vec<Fp>> = crate::par::map_slice(&cols, |col| lde(col, g, shift, omega, n));
     let tree = MerkleTree::commit_wide_periodic(&periodic_d);
     (periodic_d, tree)
 }

--- a/nonos-stark/src/air/prove_ext_pre.rs
+++ b/nonos-stark/src/air/prove_ext_pre.rs
@@ -62,13 +62,14 @@ pub fn stark_prove_ext_preprocessed<A: AirExt>(
     let shift = Fp::from_u64(SHIFT);
 
     let mut transcript = Transcript::new(b"NONOS-STARK-EXT");
-    let mut trace_d: Vec<Vec<Fp>> = Vec::with_capacity(width);
-    let mut trace_coeffs: Vec<Vec<Fp>> = Vec::with_capacity(width);
-    for c in 0..width {
+    // Each column's interpolation and coset extension are independent of the
+    // others, so the trace LDE parallelizes over columns; the indexed map keeps
+    // column order, so the committed tree is identical to the serial one.
+    let cols: Vec<(Vec<Fp>, Vec<Fp>)> = crate::par::map_index(width, |c| {
         let column: Vec<Fp> = (0..t).map(|i| trace[i * width + c]).collect();
-        trace_coeffs.push(intt(&column, g));
-        trace_d.push(lde(&column, g, shift, omega, n));
-    }
+        (intt(&column, g), lde(&column, g, shift, omega, n))
+    });
+    let (trace_coeffs, trace_d): (Vec<Vec<Fp>>, Vec<Vec<Fp>>) = cols.into_iter().unzip();
     let trace_tree = MerkleTree::commit_wide(&trace_d);
     let trace_root = trace_tree.root();
     transcript.absorb_digest(&trace_root);
@@ -83,9 +84,10 @@ pub fn stark_prove_ext_preprocessed<A: AirExt>(
     let (periodic_d, periodic_tree) =
         super::periodic_root::periodic_lde_tree(air, extra_blowup_bits);
 
-    let mut comp_d: Vec<Fp2> = Vec::with_capacity(n);
-    let mut x = shift;
-    for j in 0..n {
+    // The composition value at each coset point is independent: the evaluation
+    // point is x_j = shift * omega^j, a pure function of j, so the whole
+    // codeword parallelizes over the domain.
+    let comp_d: Vec<Fp2> = crate::par::map_index(n, |j| {
         let mut window: Vec<Fp2> = Vec::with_capacity(window_size * width);
         for k in 0..window_size {
             let idx = (j + k * blowup) % n;
@@ -94,9 +96,9 @@ pub fn stark_prove_ext_preprocessed<A: AirExt>(
             }
         }
         let periodic: Vec<Fp2> = periodic_d.iter().map(|pd| Fp2::from_base(pd[j])).collect();
-        comp_d.push(compose_ext(air, g, Fp2::from_base(x), &window, &periodic, &coeffs));
-        x = x * omega;
-    }
+        let x = shift * omega.pow(j as u64);
+        compose_ext(air, g, Fp2::from_base(x), &window, &periodic, &coeffs)
+    });
     let comp_tree = MerkleTree::commit_ext(&comp_d);
     transcript.absorb_digest(&comp_tree.root());
 
@@ -137,9 +139,10 @@ pub fn stark_prove_ext_preprocessed<A: AirExt>(
     let deep_coeffs: Vec<Fp2> =
         (0..width * window_size + 1 + n_periodic).map(|_| transcript.challenge_fp2()).collect();
 
-    let mut deep_d: Vec<Fp2> = Vec::with_capacity(n);
-    let mut x = shift;
-    for j in 0..n {
+    // The DEEP quotient at each coset point is likewise independent of the
+    // others (same x_j = shift * omega^j), so it parallelizes over the domain.
+    let deep_d: Vec<Fp2> = crate::par::map_index(n, |j| {
+        let x = shift * omega.pow(j as u64);
         let mut acc = Fp2::ZERO;
         for k in 0..window_size {
             let zk = z * Fp2::from_base(g.pow(k as u64));
@@ -158,9 +161,8 @@ pub fn stark_prove_ext_preprocessed<A: AirExt>(
             let pc = deep_coeffs[width * window_size + 1 + pi];
             acc = acc + pc * ((Fp2::from_base(pd[j]) - periodic_z[pi]) * inv_x_z);
         }
-        deep_d.push(acc);
-        x = x * omega;
-    }
+        acc
+    });
 
     let fri = fri_prove_ext(&deep_d, shift, fri_log_blowup, n_queries, grind_bits);
     let deep_tree = MerkleTree::commit_ext(&deep_d);

--- a/nonos-stark/src/air/spec.rs
+++ b/nonos-stark/src/air/spec.rs
@@ -69,7 +69,10 @@ pub trait Air {
 /// `Felt` abstraction and delegating both `transition` and `transition_ext` to it,
 /// which keeps the trait object-safe. Only AIRs proven by the money-grade engine
 /// (`stark_prove_ext`) need it.
-pub trait AirExt: Air {
+// `Sync` lets the prover evaluate the composition and DEEP polynomials across
+// cores under the `parallel` feature; every AIR is plain data, so the bound is
+// satisfied automatically and the kernel build is unaffected.
+pub trait AirExt: Air + Sync {
     /// The transition constraints over the extension field, layout as `transition`.
     fn transition_ext(&self, window: &[Fp2], periodic: &[Fp2]) -> Vec<Fp2>;
 }

--- a/nonos-stark/src/lib.rs
+++ b/nonos-stark/src/lib.rs
@@ -24,7 +24,12 @@
 //! same code, so the Fiat-Shamir keccak and the measurement blake3 are
 //! byte-identical on the prover and the verifier.
 
-#![no_std]
+// The crate is `no_std` for the kernel and bootloader. The `parallel` feature —
+// used only by the host emit tooling, never by the kernel — pulls in std and
+// rayon so a production emit uses every core; the field arithmetic and the
+// commitment layout are identical either way, and a bit-exact gate proves the
+// parallel prover emits the same proof bytes as the serial one.
+#![cfg_attr(not(feature = "parallel"), no_std)]
 
 extern crate alloc;
 
@@ -37,6 +42,7 @@ pub mod fri_ext;
 pub mod fri_poseidon;
 pub mod fri_poseidon_ext;
 pub mod merkle;
+pub(crate) mod par;
 pub mod poly;
 pub mod poseidon_merkle;
 pub mod poseidon_transcript;

--- a/nonos-stark/src/merkle/tree.rs
+++ b/nonos-stark/src/merkle/tree.rs
@@ -32,7 +32,7 @@ impl MerkleTree {
     /// Commit to a sequence of leaves, returning the tree. An empty input
     /// commits to a single zero leaf so the root is always defined.
     pub fn commit(leaves: &[Fp]) -> MerkleTree {
-        let mut level: Vec<[u8; 32]> = leaves.iter().map(|l| hash_leaf(*l)).collect();
+        let mut level: Vec<[u8; 32]> = crate::par::map_slice(leaves, |l| hash_leaf(*l));
         if level.is_empty() {
             level.push(hash_leaf(Fp::ZERO));
         }
@@ -46,7 +46,7 @@ impl MerkleTree {
     /// Same tree structure and node hashing as `commit`; only the leaf hash
     /// differs, so paths open identically via `verify_path_ext`.
     pub fn commit_ext(leaves: &[Fp2]) -> MerkleTree {
-        let mut level: Vec<[u8; 32]> = leaves.iter().map(|l| hash_leaf_ext(*l)).collect();
+        let mut level: Vec<[u8; 32]> = crate::par::map_slice(leaves, |l| hash_leaf_ext(*l));
         if level.is_empty() {
             level.push(hash_leaf_ext(Fp2::ZERO));
         }
@@ -74,13 +74,12 @@ impl MerkleTree {
     fn commit_rows(columns: &[Vec<Fp>], leaf: fn(&[Fp]) -> [u8; 32]) -> MerkleTree {
         let width = columns.len();
         let n = columns.first().map(Vec::len).unwrap_or(0);
-        let mut level: Vec<[u8; 32]> = Vec::with_capacity(n.max(1));
-        let mut row: Vec<Fp> = Vec::with_capacity(width);
-        for i in 0..n {
-            row.clear();
-            row.extend(columns.iter().map(|col| col[i]));
-            level.push(leaf(&row));
-        }
+        // Each row leaf is an independent hash of the columns at that index, so
+        // the leaf layer parallelizes cleanly; the indexed map keeps row order.
+        let mut level: Vec<[u8; 32]> = crate::par::map_index(n, |i| {
+            let row: Vec<Fp> = columns.iter().map(|col| col[i]).collect();
+            leaf(&row)
+        });
         let pad = alloc::vec![Fp::ZERO; width];
         if level.is_empty() {
             level.push(leaf(&pad));

--- a/nonos-stark/src/par.rs
+++ b/nonos-stark/src/par.rs
@@ -1,0 +1,63 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! One dispatch point for the prover's data-parallel maps. With the `parallel`
+//! feature the maps run across every core; without it they are the ordinary
+//! serial iterators the kernel builds. Both forms are indexed and
+//! order-preserving, so the output is identical either way — the callers pass
+//! pure functions of the index or element, and a bit-exact gate proves the two
+//! prover forms emit the same proof bytes.
+
+use alloc::vec::Vec;
+
+/// Map a pure function over `0..n`, collecting in index order.
+#[cfg(feature = "parallel")]
+pub(crate) fn map_index<T, F>(n: usize, f: F) -> Vec<T>
+where
+    T: Send,
+    F: Fn(usize) -> T + Send + Sync,
+{
+    use rayon::prelude::*;
+    (0..n).into_par_iter().map(f).collect()
+}
+
+#[cfg(not(feature = "parallel"))]
+pub(crate) fn map_index<T, F>(n: usize, f: F) -> Vec<T>
+where
+    F: Fn(usize) -> T,
+{
+    (0..n).map(f).collect()
+}
+
+/// Map a pure function over a slice, collecting in element order.
+#[cfg(feature = "parallel")]
+pub(crate) fn map_slice<A, T, F>(items: &[A], f: F) -> Vec<T>
+where
+    A: Sync,
+    T: Send,
+    F: Fn(&A) -> T + Send + Sync,
+{
+    use rayon::prelude::*;
+    items.par_iter().map(f).collect()
+}
+
+#[cfg(not(feature = "parallel"))]
+pub(crate) fn map_slice<A, T, F>(items: &[A], f: F) -> Vec<T>
+where
+    F: Fn(&A) -> T,
+{
+    items.iter().map(f).collect()
+}

--- a/nonos-stark/src/transcript.rs
+++ b/nonos-stark/src/transcript.rs
@@ -96,12 +96,40 @@ impl Transcript {
     /// of proof-of-work to the query soundness, raising the cost of resampling
     /// challenges to forge a proof.
     pub fn grind(&mut self, bits: u32) -> u64 {
+        let nonce = self.grind_search(bits);
+        self.mix(0x05, &nonce.to_le_bytes());
+        nonce
+    }
+
+    /// The proof-of-work search. Serially it is the smallest nonce meeting the
+    /// work; over `bits` in the 30s that is billions of hashes on one core, the
+    /// dominant cost of a deployment emit. The parallel form searches the nonce
+    /// space in blocks across every core and returns the first (lowest) hit in
+    /// each block, so it finds the identical smallest nonce as the serial search
+    /// — bit-exact, just spread across cores.
+    #[cfg(not(feature = "parallel"))]
+    fn grind_search(&self, bits: u32) -> u64 {
         let mut nonce = 0u64;
         while self.pow_word(nonce).leading_zeros() < bits {
             nonce = nonce.wrapping_add(1);
         }
-        self.mix(0x05, &nonce.to_le_bytes());
         nonce
+    }
+
+    #[cfg(feature = "parallel")]
+    fn grind_search(&self, bits: u32) -> u64 {
+        use rayon::prelude::*;
+        const BLOCK: u64 = 1 << 26;
+        let mut base = 0u64;
+        loop {
+            let hit = (base..base + BLOCK)
+                .into_par_iter()
+                .find_first(|&n| self.pow_word(n).leading_zeros() >= bits);
+            if let Some(n) = hit {
+                return n;
+            }
+            base += BLOCK;
+        }
     }
 
     /// Verifier-side grinding check: accept only if the nonce meets the `bits`

--- a/userland/stark_proofs/Cargo.toml
+++ b/userland/stark_proofs/Cargo.toml
@@ -17,5 +17,10 @@ nonos-stark = { path = "../../nonos-stark" }
 [dev-dependencies]
 rayon = "1"
 
+[features]
+# Forwards to the prover's all-cores path. The emit-hash gate builds the crate
+# both ways and diffs the proof bytes; they must be identical.
+parallel = ["nonos-stark/parallel"]
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }

--- a/userland/stark_proofs/src/lib.rs
+++ b/userland/stark_proofs/src/lib.rs
@@ -29,6 +29,8 @@ mod ntt_tests;
 #[cfg(test)]
 mod parallel_commit_tests;
 #[cfg(test)]
+mod parallel_prover_gate;
+#[cfg(test)]
 mod periodic_z_tests;
 #[cfg(test)]
 mod poly_tests;

--- a/userland/stark_proofs/src/parallel_prover_gate.rs
+++ b/userland/stark_proofs/src/parallel_prover_gate.rs
@@ -1,0 +1,70 @@
+// NONOS Operating System (AGPL-3.0-or-later)
+//! The bit-exact gate for the all-cores prover. A production emit uses the
+//! `parallel` prover to run across every core; this proves it emits the exact
+//! same bytes as the serial one. The crate compiles either serial (no feature)
+//! or parallel (`--features parallel`) — never both in one binary — so the gate
+//! is a two-build diff: this test prints the blake3 of a real preprocessed
+//! proof over a small wired AIR, and the harness runs it under both builds and
+//! requires the two digests to match. A parallel bug that changed any committed
+//! value would change the digest and fail the diff.
+
+use crate::crypto::stark::air::{
+    stark_prove_ext_preprocessed, Accumulator, AirExt, RangeCheck, WiredExt,
+};
+use crate::crypto::stark::field::Fp;
+use crate::crypto::stark::hash::blake3_hash;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+fn neg(x: u64) -> Fp {
+    Fp::ZERO - Fp::from_u64(x)
+}
+
+fn join_split() -> WiredExt {
+    let regions: Vec<Box<dyn AirExt>> = alloc::vec![
+        Box::new(Accumulator { log_t: 3 }) as Box<dyn AirExt>,
+        Box::new(RangeCheck { log_t: 4 }),
+    ];
+    let mut sigma: Vec<usize> = (0..32).collect();
+    sigma.swap(1, 8);
+    WiredExt::new(regions, alloc::vec![0], sigma, Fp::from_u64(5), Fp::from_u64(7))
+}
+
+fn witness(air: &WiredExt) -> Vec<Fp> {
+    let addends =
+        [Fp::from_u64(7), Fp::from_u64(3), neg(8), neg(1), neg(1), Fp::ZERO, Fp::ZERO, Fp::ZERO];
+    let mut cons = Vec::new();
+    let mut acc = Fp::ZERO;
+    for &a in &addends {
+        cons.push(acc);
+        cons.push(a);
+        acc = acc + a;
+    }
+    let mut rng = Vec::new();
+    let mut v = 7u64;
+    for i in 0..16usize {
+        let bit = if i < 15 { v & 1 } else { 0 };
+        rng.push(Fp::from_u64(v));
+        rng.push(Fp::from_u64(bit));
+        if i < 15 {
+            v >>= 1;
+        }
+    }
+    air.trace(&[cons, rng])
+}
+
+#[test]
+fn emit_preprocessed_proof_digest() {
+    let air = join_split();
+    let w = witness(&air);
+    // A raised blowup so the parallel paths (multi-column LDE, wide-leaf
+    // hashing, deep-domain commit) are all exercised, not just the trivial one.
+    let pre = stark_prove_ext_preprocessed(&air, &w, 32, 8, 3);
+    let bytes = crate::production_vector_gen::wire::serialize_pre(&pre);
+    let digest = blake3_hash(&bytes);
+    let mut hex = alloc::string::String::from("PROOF_DIGEST=");
+    for b in &digest {
+        hex.push_str(&alloc::format!("{:02x}", b));
+    }
+    std::println!("{hex} len={}", bytes.len());
+}

--- a/userland/stark_proofs/src/production_vector_gen/mod.rs
+++ b/userland/stark_proofs/src/production_vector_gen/mod.rs
@@ -9,4 +9,4 @@ pub(crate) mod parallel;
 mod run;
 mod structure;
 mod vector;
-mod wire;
+pub(crate) mod wire;

--- a/userland/stark_proofs/src/production_vector_gen/wire.rs
+++ b/userland/stark_proofs/src/production_vector_gen/wire.rs
@@ -7,7 +7,7 @@
 use crate::crypto::stark::air::StarkProofExtPre;
 use alloc::vec::Vec;
 
-pub(super) fn serialize_pre(pre: &StarkProofExtPre) -> Vec<u8> {
+pub(crate) fn serialize_pre(pre: &StarkProofExtPre) -> Vec<u8> {
     let mut b = crate::stark_selftest_gen::serialize(&pre.proof);
     // sidecar: n_periodic, the claims at z, then one opening per query in
     // query order: n_periodic row values, then the path.


### PR DESCRIPTION
The full-prover parallelization: turns a deep-domain preprocessed emit from a single-threaded run into an all-cores one. Distinct from #388 (which parallelized only the standalone `periodic_root` commit); this parallelizes the whole preprocessed prover.

What runs across cores (all embarrassingly parallel, each point/column an independent pure function):
- the per-column trace and periodic coset LDEs (the dominant cost, committed twice)
- `comp_d` and `deep_d` over the eval domain (evaluation point x_j = shift·ω^j)
- wide-leaf and ext Merkle leaf hashing in every commit

How it stays safe:
- `nonos-stark` stays `no_std` and serial for the kernel/bootloader; the `parallel` feature (host tooling only) pulls std + rayon. `#![cfg_attr(not(feature = "parallel"), no_std)]`.
- one dispatch helper (`par::map_index` / `map_slice`) — each hot loop is one line, serial or parallel, both indexed and order-preserving, so committed data is identical by construction.
- `AirExt: Sync` added (satisfied automatically — every AIR is plain data), so the composition/DEEP evaluations can share the AIR across threads.

## Validation — two levels

1. **Two-build byte diff:** the same preprocessed proof over a wired AIR, serialized and blake3'd, produces the identical digest whether built serial or `--features parallel`. Full suite passes both ways; serial `nonos-stark` builds clean, so the `Sync` bound broke no impl.

2. **Full-scale root match:** on the production 2^24 / 444-column recursion AIR, the parallel prover's committed `periodic_root` is byte-identical to the serial prover's. This closes the self-consistent-but-wrong-root risk with real data at production scale, not only on a small gate AIR.

Not auto-enabled anywhere — the gen opts in.