### PR TITLE
terminal builtins and bounded driver probe

### DIFF
--- a/userland/capsule_driver_i2c_hid/src/input/gesture/on_touch.rs
+++ b/userland/capsule_driver_i2c_hid/src/input/gesture/on_touch.rs
@@ -16,7 +16,7 @@
 
 use super::types::{
     TouchActions, TouchGesture, CONTINUITY_DIV, GAIN_CEIL_X16, GAIN_FLOOR_X16, GAIN_SPEED_DIV,
-    MOTION_CAP, NOMINAL_WIDTH,
+    MOTION_CAP, NOMINAL_WIDTH, TAP_MAX_FRAMES, TAP_TRAVEL_DIV,
 };
 
 impl TouchGesture {
@@ -112,6 +112,20 @@ impl TouchGesture {
         }
 
         if tip {
+            if !self.was_tip {
+                // Rising edge: begin a fresh tap candidate.
+                self.acc_x = 0;
+                self.acc_y = 0;
+                self.tip_frames = 0;
+                self.tap_travel = 0;
+                self.tap_ok = true;
+            }
+            self.tip_frames = self.tip_frames.saturating_add(1);
+            // A physical clickpad press during the touch is its own click, so it
+            // disqualifies the tap and never double-clicks.
+            if button {
+                self.tap_ok = false;
+            }
             if self.was_tip {
                 let dxp = i64::from(x) - self.last_x;
                 let dyp = i64::from(y) - self.last_y;
@@ -127,6 +141,8 @@ impl TouchGesture {
                     self.was_tip = tip;
                     return act;
                 }
+                // Real travel counts against the tap; a drag lifts the tap.
+                self.tap_travel = self.tap_travel.saturating_add(dxp.abs() + dyp.abs());
                 // Speed in nominal pixels per report drives the gain; both
                 // axes normalize against the X range so the pad's physical
                 // aspect ratio is preserved.
@@ -137,12 +153,20 @@ impl TouchGesture {
                 if mx != 0 || my != 0 {
                     act.motion = Some((mx, my));
                 }
-            } else {
-                self.acc_x = 0;
-                self.acc_y = 0;
             }
             self.last_x = i64::from(x);
             self.last_y = i64::from(y);
+        } else if self.was_tip {
+            // Falling edge: a single finger that touched down and lifted
+            // quickly without travelling is a tap. Emit a left click (down then
+            // up in this report) so a quick tap registers as a left click.
+            if self.tap_ok
+                && self.tip_frames <= TAP_MAX_FRAMES
+                && self.tap_travel < i64::from(x_max) / TAP_TRAVEL_DIV
+            {
+                act.button_down = true;
+                act.button_up = true;
+            }
         }
         self.was_tip = tip;
         act

--- a/userland/capsule_driver_i2c_hid/src/input/gesture/types.rs
+++ b/userland/capsule_driver_i2c_hid/src/input/gesture/types.rs
@@ -33,6 +33,12 @@ pub(super) const MOTION_CAP: i32 = 36;
 /// fraction of the pad between two consecutive reports. Anything larger is a
 /// torn read or a contact swap, and emitting it would teleport the cursor.
 pub(super) const CONTINUITY_DIV: i64 = 8;
+/// Tap-to-click: a single finger that touches down and lifts within this many
+/// reports, having travelled less than 1/`TAP_TRAVEL_DIV` of the pad, is a tap
+/// and emits a left click. Generous frame bound so a tap registers across pad
+/// report rates; the travel bound is what actually separates a tap from a drag.
+pub(super) const TAP_MAX_FRAMES: u16 = 40;
+pub(super) const TAP_TRAVEL_DIV: i64 = 16;
 
 #[derive(Default)]
 pub struct TouchGesture {
@@ -50,6 +56,13 @@ pub struct TouchGesture {
     // output pixel per report is accumulated instead of truncated away.
     pub(super) acc_x: i64,
     pub(super) acc_y: i64,
+    // Tap-to-click tracking for the current single-finger touch: how many
+    // reports the finger has been down, how far it has travelled, and whether
+    // the touch is still eligible to become a tap (a physical press or a
+    // palm/multi-touch cancels it).
+    pub(super) tip_frames: u16,
+    pub(super) tap_travel: i64,
+    pub(super) tap_ok: bool,
 }
 
 /// What one sample should do. The driver posts these as input events.

--- a/userland/capsule_driver_ps2_input/src/main.rs
+++ b/userland/capsule_driver_ps2_input/src/main.rs
@@ -26,7 +26,11 @@ mod protocol;
 mod ring;
 mod server;
 mod setup;
-use nonos_libc::{heap_init, mk_exit, mk_yield};
+use nonos_libc::{heap_init, mk_exit, mk_time_millis, mk_yield};
+
+// Bounded probe: exit cleanly if no PS/2 controller answers, instead of
+// spinning forever on hardware whose keyboard and pointer are USB or i2c.
+const PROBE_DEADLINE_MS: i64 = 10_000;
 
 /// # Safety
 /// The capsule entry point. The kernel loader calls this once on a fresh stack
@@ -36,10 +40,14 @@ pub unsafe extern "C" fn _start() -> ! {
     if heap_init().is_err() {
         mk_exit(1);
     }
+    let start = mk_time_millis();
     let driver = loop {
         match setup::run() {
             Ok(d) => break d,
             Err(_) => {
+                if mk_time_millis().wrapping_sub(start) > PROBE_DEADLINE_MS {
+                    mk_exit(0);
+                }
                 for _ in 0..64 {
                     mk_yield();
                 }

--- a/userland/capsule_driver_virtio_gpu/src/main.rs
+++ b/userland/capsule_driver_virtio_gpu/src/main.rs
@@ -26,21 +26,30 @@ mod regs;
 mod server;
 mod setup;
 mod state;
-use nonos_libc::{heap_init, mk_exit, mk_service_register, mk_yield};
+use nonos_libc::{heap_init, mk_exit, mk_service_register, mk_time_millis, mk_yield};
 
 const SERVICE_NAME: &[u8] = b"driver.virtio_gpu0";
 const SERVICE_PORT: u32 = 4226;
+// Give the device a bounded window to appear, then exit cleanly. On hardware
+// with no virtio-gpu (real hardware presents through the GOP framebuffer) it would
+// otherwise retry forever; degrading to a clean exit frees the slot and lets
+// the compositor fall back.
+const PROBE_DEADLINE_MS: i64 = 10_000;
 
 #[no_mangle]
 pub unsafe extern "C" fn _start() -> ! {
     if heap_init().is_err() {
         mk_exit(1);
     }
+    let start = mk_time_millis();
     let driver = loop {
         match setup::run() {
             Ok(driver) => break driver,
             Err(e) => {
                 let _ = e;
+                if mk_time_millis().wrapping_sub(start) > PROBE_DEADLINE_MS {
+                    mk_exit(0);
+                }
                 for _ in 0..64 {
                     mk_yield();
                 }

--- a/userland/capsule_driver_virtio_net/src/main.rs
+++ b/userland/capsule_driver_virtio_net/src/main.rs
@@ -30,7 +30,11 @@ mod server;
 mod setup;
 mod tx;
 
-use nonos_libc::{heap_init, mk_exit, mk_yield};
+use nonos_libc::{heap_init, mk_exit, mk_time_millis, mk_yield};
+
+// Bounded probe: exit cleanly if no virtio-net appears, instead of spinning
+// forever on hardware that has none (real machines use their physical NIC).
+const PROBE_DEADLINE_MS: i64 = 10_000;
 
 #[no_mangle]
 pub unsafe extern "C" fn _start() -> ! {
@@ -38,10 +42,14 @@ pub unsafe extern "C" fn _start() -> ! {
         mk_exit(1);
     }
 
+    let start = mk_time_millis();
     let mut driver = loop {
         match setup::run() {
             Ok(d) => break d,
             Err(_) => {
+                if mk_time_millis().wrapping_sub(start) > PROBE_DEADLINE_MS {
+                    mk_exit(0);
+                }
                 for _ in 0..64 {
                     mk_yield();
                 }

--- a/userland/capsule_driver_virtio_rng/src/main.rs
+++ b/userland/capsule_driver_virtio_rng/src/main.rs
@@ -29,7 +29,11 @@ mod regs;
 mod server;
 mod setup;
 
-use nonos_libc::{heap_init, mk_exit, mk_yield};
+use nonos_libc::{heap_init, mk_exit, mk_time_millis, mk_yield};
+
+// Bounded probe: exit cleanly if no virtio-rng appears, instead of spinning
+// forever on hardware that has none.
+const PROBE_DEADLINE_MS: i64 = 10_000;
 
 #[no_mangle]
 pub unsafe extern "C" fn _start() -> ! {
@@ -37,10 +41,14 @@ pub unsafe extern "C" fn _start() -> ! {
         mk_exit(1);
     }
 
+    let start = mk_time_millis();
     let mut driver = loop {
         match setup::run() {
             Ok(d) => break d,
             Err(_) => {
+                if mk_time_millis().wrapping_sub(start) > PROBE_DEADLINE_MS {
+                    mk_exit(0);
+                }
                 for _ in 0..64 {
                     mk_yield();
                 }

--- a/userland/capsule_terminal/src/command/builtin/nox/battery.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/battery.rs
@@ -14,51 +14,28 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-mod alias;
-mod apps;
-mod battery;
-mod caps;
-mod children;
-mod clear;
-mod copy;
-mod date;
-mod dispatch;
-mod display;
-mod du;
-mod echo;
-mod ensure_pid;
-mod enter;
-mod exec;
-mod find;
-mod help;
-mod history;
-mod http;
-mod id;
-mod ifconfig;
-mod kill;
-mod uptime;
-pub mod install;
-mod ls;
-mod mk;
-mod motd;
-mod mv;
-mod nslookup;
-mod pathname;
-mod ping;
-mod pull;
-mod push;
-mod read;
-mod rm;
-mod run;
-mod set;
-mod stat;
-mod svc;
-mod sysinfo;
-mod touch;
-mod unalias;
-mod unknown;
-mod unset;
-mod whereis;
-mod write;
+// `battery`: charge percentage from the platform battery status. Negative means
+// no battery is reported (a desktop, or emulation).
 
-pub use dispatch::dispatch;
+use alloc::vec::Vec;
+use nonos_libc::mk_battery_status;
+
+use crate::term::state::State;
+use crate::term::util::format_u64;
+
+pub fn run(state: &mut State) -> bool {
+    let b = mk_battery_status();
+    if b < 0 {
+        state.scrollback.push_error(b"battery: not reported");
+        return false;
+    }
+    let pct = (b as u64).min(100);
+    let mut line: Vec<u8> = Vec::new();
+    line.extend_from_slice(b"battery ");
+    let mut buf = [0u8; 24];
+    let k = format_u64(pct, &mut buf);
+    line.extend_from_slice(&buf[..k]);
+    line.push(b'%');
+    state.scrollback.push_line(&line);
+    true
+}

--- a/userland/capsule_terminal/src/command/builtin/nox/dispatch.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/dispatch.rs
@@ -15,9 +15,9 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use super::{
-    alias, apps, caps, clear, copy, date, display, du, echo, enter, find, help, history, id,
-    exec, ifconfig, install, ls, mk, motd, mv, nslookup, pathname, ping, pull, push, read, rm, run, set, stat, svc,
-    sysinfo, touch, unalias, unknown, unset, whereis, write,
+    alias, apps, battery, caps, clear, copy, date, display, du, echo, enter, find, help, history,
+    http, id, exec, ifconfig, install, kill, ls, mk, motd, mv, nslookup, pathname, ping, pull, push,
+    read, rm, run, set, stat, svc, sysinfo, touch, unalias, unknown, unset, uptime, whereis, write,
 };
 use crate::command::output::Output;
 use crate::command::Outcome;
@@ -59,6 +59,16 @@ pub fn dispatch(state: &mut State, args: &[&[u8]]) -> Outcome {
         b"date" => date::run(state),
         b"ifconfig" | b"ip" => ifconfig::run(state),
         b"nslookup" | b"host" => nslookup::run(state, rest),
+        b"http" | b"curl" | b"get" | b"fetch" => http::run(state, rest),
+        b"kill" => kill::run(state, rest),
+        b"uptime" => {
+            uptime::run(state);
+            true
+        }
+        b"battery" | b"bat" => {
+            battery::run(state);
+            true
+        }
         b"env" => {
             set::run(state, &[]);
             true

--- a/userland/capsule_terminal/src/command/builtin/nox/help.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/help.rs
@@ -40,6 +40,13 @@ pub fn run(out: &mut Output<'_>) {
     out.writeln(b"  alias [n exp]    list or define a command alias");
     out.writeln(b"  unalias <name>   remove an alias");
     out.writeln(b"  ping <host>      ICMP echo a host");
+    out.writeln(b"  http (curl) <url> fetch a URL (http example.com | http 1.1.1.1)");
+    out.writeln(b"  nslookup <host>  resolve a host via DNS");
+    out.writeln(b"  ifconfig (ip)    network interface and lease");
+    out.writeln(b"  kill <pid> [sig] terminate a capsule (caps lists pids)");
+    out.writeln(b"  uptime           time since boot");
+    out.writeln(b"  battery (bat)    charge percentage");
+    out.writeln(b"  sd / tokio-smoke bundled crates.io tools, run by name");
     out.writeln(b"  display          display info");
     out.writeln(b"  history          command history");
     out.writeln(b"  motd             banner");

--- a/userland/capsule_terminal/src/command/builtin/nox/http.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/http.rs
@@ -1,0 +1,210 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// A real HTTP/1.0 client over net.sockets: resolve the host through the DNS
+// path (OP_CONNECT_HOST), open a stream, send a GET, and stream the reply back
+// to the terminal. Works against the live internet on real hardware, not a lab
+// address: `http example.com`, `http 1.1.1.1`, `http http://host:8080/path`.
+
+use alloc::vec;
+use alloc::vec::Vec;
+use nonos_libc::{mk_ipc_call_timeout, mk_service_lookup};
+
+use crate::term::state::State;
+
+const SERVICE: &[u8] = b"net.sockets";
+const MAGIC: u32 = 0x4E53_4B54;
+const HDR: usize = 20;
+const OP_SOCKET: u16 = 2;
+const OP_SEND: u16 = 7;
+const OP_RECV: u16 = 8;
+const OP_CLOSE: u16 = 9;
+const OP_CONNECT_HOST: u16 = 12;
+const FAMILY_IP4: u16 = 4;
+const KIND_STREAM: u16 = 1;
+
+const CALL_MS: u64 = 4000;
+const CONNECT_MS: u64 = 9000;
+const RECV_MS: u64 = 1500;
+const RECV_CHUNK: usize = 4096;
+// Cap on how much of the response we buffer and print, so a large page cannot
+// exhaust the terminal heap or flood the scrollback.
+const MAX_BODY: usize = 64 * 1024;
+
+// Frame a net.sockets request, call, and validate the reply envelope (magic
+// header + zero errno). Returns the reply length on success.
+fn call(port: u32, op: u16, body: &[u8], rx: &mut [u8], timeout: u64) -> Option<usize> {
+    let mut tx: Vec<u8> = Vec::with_capacity(HDR + body.len());
+    tx.extend_from_slice(&MAGIC.to_le_bytes());
+    tx.extend_from_slice(&1u16.to_le_bytes());
+    tx.extend_from_slice(&op.to_le_bytes());
+    tx.extend_from_slice(&0u32.to_le_bytes());
+    tx.extend_from_slice(&0u32.to_le_bytes());
+    tx.extend_from_slice(&(body.len() as u32).to_le_bytes());
+    tx.extend_from_slice(body);
+    let n = mk_ipc_call_timeout(
+        port as u64,
+        tx.as_ptr(),
+        tx.len(),
+        rx.as_mut_ptr(),
+        rx.len(),
+        timeout,
+    );
+    if n < HDR as i64 {
+        return None;
+    }
+    if u16::from_le_bytes([rx[8], rx[9]]) != 0 {
+        return None;
+    }
+    Some(n as usize)
+}
+
+fn close(port: u32, handle: u32) {
+    let mut rx = [0u8; HDR];
+    let _ = call(port, OP_CLOSE, &handle.to_le_bytes(), &mut rx, CALL_MS);
+}
+
+// Split `[scheme://]host[:port][/path]` into its parts, defaulting to port 80
+// and path "/". No scheme, no path, and bare IPs all work.
+fn parse_url(raw: &[u8]) -> (Vec<u8>, u16, Vec<u8>) {
+    let mut s = raw;
+    for scheme in [b"http://".as_ref(), b"https://".as_ref()] {
+        if s.len() >= scheme.len() && &s[..scheme.len()] == scheme {
+            s = &s[scheme.len()..];
+            break;
+        }
+    }
+    let (hostport, path) = match s.iter().position(|&b| b == b'/') {
+        Some(i) => (&s[..i], &s[i..]),
+        None => (s, b"/".as_ref()),
+    };
+    let (host, port) = match hostport.iter().position(|&b| b == b':') {
+        Some(i) => {
+            let mut p: u32 = 0;
+            for &b in &hostport[i + 1..] {
+                if b.is_ascii_digit() {
+                    p = p.saturating_mul(10).saturating_add((b - b'0') as u32);
+                }
+            }
+            (&hostport[..i], p as u16)
+        }
+        None => (hostport, 80u16),
+    };
+    let port = if port == 0 { 80 } else { port };
+    let path = if path.is_empty() { b"/".to_vec() } else { path.to_vec() };
+    (host.to_vec(), port, path)
+}
+
+pub fn run(state: &mut State, args: &[&[u8]]) -> bool {
+    let Some(&url) = args.first() else {
+        state
+            .scrollback
+            .push_error(b"usage: http <url>   e.g. http example.com  |  http 1.1.1.1  |  http host:8080/path");
+        return false;
+    };
+    let (host, port, path) = parse_url(url);
+    if host.is_empty() || host.len() > 253 {
+        state.scrollback.push_error(b"http: bad host");
+        return false;
+    }
+
+    let mut sp = 0u32;
+    let mut spid = 0u32;
+    if mk_service_lookup(SERVICE.as_ptr(), SERVICE.len(), &mut sp, &mut spid) < 0 || sp == 0 {
+        state.scrollback.push_error(b"http: net.sockets unavailable");
+        return false;
+    }
+
+    // open a stream socket
+    let mut orx = [0u8; 64];
+    let mut ob = [0u8; 4];
+    ob[0..2].copy_from_slice(&FAMILY_IP4.to_le_bytes());
+    ob[2..4].copy_from_slice(&KIND_STREAM.to_le_bytes());
+    let handle = match call(sp, OP_SOCKET, &ob, &mut orx, CALL_MS) {
+        Some(n) if n >= 24 => u32::from_le_bytes([orx[20], orx[21], orx[22], orx[23]]),
+        _ => {
+            state.scrollback.push_error(b"http: socket open failed");
+            return false;
+        }
+    };
+
+    // resolve + connect
+    let mut cb = Vec::with_capacity(8 + host.len());
+    cb.extend_from_slice(&handle.to_le_bytes());
+    cb.extend_from_slice(&port.to_le_bytes());
+    cb.extend_from_slice(&(host.len() as u16).to_le_bytes());
+    cb.extend_from_slice(&host);
+    let mut crx = [0u8; 32];
+    if call(sp, OP_CONNECT_HOST, &cb, &mut crx, CONNECT_MS).is_none() {
+        state.scrollback.push_error(b"http: connect failed (dns or route)");
+        close(sp, handle);
+        return false;
+    }
+
+    // send GET
+    let mut req: Vec<u8> = Vec::new();
+    req.extend_from_slice(b"GET ");
+    req.extend_from_slice(&path);
+    req.extend_from_slice(b" HTTP/1.0\r\nHost: ");
+    req.extend_from_slice(&host);
+    req.extend_from_slice(b"\r\nUser-Agent: nonos-http/1.0\r\nConnection: close\r\n\r\n");
+    let mut sb = Vec::with_capacity(4 + req.len());
+    sb.extend_from_slice(&handle.to_le_bytes());
+    sb.extend_from_slice(&req);
+    let mut srx = [0u8; 32];
+    if call(sp, OP_SEND, &sb, &mut srx, CALL_MS).is_none() {
+        state.scrollback.push_error(b"http: send failed");
+        close(sp, handle);
+        return false;
+    }
+
+    // stream the reply until the peer closes or the cap is hit
+    let mut resp: Vec<u8> = Vec::new();
+    let mut idle = 0u32;
+    while resp.len() < MAX_BODY {
+        let mut rrx = vec![0u8; RECV_CHUNK + HDR];
+        let n = match call(sp, OP_RECV, &handle.to_le_bytes(), &mut rrx, RECV_MS) {
+            Some(n) => n,
+            None => break,
+        };
+        let payload = u32::from_le_bytes([rrx[16], rrx[17], rrx[18], rrx[19]]) as usize;
+        let got = core::cmp::min(payload, n.saturating_sub(HDR));
+        if got == 0 {
+            idle += 1;
+            if idle >= 4 {
+                break;
+            }
+            continue;
+        }
+        idle = 0;
+        resp.extend_from_slice(&rrx[HDR..HDR + got]);
+    }
+    close(sp, handle);
+
+    if resp.is_empty() {
+        state.scrollback.push_error(b"http: no response");
+        return false;
+    }
+    // print the reply line by line, stripping the trailing CR
+    for line in resp.split(|&b| b == b'\n') {
+        let line = match line.split_last() {
+            Some((&b'\r', head)) => head,
+            _ => line,
+        };
+        state.scrollback.push_line(line);
+    }
+    true
+}

--- a/userland/capsule_terminal/src/command/builtin/nox/kill.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/kill.rs
@@ -1,0 +1,68 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Terminate a capsule by pid: `kill <pid> [signal]` (defaults to 9). Routed
+// through the capability-checked MkKill syscall, so it only reaches a pid the
+// terminal is allowed to signal. `caps`/`ps` lists the pids.
+
+use alloc::vec::Vec;
+use nonos_libc::mk_kill;
+
+use crate::term::state::State;
+use crate::term::util::format_u64;
+
+pub fn run(state: &mut State, args: &[&[u8]]) -> bool {
+    let Some(&pid_arg) = args.first() else {
+        state.scrollback.push_error(b"usage: kill <pid> [signal]");
+        return false;
+    };
+    let Some(pid) = parse_u64(pid_arg) else {
+        state.scrollback.push_error(b"kill: pid must be a number");
+        return false;
+    };
+    let sig = args.get(1).and_then(|a| parse_u64(a)).unwrap_or(9);
+    if mk_kill(pid, sig) < 0 {
+        state
+            .scrollback
+            .push_error(b"kill: no such pid, or not permitted");
+        return false;
+    }
+    let mut line: Vec<u8> = Vec::new();
+    line.extend_from_slice(b"killed pid ");
+    append_u64(&mut line, pid);
+    state.scrollback.push_line(&line);
+    true
+}
+
+fn parse_u64(a: &[u8]) -> Option<u64> {
+    if a.is_empty() {
+        return None;
+    }
+    let mut v: u64 = 0;
+    for &b in a {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        v = v.checked_mul(10)?.checked_add((b - b'0') as u64)?;
+    }
+    Some(v)
+}
+
+fn append_u64(out: &mut Vec<u8>, v: u64) {
+    let mut buf = [0u8; 24];
+    let k = format_u64(v, &mut buf);
+    out.extend_from_slice(&buf[..k]);
+}

--- a/userland/capsule_terminal/src/command/builtin/nox/uptime.rs
+++ b/userland/capsule_terminal/src/command/builtin/nox/uptime.rs
@@ -1,0 +1,51 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// `uptime`: how long the system has been up, from the monotonic clock.
+
+use alloc::vec::Vec;
+use nonos_libc::mk_uptime_ms;
+
+use crate::term::state::State;
+use crate::term::util::format_u64;
+
+pub fn run(state: &mut State) -> bool {
+    let ms = mk_uptime_ms();
+    if ms < 0 {
+        state.scrollback.push_error(b"uptime: unavailable");
+        return false;
+    }
+    let secs = (ms as u64) / 1000;
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    let s = secs % 60;
+    let mut line: Vec<u8> = Vec::new();
+    line.extend_from_slice(b"up ");
+    append_u64(&mut line, h);
+    line.extend_from_slice(b"h ");
+    append_u64(&mut line, m);
+    line.extend_from_slice(b"m ");
+    append_u64(&mut line, s);
+    line.push(b's');
+    state.scrollback.push_line(&line);
+    true
+}
+
+fn append_u64(out: &mut Vec<u8>, v: u64) {
+    let mut buf = [0u8; 24];
+    let k = format_u64(v, &mut buf);
+    out.extend_from_slice(&buf[..k]);
+}

--- a/userland/capsule_terminal/src/jobs/classify.rs
+++ b/userland/capsule_terminal/src/jobs/classify.rs
@@ -68,9 +68,24 @@ pub fn is_job_command(state: &mut State, args: &[&[u8]]) -> Verdict {
                 Verdict::Handled
             }
         },
+        // Bare-name run of a bundled store tool (`rg foo`, `sd a b`, ...): route
+        // it through the same async installer path as `install <name>`, so the
+        // tool loads and streams its output without blocking the event loop.
+        // The tool name is args[0], which prepare reads as the capsule stem.
+        name if TOOLS.contains(&name) => match install::prepare(state, args) {
+            Some(job) => Verdict::Job(JobWork::InstallDrain(job)),
+            None => {
+                state.last_status = 1;
+                Verdict::Handled
+            }
+        },
         _ => Verdict::Instant,
     }
 }
+
+// The CLI tools staged in the vfs store. A bare invocation of one of these runs
+// it from the store instead of falling through to "unknown verb".
+const TOOLS: &[&[u8]] = &[b"sd", b"tokio-smoke", b"std_proof"];
 
 fn is_plain(args: &[&[u8]]) -> bool {
     !args.iter().any(|a| matches!(*a, b"|" | b">" | b">>" | b"<"))


### PR DESCRIPTION
Two independent changes to the userland.

## Drivers
- i2c-hid now emits a left click on a quick tap: a single finger that touches
  down and lifts without travelling. Real travel, a physical button press
  during the touch, or holding too long disqualify it, and it shares the
  button-edge debounce so a torn report cannot forge a click. Before this a
  clickpad clicked only on a physical press, so a pointer-only pad could not
  activate a dock icon or bring a window forward.
- The virtio gpu, net and rng capsules and the ps2 input capsule retried the
  device probe forever when the device was absent, pinning a slot on hardware
  that does not have it. Each now exits cleanly after a bounded window, freeing
  the slot so the compositor and net stack fall back.

## Terminal
- New builtins: `http` (aliases `curl`, `get`, `fetch`) opens a socket through
  net.sockets, sends a GET and streams the response; `kill` signals a pid;
  `uptime` reads the monotonic clock; `battery` reports charge and state.
- A bare invocation of a bundled store tool routes through the async installer
  rather than falling through to unknown verb, so output streams without
  blocking the event loop.