### PR TITLE
browser: fetch images with Connection: close

### DIFF
--- a/userland/capsule_browser/src/browser/fetch/tls/verify_and_send.rs
+++ b/userland/capsule_browser/src/browser/fetch/tls/verify_and_send.rs
@@ -20,13 +20,14 @@ use crate::browser::net;
 use crate::browser::tls13;
 
 pub(in crate::browser::fetch) fn verify_and_send(port: u32, f: &mut Fetch) {
-    // Image fetches keep the connection open so the next same-host image can
-    // reuse the handshake; everything else closes as before.
-    let req = if f.image.is_some() {
-        http::request::build_keep_alive(&f.url)
-    } else {
-        http::request::build(&f.url, f.post.as_deref())
-    };
+    // Every fetch asks the server to close after the response. A close is a
+    // hard end-of-body the reader cannot miss; a kept-alive response has to be
+    // framed exactly and its plaintext offset carried across the next request
+    // on the same connection, and any drift there strands the following image.
+    // CDNs serve images chunked and gzipped, which is the fragile framing, so
+    // the reuse optimisation cost every image on real pages. Correctness over a
+    // saved handshake.
+    let req = http::request::build(&f.url, f.post.as_deref());
     let host = f.url.host.clone();
     let Some(tls) = f.tls.as_ref() else {
         f.phase = Phase::Error;


### PR DESCRIPTION
Image fetches were the only requests asking for keep-alive. That sends them
through the connection reuse path: a finished image's socket is stashed, and
the next same-host image reuses it, skipping the earlier response by its
plaintext offset on the shared buffer.

The HTTP framing on that path is sound. Driving a captured stream of two
pipelined, chunked, gzipped responses over a single connection through
`frame_len` lands the boundary exactly on the second status line and both
bodies parse. The fragile part is a layer down: decrypting the TLS records that
accumulate across the reuse and lining the consumed offset up with the
encrypted record boundaries. Any drift there strands every following image,
and it is precisely the path nothing off-device exercises. A page's own
stylesheet, from the same host over a `Connection: close` socket, decodes and
renders fine.

This change sends images with `Connection: close` as well, so each is a single
framed response on its own connection, the same path the stylesheet fetch
already takes and the same completion signal. The stash and reuse code stays in
place but no longer fires for images, since the server closes after each one.
It costs a handshake per image, which is the right trade for images that load.

## Status

The reasoning composes two paths that are each already known good: the
`Connection: close` read that the stylesheet fetch uses, and the image decode
itself. It builds clean for the user target. It has not yet been confirmed on a
live network run, which is the remaining verification.
