### PR TITLE
shell: show the window-launch result as a toast

### DIFF
--- a/userland/capsule_desktop_shell/src/server/handlers/launcher_focus.rs
+++ b/userland/capsule_desktop_shell/src/server/handlers/launcher_focus.rs
@@ -17,9 +17,9 @@
 use nonos_libc::mk_time_millis;
 
 use crate::render::layout::{bottom_dock_rect, TASKBAR_ENTRY_W};
-use crate::server::handlers::launcher_request;
+use crate::server::handlers::launcher_request::{self, LaunchOutcome};
 use crate::server::refresh_taskbar::refresh_taskbar;
-use crate::state::{mark_taskbar_launch, Context, LAUNCHER_APPS};
+use crate::state::{mark_taskbar_launch, Context, NotifyLevel, LAUNCHER_APPS};
 
 pub fn handle(ctx: &mut Context, x: u32, y: u32) {
     let bottom = bottom_dock_rect(ctx.width, ctx.height);
@@ -30,10 +30,24 @@ pub fn handle(ctx: &mut Context, x: u32, y: u32) {
             && y >= bottom.y + 10
             && y < bottom.y + bottom.height - 10
         {
-            if launcher_request::request(app) {
-                mark_taskbar_launch(&mut ctx.taskbar, index, mk_time_millis());
-                refresh_taskbar(ctx);
+            let now = mk_time_millis();
+            // Surface the result on screen: with no serial port a dock click is
+            // otherwise silent, so a toast says which branch it took.
+            match launcher_request::request(app) {
+                LaunchOutcome::Queued => {
+                    ctx.toasts.push(b"opening a new window", NotifyLevel::Info, now);
+                    mark_taskbar_launch(&mut ctx.taskbar, index, now);
+                }
+                LaunchOutcome::Focused => {
+                    ctx.toasts
+                        .push(b"window limit reached, focusing", NotifyLevel::Warn, now);
+                    mark_taskbar_launch(&mut ctx.taskbar, index, now);
+                }
+                LaunchOutcome::Failed => {
+                    ctx.toasts.push(b"could not open window", NotifyLevel::Error, now);
+                }
             }
+            refresh_taskbar(ctx);
             return;
         }
         row_x += TASKBAR_ENTRY_W + 6;

--- a/userland/capsule_desktop_shell/src/server/handlers/launcher_request.rs
+++ b/userland/capsule_desktop_shell/src/server/handlers/launcher_request.rs
@@ -18,6 +18,16 @@ use nonos_libc::{mk_ipc_send_to_pid, mk_service_lookup, mk_spawn_instance};
 
 use crate::state::apps::LauncherApp;
 
+/// What a dock-launch click actually did, so the caller can surface it on
+/// screen. `Queued` means the kernel accepted a new-window spawn; `Focused`
+/// means the slot table was full and the running window was raised instead.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum LaunchOutcome {
+    Queued,
+    Focused,
+    Failed,
+}
+
 const CONTROL_LEN: usize = 8;
 const CONTROL_MAGIC: u32 = u32::from_le_bytes(*b"NCTL");
 const CONTROL_VERSION: u16 = 1;
@@ -30,13 +40,17 @@ const OP_FOCUS_SELF: u16 = 1;
 // appears a tick later; when every declared slot is live the kernel returns
 // an error and we focus the running instance instead, so a click is never a
 // dead end.
-pub fn request(app: &LauncherApp) -> bool {
+pub fn request(app: &LauncherApp) -> LaunchOutcome {
     if mk_spawn_instance(app.service) >= 0 {
-        return true;
+        return LaunchOutcome::Queued;
     }
-    let Some(pid) = lookup_pid(app.service) else { return false };
+    let Some(pid) = lookup_pid(app.service) else { return LaunchOutcome::Failed };
     let frame = focus_frame();
-    mk_ipc_send_to_pid(pid, frame.as_ptr(), frame.len()) >= 0
+    if mk_ipc_send_to_pid(pid, frame.as_ptr(), frame.len()) >= 0 {
+        LaunchOutcome::Focused
+    } else {
+        LaunchOutcome::Failed
+    }
 }
 
 pub(crate) fn lookup_pid(service: &[u8]) -> Option<u32> {


### PR DESCRIPTION
A dock click opens a new window of an app, or focuses the running one when the
app already has all of its declared windows open. Both cases looked the same on
screen, so a click that reached the window limit was indistinguishable from a
click that did nothing.

The launcher request now returns which of the three outcomes happened (a new
window queued, an existing window focused, or the launch failed) and the click
handler raises a short toast for each. The toast is drawn through the existing
compositor path, so it needs no additional capability in the shell manifest.