### PR TITLE
browser: inline-block, absolute anchoring, and nowrap in box layout

### DIFF
--- a/userland/capsule_browser/src/browser/layout/boxmodel/collect_items.rs
+++ b/userland/capsule_browser/src/browser/layout/boxmodel/collect_items.rs
@@ -17,21 +17,27 @@
 use alloc::vec::Vec;
 
 use super::abs_out_of_flow::out_of_flow;
+use super::border_box_w::border_box_w;
+use super::content_width::content_width;
+use super::ctx::Ctx;
+use super::display_list::DisplayList;
 use super::image_box::image_box;
 use super::inline_items::InlineItem;
-use crate::browser::css::WhiteSpace;
+use super::layout_box::layout_box;
+use crate::browser::css::{Size, WhiteSpace};
 
 use super::tree::{BoxKind, BoxNode};
 
 const MAX_DEPTH: u32 = 400;
 
-// Flatten an inline subtree into measured words, images and hard breaks.
-// A stray block inside an inline run flows like its children.
+// Flatten an inline subtree into measured words, images, inline-block atoms
+// and hard breaks. A stray block inside an inline run flows like its children.
 pub(super) fn collect_items(
     children: &[BoxNode],
     content_w: i32,
     out: &mut Vec<InlineItem>,
     depth: u32,
+    ctx: Ctx,
 ) {
     if depth > MAX_DEPTH {
         return;
@@ -118,8 +124,24 @@ pub(super) fn collect_items(
                     fit: c.style.object_fit,
                 });
             }
+            BoxKind::InlineBlock => {
+                // An inline-block is an atom on the line. Give it its own
+                // width (explicit, else shrink to content) and lay its block
+                // context out at the origin; the line box shifts it into place.
+                let bw = match c.style.width {
+                    Size::Auto => content_width(c, depth + 1).clamp(1, content_w.max(1)),
+                    _ => border_box_w(&c.style, content_w).clamp(1, content_w.max(1)),
+                };
+                let mut sub: DisplayList = Vec::new();
+                let h = layout_box(c, 0, 0, bw, &mut sub, depth + 1, ctx);
+                // The block may resolve wider than the hint (a min-width, an
+                // unbreakable child), so the advance is the real laid-out
+                // extent, or the next item would overlap it.
+                let w = sub.iter().map(|f| f.x + f.w).max().unwrap_or(bw).max(bw);
+                out.push(InlineItem::Atom { frags: sub, w, h });
+            }
             BoxKind::Inline | BoxKind::Block | BoxKind::Flex | BoxKind::Grid => {
-                collect_items(&c.children, content_w, out, depth + 1);
+                collect_items(&c.children, content_w, out, depth + 1, ctx);
             }
         }
     }

--- a/userland/capsule_browser/src/browser/layout/boxmodel/element_box.rs
+++ b/userland/capsule_browser/src/browser/layout/boxmodel/element_box.rs
@@ -116,12 +116,16 @@ pub(super) fn element_box(
         BoxKind::Flex
     } else if style.is_block || out_of_flow(&style) {
         BoxKind::Block
+    } else if style.is_inline_block {
+        BoxKind::InlineBlock
     } else {
         BoxKind::Inline
     };
     let mut kids = match kind {
         BoxKind::Flex | BoxKind::Grid => wrap_items(&style, kids),
-        BoxKind::Block => wrap_mixed(&style, kids),
+        // An inline-block runs a block formatting context inside, so its
+        // children get the same anonymous-block wrapping a block box does.
+        BoxKind::Block | BoxKind::InlineBlock => wrap_mixed(&style, kids),
         _ => kids,
     };
     // Grid items that asked for a named or numeric position get it resolved

--- a/userland/capsule_browser/src/browser/layout/boxmodel/flush_line.rs
+++ b/userland/capsule_browser/src/browser/layout/boxmodel/flush_line.rs
@@ -118,6 +118,24 @@ pub(super) fn flush_line(
                     node,
                 });
             }
+            InlineItem::Atom { frags: sub, h, .. } => {
+                // Shift the inline-block's own fragments, laid out at the
+                // origin, into its slot on the line, sitting on the line's
+                // bottom edge so it aligns with the text run.
+                let dx = x + shift + ix;
+                let dy = top + (line_h - h).max(0);
+                for mut f in sub {
+                    f.x += dx;
+                    f.y += dy;
+                    if let Some(c) = f.clip.as_mut() {
+                        c[0] += dx;
+                        c[1] += dy;
+                        c[2] += dx;
+                        c[3] += dy;
+                    }
+                    frags.push(f);
+                }
+            }
             InlineItem::Break => {}
         }
     }

--- a/userland/capsule_browser/src/browser/layout/boxmodel/inline_items.rs
+++ b/userland/capsule_browser/src/browser/layout/boxmodel/inline_items.rs
@@ -43,6 +43,13 @@ pub(super) enum InlineItem {
         node: usize,
         fit: crate::browser::css::ObjectFit,
     },
+    // An inline-block, laid out in its own coordinate space at the origin; the
+    // line box places it by shifting its whole fragment run into the slot.
+    Atom {
+        frags: super::display_list::DisplayList,
+        w: i32,
+        h: i32,
+    },
     Break,
 }
 
@@ -51,6 +58,7 @@ impl InlineItem {
         match self {
             InlineItem::Word { adv, .. } => *adv,
             InlineItem::Image { w, .. } => *w,
+            InlineItem::Atom { w, .. } => *w,
             InlineItem::Break => 0,
         }
     }
@@ -59,6 +67,7 @@ impl InlineItem {
         match self {
             InlineItem::Word { line_h, .. } => *line_h,
             InlineItem::Image { h, .. } => *h,
+            InlineItem::Atom { h, .. } => *h,
             InlineItem::Break => 0,
         }
     }

--- a/userland/capsule_browser/src/browser/layout/boxmodel/layout_absolutes.rs
+++ b/userland/capsule_browser/src/browser/layout/boxmodel/layout_absolutes.rs
@@ -18,6 +18,7 @@ use crate::browser::css::Size;
 
 use super::abs_out_of_flow::out_of_flow;
 use super::border_box_w::border_box_w;
+use super::content_width::content_width;
 use super::ctx::Ctx;
 use super::display_list::DisplayList;
 use super::layout_box::layout_box;
@@ -25,8 +26,10 @@ use super::offset_px::offset_px;
 use super::tree::BoxNode;
 
 // Lay this container's absolutely positioned children against the current
-// containing block. top/left anchor; right places when left is auto; an
-// auto width spans between the resolved offsets.
+// containing block. top/left anchor; right places when left is auto. An auto
+// width spans the gap only when both left and right are pinned; with just one
+// side, or neither, the box shrinks to its content, which is how a badge or a
+// close button anchored to a corner sizes itself.
 pub(super) fn layout_absolutes(node: &BoxNode, frags: &mut DisplayList, depth: u32, ctx: Ctx) {
     for c in &node.children {
         if !out_of_flow(&c.style) {
@@ -36,7 +39,13 @@ pub(super) fn layout_absolutes(node: &BoxNode, frags: &mut DisplayList, depth: u
         let left = offset_px(c.style.left, cb.w);
         let right = offset_px(c.style.right, cb.w);
         let bw = match c.style.width {
-            Size::Auto => (cb.w - left.unwrap_or(0) - right.unwrap_or(0)).max(16),
+            Size::Auto if left.is_some() && right.is_some() => {
+                (cb.w - left.unwrap_or(0) - right.unwrap_or(0)).max(16)
+            }
+            Size::Auto => {
+                let avail = (cb.w - left.unwrap_or(0) - right.unwrap_or(0)).max(0);
+                content_width(c, depth + 1).clamp(16, avail.max(16))
+            }
             _ => border_box_w(&c.style, cb.w),
         };
         let x = cb.x

--- a/userland/capsule_browser/src/browser/layout/boxmodel/layout_inline.rs
+++ b/userland/capsule_browser/src/browser/layout/boxmodel/layout_inline.rs
@@ -16,7 +16,7 @@
 
 use alloc::vec::Vec;
 
-use crate::browser::css::Computed;
+use crate::browser::css::{Computed, WhiteSpace};
 
 use super::collect_items::collect_items;
 use super::ctx::Ctx;
@@ -43,6 +43,9 @@ pub(super) fn layout_inline(
     }
     let base_lh = container.line_height() as i32;
     let align = container.text_align;
+    // white-space: nowrap keeps the run on one line; only an explicit break
+    // ends it. The box's own overflow then clips what runs past its edge.
+    let nowrap = matches!(container.white_space, WhiteSpace::Nowrap);
     let mut pending: Vec<(i32, InlineItem)> = Vec::new();
     let mut cx = 0i32;
     let mut line_h = 0i32;
@@ -57,7 +60,7 @@ pub(super) fn layout_inline(
         }
         let adv = item.advance_w();
         let gap = if cx == 0 { 0 } else { item.space_w() };
-        if cx > 0 && cx + gap + adv > w {
+        if !nowrap && cx > 0 && cx + gap + adv > w {
             cy +=
                 flush_line(frags, &mut pending, x, y + cy, w, line_h.max(base_lh), cx, align, ctx);
             cx = 0;

--- a/userland/capsule_browser/src/browser/layout/boxmodel/layout_inline.rs
+++ b/userland/capsule_browser/src/browser/layout/boxmodel/layout_inline.rs
@@ -37,7 +37,7 @@ pub(super) fn layout_inline(
     ctx: Ctx,
 ) -> i32 {
     let mut items: Vec<InlineItem> = Vec::new();
-    collect_items(children, w, &mut items, 0);
+    collect_items(children, w, &mut items, 0, ctx);
     if items.is_empty() {
         return 0;
     }

--- a/userland/capsule_browser/src/browser/layout/boxmodel/tree.rs
+++ b/userland/capsule_browser/src/browser/layout/boxmodel/tree.rs
@@ -22,6 +22,10 @@ use crate::browser::css::Computed;
 pub enum BoxKind {
     Block,
     Inline,
+    // Inline-level on the outside, block on the inside: it sits in a line box
+    // like a word but sizes to its own width and height and lays its children
+    // in a block context.
+    InlineBlock,
     Flex,
     Grid,
     Text(String),


### PR DESCRIPTION
Three box-model fixes that surfaced while rendering real pages.

## inline-block boxes lay out as sized inline atoms

`display: inline-block` resolved to a plain inline box, so its width and height
were dropped and its children flowed as loose words. Buttons, badges, code
chips and nav pills built that way collapsed to their text size.

It now has its own box kind. It runs a block formatting context inside, sized
to its width or, when auto, to its content, and enters the line as a single
atom whose advance is the real laid-out width. The line box shifts the atom's
own fragments into place, so it sits inline beside text while keeping its box.
A minimum width or an unbreakable child widens the atom, so following content
never overlaps it.

## Absolutely positioned boxes anchored to one side shrink to fit

An absolute box with a `right` offset but no `left` and no `width` was handed
the full containing block minus the offset, so a corner badge or a close button
stretched across the whole width. Auto width should span the gap only when both
`left` and `right` are pinned; with a single side it shrinks to its content.

## white-space: nowrap is honored in inline layout

The line breaker wrapped a run the moment it passed the container width and
never consulted `white-space`. A nav bar, a button label or a table cell set to
`nowrap` wrapped onto extra lines instead of staying on one. The automatic
break is now suppressed under `nowrap`; an explicit break still ends the line,
and the box's own `overflow: hidden` clips what runs past the edge.

## Verification

Each was reproduced in a minimal page, fixed, and confirmed by the rendered
output. A reference documentation page renders correctly with the inline-block
change picking up its code chips, and an interactive framework page is
unchanged, so the common path is undisturbed.
