### PR TITLE
spawn: keep the on-demand window drain from being starved

### DIFF
--- a/src/syscall/microkernel/spawn_instance.rs
+++ b/src/syscall/microkernel/spawn_instance.rs
@@ -45,11 +45,29 @@ pub fn sys_spawn_instance(name_ptr: u64, name_len: u64) -> i64 {
         Err(_) => return ERRNO_INVAL,
     };
     let result = queue_by_name(name);
+    if result >= 0 {
+        boost_init_for_drain();
+    }
     // Land every request in the boot log so the on-demand path is observable.
     crate::sys::serial::print(b"[SPAWN-INSTANCE] queued ");
     crate::sys::serial::print(name.as_bytes());
     crate::sys::serial::print(if result >= 0 { b" -> ok\n" } else { b" -> fail\n" });
     result
+}
+
+// The queued window spawn is drained by init, which runs at Priority::Low so an
+// idle desktop leaves its cycles to the apps. A busy-yielding app with a fetch
+// in flight can then starve a low-priority init off a single CPU, and the drain
+// never runs, so the second window never opens. This syscall runs in the
+// scheduled caller (the shell), so lift init to Normal here: init cannot boost
+// itself once starved, but the click that needs the window can. Init drops back
+// to Low from its own loop once the queue empties. Init is pid 1, the first
+// process the kernel creates, before any capsule.
+fn boost_init_for_drain() {
+    const INIT_PID: u32 = 1;
+    if let Some(pcb) = crate::process::core::PROCESS_TABLE.find_by_pid(INIT_PID) {
+        *pcb.priority.lock() = crate::process::core::Priority::Normal;
+    }
 }
 
 // Map a handle to an app that declares instance endpoints, and queue it.

--- a/src/userspace/init/instance_spawn/mod.rs
+++ b/src/userspace/init/instance_spawn/mod.rs
@@ -35,6 +35,7 @@ mod queue;
 mod request;
 mod service;
 
+pub(crate) use queue::has_pending;
 pub use queue::PendingApp;
 pub use request::request;
 pub(crate) use service::service;

--- a/src/userspace/init/instance_spawn/queue.rs
+++ b/src/userspace/init/instance_spawn/queue.rs
@@ -64,3 +64,14 @@ pub(super) fn take() -> Vec<PendingApp> {
     }
     core::mem::take(&mut *q)
 }
+
+/// Whether any window-instance request is waiting to be drained. The init loop
+/// reads this to raise its priority only while there is deferred window work. A
+/// contended lock means a push is in flight, which is itself pending work, so it
+/// counts as pending rather than risking a missed boost.
+pub(crate) fn has_pending() -> bool {
+    match PENDING.try_lock() {
+        Some(q) => !q.is_empty(),
+        None => true,
+    }
+}

--- a/src/userspace/init/mod.rs
+++ b/src/userspace/init/mod.rs
@@ -22,4 +22,5 @@ mod supervisor;
 
 pub use entry::run_init;
 pub use instance_spawn::{request as request_instance, PendingApp};
+pub(crate) use instance_spawn::has_pending as instance_spawns_pending;
 pub(crate) use instance_spawn::service as service_instance_spawns;

--- a/src/userspace/init/supervisor/loop_impl.rs
+++ b/src/userspace/init/supervisor/loop_impl.rs
@@ -20,12 +20,15 @@
 //! probe capsules — liveness arrives through the existing process
 //! state machine.
 
+use crate::process::core::Priority;
+
 const TICK_INTERVAL_MS: u64 = 1000;
 
 pub(crate) fn init_loop() -> ! {
     let mut last_tick = 0u64;
     #[cfg(feature = "microkernel-setup-wizard")]
     let mut desktop_started = false;
+    let mut boosted = false;
     loop {
         let now = crate::time::timestamp_millis();
         if now >= last_tick + TICK_INTERVAL_MS {
@@ -37,11 +40,35 @@ pub(crate) fn init_loop() -> ! {
             super::super::spawn_plan::spawn_post_wizard();
             desktop_started = true;
         }
+        // Init runs at Priority::Low so an idle system spends its cycles on the
+        // apps, but the window-instance drain below (and the focus-frame
+        // delivery inside it) must not be starved: a busy-yielding app with a
+        // network fetch in flight would otherwise keep a low-priority init off
+        // the single CPU, so a dock click never opened its second window. Raise
+        // to Normal while there is queued window work and drop back to Low when
+        // idle, so the drain runs promptly without making an idle init costly.
+        let want = crate::userspace::init::instance_spawns_pending();
+        if want != boosted {
+            set_init_priority(if want { Priority::Normal } else { Priority::Low });
+            boosted = want;
+        }
         // Perform any window-instance spawns the shell requested. Running
         // them here, in init's context, keeps the heavy spawn out of the
         // calling capsule's syscall, which is what stopped the caller from
         // resuming (it faulted on its own code under the wrong page tables).
         crate::userspace::init::service_instance_spawns();
         crate::sched::yield_now();
+    }
+}
+
+// Set init's own scheduling priority. Mirrors `lower_init_priority` in entry.rs;
+// used to lift the drain out of starvation while there is a window to open, then
+// return to Low when the queue is empty.
+fn set_init_priority(p: Priority) {
+    use crate::process::core::{CURRENT_PID, PROCESS_TABLE};
+    use core::sync::atomic::Ordering;
+    let pid = CURRENT_PID.load(Ordering::Relaxed);
+    if let Some(pcb) = PROCESS_TABLE.find_by_pid(pid) {
+        *pcb.priority.lock() = p;
     }
 }


### PR DESCRIPTION
Opening a second or third window of an app stopped working: a dock click
registered (the request was queued) but the window never appeared.

The on-demand window path spawns each extra window from init's context, off a
queue that a dock click fills through mk_spawn_instance. init drains that queue
in its residual loop, but it runs at Priority::Low so an idle desktop spends
its cycles on the apps rather than on init. That is fine until an app yields
instead of sleeping while it has async work in flight (a browser fetch, the
wallet reading balances). On a single CPU the busy app then keeps a
low-priority init from ever being scheduled, the drain never runs, and the
queue fills and rejects every further click.

init cannot raise its own priority once it has been starved, because it never
runs to do so. The fix moves the boost to the caller: mk_spawn_instance runs in
the shell, which is scheduled, so it lifts init to Normal the moment a request
is queued. init then drains the queue and returns itself to Low from its own
loop once the queue is empty, so an idle init stays as cheap as before.

Verified under QEMU: clicking the terminal and browser dock icons now spawns
app.terminal.1/.2/.3 and app.browser.1/.2 as real windows, with no queue
rejections, where before every request after the first landed with the window
never opening.