### PR TITLE
Wi-Fi on real hardware, and three ways a build could ship the wrong thing

### DIFF
--- a/.github/workflows/ci-windows-virtualbox.yml
+++ b/.github/workflows/ci-windows-virtualbox.yml
@@ -14,6 +14,12 @@
 name: windows-virtualbox
 
 on:
+  # A dispatch can only be started from the default branch, so until this is
+  # merged the push trigger below is how it runs. It is scoped to this file, so
+  # ordinary work on the branch does not spend a Windows runner.
+  push:
+    branches: [browser-engine]
+    paths: [".github/workflows/ci-windows-virtualbox.yml"]
   workflow_dispatch:
     inputs:
       release_tag:
@@ -41,8 +47,8 @@ jobs:
       - name: Fetch the image
         run: |
           New-Item -ItemType Directory -Force -Path artifacts | Out-Null
-          gh release download "${{ inputs.release_tag }}" --repo "$env:GITHUB_REPOSITORY" `
-              --pattern "${{ inputs.asset }}" --dir artifacts --clobber
+          gh release download "${{ inputs.release_tag || 'windows-boot-test' }}" --repo "$env:GITHUB_REPOSITORY" `
+              --pattern "${{ inputs.asset || 'nonos.iso' }}" --dir artifacts --clobber
           Move-Item artifacts\* artifacts\nonos.iso -Force -EA SilentlyContinue
           Get-FileHash artifacts\nonos.iso -Algorithm SHA256
         shell: pwsh
@@ -66,7 +72,7 @@ jobs:
         run: |
           $vb = "C:\Program Files\Oracle\VirtualBox\VBoxManage.exe"
           & $vb startvm nonos --type headless
-          Start-Sleep -Seconds ${{ inputs.boot_seconds }}
+          Start-Sleep -Seconds ${{ inputs.boot_seconds || '180' }}
           & $vb controlvm nonos screenshotpng "$PWD\artifacts\screen.png"
           & $vb controlvm nonos poweroff
         shell: pwsh

--- a/.github/workflows/ci-windows-virtualbox.yml
+++ b/.github/workflows/ci-windows-virtualbox.yml
@@ -16,9 +16,13 @@ name: windows-virtualbox
 on:
   workflow_dispatch:
     inputs:
-      iso_url:
-        description: "URL of the ISO to boot"
+      release_tag:
+        description: "Tag of the release carrying the ISO. A draft works, so an image can be tested before it is published."
         required: true
+      asset:
+        description: "Name of the ISO asset on that release"
+        required: false
+        default: "nonos.iso"
       boot_seconds:
         description: "How long to let it run before capturing"
         required: false
@@ -37,9 +41,13 @@ jobs:
       - name: Fetch the image
         run: |
           New-Item -ItemType Directory -Force -Path artifacts | Out-Null
-          Invoke-WebRequest -Uri "${{ inputs.iso_url }}" -OutFile artifacts\nonos.iso
+          gh release download "${{ inputs.release_tag }}" --repo "$env:GITHUB_REPOSITORY" `
+              --pattern "${{ inputs.asset }}" --dir artifacts --clobber
+          Move-Item artifacts\* artifacts\nonos.iso -Force -EA SilentlyContinue
           Get-FileHash artifacts\nonos.iso -Algorithm SHA256
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Create the machine
         run: |

--- a/.github/workflows/ci-windows-virtualbox.yml
+++ b/.github/workflows/ci-windows-virtualbox.yml
@@ -1,0 +1,91 @@
+# Boot the image under VirtualBox on a Windows host and bring back what it did.
+#
+# Every other runtime job here uses QEMU on Linux with a virtio network card.
+# VirtualBox presents an Intel card instead, so the e1000 driver has had no
+# coverage at all, and the reports we cannot reproduce all come from Windows
+# hosts. This runs the real thing: Windows, VirtualBox, the shipped ISO, with a
+# serial port to a file so the guest can say what happened.
+#
+# The runner is itself a virtual machine, so VirtualBox may not be able to take
+# the processor's virtualisation extensions. That is not a wasted run: VBox.log
+# records which execution engine it got, and knowing whether a Windows host in
+# this configuration can run the image at all is the question being asked.
+
+name: windows-virtualbox
+
+on:
+  workflow_dispatch:
+    inputs:
+      iso_url:
+        description: "URL of the ISO to boot"
+        required: true
+      boot_seconds:
+        description: "How long to let it run before capturing"
+        required: false
+        default: "180"
+
+jobs:
+  boot:
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Install VirtualBox
+        run: choco install virtualbox --no-progress --yes
+        shell: pwsh
+
+      - name: Fetch the image
+        run: |
+          New-Item -ItemType Directory -Force -Path artifacts | Out-Null
+          Invoke-WebRequest -Uri "${{ inputs.iso_url }}" -OutFile artifacts\nonos.iso
+          Get-FileHash artifacts\nonos.iso -Algorithm SHA256
+        shell: pwsh
+
+      - name: Create the machine
+        run: |
+          $vb = "C:\Program Files\Oracle\VirtualBox\VBoxManage.exe"
+          & $vb createvm --name nonos --ostype Linux_64 --register
+          & $vb modifyvm nonos --memory 4096 --cpus 2 --firmware efi `
+              --graphicscontroller vmsvga --vram 128 `
+              --nic1 nat --nictype1 82540EM --accelerate3d off
+          & $vb modifyvm nonos --uart1 0x3F8 4 --uartmode1 file "$PWD\artifacts\serial.log"
+          & $vb storagectl nonos --name SATA --add sata --controller IntelAhci
+          & $vb storageattach nonos --storagectl SATA --port 0 --device 0 `
+              --type dvddrive --medium "$PWD\artifacts\nonos.iso"
+        shell: pwsh
+
+      - name: Boot it
+        run: |
+          $vb = "C:\Program Files\Oracle\VirtualBox\VBoxManage.exe"
+          & $vb startvm nonos --type headless
+          Start-Sleep -Seconds ${{ inputs.boot_seconds }}
+          & $vb controlvm nonos screenshotpng "$PWD\artifacts\screen.png"
+          & $vb controlvm nonos poweroff
+        shell: pwsh
+        continue-on-error: true
+
+      - name: Say what happened
+        if: always()
+        run: |
+          Copy-Item "$env:USERPROFILE\VirtualBox VMs\nonos\Logs\VBox.log" artifacts\ -EA SilentlyContinue
+          Write-Host "=== execution engine ==="
+          Select-String -Path artifacts\VBox.log -Pattern "NEM|VT-x|AMD-V|Driverless" -EA SilentlyContinue |
+            Select-Object -First 6
+          Write-Host "=== serial, last 40 lines ==="
+          if (Test-Path artifacts\serial.log) {
+            Get-Content artifacts\serial.log -Tail 40
+          } else {
+            Write-Host "no serial output: the guest never reached a console"
+          }
+        shell: pwsh
+
+      - name: Keep the evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-virtualbox-boot
+          path: |
+            artifacts/serial.log
+            artifacts/screen.png
+            artifacts/VBox.log
+          if-no-files-found: warn

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -956,7 +956,14 @@ max_size  = "16MiB"
 [profile.release]
 opt-level       = 3
 lto             = "thin"
-codegen-units   = 4
+# One codegen unit, to keep the build reproducible. Thin LTO across several
+# units settles its imports and partition boundaries per run, which is a known
+# way for two builds of one commit to diverge. Measured here the kernel ELF came
+# out byte identical either way, so this is precaution rather than a fix, paid
+# for in build time. The divergence that was actually observed is in the STARK
+# attestation trailer, which is randomised because the proof is zero knowledge,
+# and no build setting changes that.
+codegen-units   = 1
 panic           = "abort"
 strip           = "debuginfo"
 debug           = false

--- a/mk/20-build.mk
+++ b/mk/20-build.mk
@@ -221,6 +221,16 @@ $(NONOS_RT_OBJ): $(NONOS_RT_SRCS) | $(TARGET_DIR)/.nonos-toolchain.stamp
 		RUSTUP_TOOLCHAIN=$(TOOLCHAIN) \
 		$(CARGO) rustc --release --target ../../userland/$(NONOS_USER_TARGET).json \
 		-Zbuild-std=core -- --emit obj=$(NONOS_RT_OBJ)
+	@# `--emit obj=` only writes when cargo actually runs rustc. This crate keeps
+	@# its own target directory, which `distclean` does not remove, so cargo can
+	@# call it fresh, skip rustc and leave nothing behind while still exiting 0.
+	@# Every std capsule then fails to link against an object that is not there.
+	@test -f $(NONOS_RT_OBJ) || { \
+		cd toolchain/nonos-rt && RUSTUP_TOOLCHAIN=$(TOOLCHAIN) $(CARGO) clean && cd ../.. && \
+		cd toolchain/nonos-rt && RUSTUP_TOOLCHAIN=$(TOOLCHAIN) $(CARGO) rustc --release \
+			--target ../../userland/$(NONOS_USER_TARGET).json \
+			-Zbuild-std=core -- --emit obj=$(NONOS_RT_OBJ); }
+	@test -f $(NONOS_RT_OBJ) || { echo "nonos_rt.o was not produced"; exit 1; }
 
 # std platform layer: patch the pinned rust-src so -Zbuild-std=std turns
 # unmodified `use std::...` crates into NONOS binaries. Stamped and keyed on
@@ -654,7 +664,14 @@ endef
 # Kernel ELF artefact rule, no-features default (resolves to
 # microkernel-core via Cargo.toml). Phony deps stay off this rule so a
 # chain walk does not invalidate kernels built with a feature variant.
-$(TARGET_DIR)/x86_64-nonos/release/nonos-kernel: $(SIGNING_KEY)
+#
+# The signing key is an order-only prerequisite for the same reason. A rotated
+# key is newer than the kernel ELF, and as a normal prerequisite that rebuilt
+# this featureless kernel over the same output path a feature variant writes.
+# The signer then dual-signed and attested a microkernel-core image while the
+# log still said microkernel-full-gui. The key has to exist; its age says
+# nothing about whether this ELF is current.
+$(TARGET_DIR)/x86_64-nonos/release/nonos-kernel: | $(SIGNING_KEY)
 	@echo "Building kernel (default = microkernel-core)..."
 	@$(SDK_FLAGS) NONOS_SIGNING_KEY=$(KERNEL_SIGNING_KEY) \
 		RUSTUP_TOOLCHAIN=$(TOOLCHAIN) \

--- a/mk/30-image.mk
+++ b/mk/30-image.mk
@@ -7,6 +7,16 @@
 # the distributable production image. For a USB stick use nonos-mk-usb-img
 # instead: it writes a real GPT partition table, which is what firmware
 # expects from a disk, where a plain El Torito ISO is not dependable.
+# Every timestamp that reaches an image is pinned. Left alone, the FAT volume
+# serial, the file modification times and the ISO volume descriptor all carry
+# the wall clock, so two builds of one commit differ in hash while being
+# byte-identical in content. The download page states these builds are
+# reproducible, and that has to be true of the artefact and not just the source.
+# Override NONOS_IMAGE_DATE only to reproduce an older image.
+NONOS_IMAGE_DATE      ?= 2026010100000000
+NONOS_IMAGE_TOUCH     ?= 202601010000.00
+NONOS_IMAGE_FAT_SERIAL ?= 4e4f4e4f
+
 NONOS_ISO ?= $(TARGET_DIR)/nonos.iso
 nonos-mk-iso: nonos-mk-esp
 	@echo "Building bootable UEFI ISO $(NONOS_ISO)..."
@@ -15,12 +25,15 @@ nonos-mk-iso: nonos-mk-esp
 	@sz=$$(( $$(du -sm $(ESP_DIR)/EFI | cut -f1) + 16 )); \
 		dd if=/dev/zero of=$(TARGET_DIR)/efiboot.img bs=1048576 count=$$sz status=none 2>/dev/null \
 		|| dd if=/dev/zero of=$(TARGET_DIR)/efiboot.img bs=1048576 count=$$sz 2>/dev/null
-	@mformat -i $(TARGET_DIR)/efiboot.img -F ::
-	@mcopy -i $(TARGET_DIR)/efiboot.img -s $(ESP_DIR)/EFI ::/EFI
 	@cp -r $(ESP_DIR)/EFI $(TARGET_DIR)/isoroot/
+	@find $(TARGET_DIR)/isoroot -exec touch -t $(NONOS_IMAGE_TOUCH) {} +
+	@mformat -i $(TARGET_DIR)/efiboot.img -N $(NONOS_IMAGE_FAT_SERIAL) -F ::
+	@mcopy -i $(TARGET_DIR)/efiboot.img -s $(TARGET_DIR)/isoroot/EFI ::/EFI
 	@cp $(TARGET_DIR)/efiboot.img $(TARGET_DIR)/isoroot/
+	@find $(TARGET_DIR)/isoroot -exec touch -t $(NONOS_IMAGE_TOUCH) {} +
 	@xorriso -as mkisofs -R -J -V NONOS \
 		-e efiboot.img -no-emul-boot \
+		--modification-date=$(NONOS_IMAGE_DATE) \
 		-o $(NONOS_ISO) $(TARGET_DIR)/isoroot >/dev/null 2>&1
 	@echo "ISO ready at $(NONOS_ISO)"
 	@echo "  Boot in QEMU:  qemu-system-x86_64 -bios OVMF.fd -cdrom $(NONOS_ISO)"

--- a/mk/50-ci.mk
+++ b/mk/50-ci.mk
@@ -95,6 +95,11 @@ nonos-mk-distclean: nonos-mk-clean-all
 	@rm -rf $(BOOTLOADER_DIR)/target target
 	@rm -f $(SIGNING_KEY) $(KERNEL_MLDSA65_KEY) $(KERNEL_MLDSA65_PUB)
 	@rm -rf $(ZK_KEYS_DIR)
+	@# The std startup object is emitted into target/ by a crate that keeps its
+	@# own target directory. Leaving that behind means cargo calls the crate fresh
+	@# on the next build, never runs rustc, and so never re-emits the object that
+	@# every std capsule links against.
+	@rm -rf toolchain/nonos-rt/target
 
 nonos-mk-fmt:
 	@RUSTUP_TOOLCHAIN=$(TOOLCHAIN) $(CARGO) fmt

--- a/src/hardware/e1000_capsule/spawn.rs
+++ b/src/hardware/e1000_capsule/spawn.rs
@@ -55,6 +55,10 @@ pub fn spawn_driver_e1000_capsule() -> Result<(), SpawnError> {
         target_triple: TARGET_TRIPLE,
         requested_caps: Capability::IPC.bit()
             | Capability::Memory.bit()
+            // The station address is drawn rather than read out of the EEPROM,
+            // and CryptoRandom is gated on this capability. The draw fails closed,
+            // so without it the card never gets an address to transmit under.
+            | Capability::Crypto.bit()
             | Capability::Driver.bit()
             | Capability::DeviceEnum.bit()
             | Capability::Mmio.bit()

--- a/src/hardware/rtl8821ce_capsule/spawn.rs
+++ b/src/hardware/rtl8821ce_capsule/spawn.rs
@@ -49,6 +49,10 @@ pub fn spawn_driver_rtl8821ce_capsule() -> Result<(), SpawnError> {
         target_triple: TARGET_TRIPLE,
         requested_caps: Capability::IPC.bit()
             | Capability::Memory.bit()
+            // The station address is drawn rather than read out of the efuse, and
+            // CryptoRandom is gated on this capability. Without it the draw comes
+            // back empty, the PHY is never configured, and the radio stays down.
+            | Capability::Crypto.bit()
             | crate::capabilities::serial_debug_cap()
             | Capability::Driver.bit()
             | Capability::DeviceEnum.bit()

--- a/userland/capsule_browser/src/browser/fetch/socks/connect.rs
+++ b/userland/capsule_browser/src/browser/fetch/socks/connect.rs
@@ -31,7 +31,19 @@ pub fn connect(port: u32, f: &mut Fetch) {
         return;
     }
     if f.socks[0] != 0x05 || f.socks[1] != 0x00 || f.socks[2] != 0x00 {
-        f.error = Some("socks connect rejected");
+        // The proxy already said which step refused, so report that rather than
+        // the bare fact of refusal. Each of these is a different thing to go and
+        // look at, and on a machine with no console this line is the only place
+        // the difference shows.
+        f.error = Some(match f.socks[1] {
+            0x01 => "mixnet: the request could not be built",
+            0x02 => "mixnet: refused by ruleset",
+            0x03 => "mixnet: no session, the mixnet is not connected",
+            0x04 => "mixnet: no exit for this destination",
+            0x05 => "mixnet: the gateway refused the request",
+            0x06 => "mixnet: expired in transit",
+            _ => "socks connect rejected",
+        });
         f.phase = Phase::Error;
         return;
     }

--- a/userland/capsule_driver_e1000/Capsule.mk
+++ b/userland/capsule_driver_e1000/Capsule.mk
@@ -15,8 +15,11 @@ CAPSULE_FEATURE          := nonos-capsule-driver-e1000
 CAPSULE_NAMESPACE        := systems.nonos.driver.e1000_0
 CAPSULE_SERVICE_ENDPOINT := service:4210:driver.e1000_0
 CAPSULE_REPLY_ENDPOINT   := reply:4211:endpoint.4294967308
-# IPC|Memory|Driver|DeviceEnum|Mmio|Irq|Dma = 0xF8019
-CAPSULE_REQUIRED_CAPS    := 0xF8019
+# IPC|Memory|Crypto|Driver|DeviceEnum|Mmio|Irq|Dma = 0xF8039
+# Crypto (0x20) is what the CryptoRandom syscall is gated on. The station address
+# is drawn rather than read out of the EEPROM, and that draw fails closed, so
+# without this the card has no address to transmit under.
+CAPSULE_REQUIRED_CAPS    := 0xF8039
 CAPSULE_KERNEL_MIRROR    := src/hardware/e1000_capsule
 
 include nonos-mk/capsule.mk

--- a/userland/capsule_driver_rtl8821ce/Capsule.mk
+++ b/userland/capsule_driver_rtl8821ce/Capsule.mk
@@ -12,11 +12,14 @@ CAPSULE_FEATURE          := nonos-capsule-driver-rtl8821ce
 CAPSULE_NAMESPACE        := systems.nonos.driver.rtl8821ce0
 CAPSULE_SERVICE_ENDPOINT := service:4234:driver.rtl8821ce0
 CAPSULE_REPLY_ENDPOINT   := reply:4235:endpoint.4294967320
-# IPC|Memory|Driver|DeviceEnum|Mmio|Irq|Dma|Debug = 0xF8119
+# IPC|Memory|Crypto|Driver|DeviceEnum|Mmio|Irq|Dma|Debug = 0xF8139
 # Debug (0x100) is the upper bound so a serial-debug kernel can grant it and the
 # radio bring-up reports its progress; a hardened build grants a subset without
 # it and the driver still spawns.
-CAPSULE_REQUIRED_CAPS    := 0xF8119
+# Crypto (0x20) is what the CryptoRandom syscall is gated on. The station address
+# is drawn rather than read out of the efuse, so without this the draw returns
+# nothing and the PHY is left unconfigured with the radio down.
+CAPSULE_REQUIRED_CAPS    := 0xF8139
 CAPSULE_KERNEL_MIRROR    := src/hardware/rtl8821ce_capsule
 
 include nonos-mk/capsule.mk

--- a/userland/capsule_driver_rtl8821ce/src/efuse.rs
+++ b/userland/capsule_driver_rtl8821ce/src/efuse.rs
@@ -24,6 +24,8 @@
 //! so only the bank select and the 2.5V LDO disable bracket the read. Values are
 //! rtw88 facts (`reg.h`, `efuse.c`, `rtw8821c.c`), reimplemented not copied.
 
+use core::sync::atomic::{AtomicU32, Ordering};
+
 use crate::regs::Mmio;
 
 /// The efuse control register: address in bits 8..18, data in the low byte, and
@@ -52,6 +54,25 @@ const RFE_OPTION_OFFSET: usize = 0xCA;
 /// rtw88 `struct rtw8821ce_efuse.mac_addr`).
 const MAC_ADDR_OFFSET: usize = 0xD0;
 
+/// What the chip said when an efuse read stalled: the control register as it last
+/// read back, the byte address it stalled on, and the LDO/bank register. A stage
+/// name alone cannot distinguish a dead register window from a live one whose
+/// efuse controller is not clocked, and this machine has no serial console, so
+/// these travel to the panel in the status reply.
+static LAST_CTL: AtomicU32 = AtomicU32::new(0);
+static LAST_ADDR: AtomicU32 = AtomicU32::new(0);
+static LAST_LDO: AtomicU32 = AtomicU32::new(0);
+
+/// The control, address and LDO registers recorded by the last stalled read.
+/// All zero means no read has stalled since boot.
+pub fn diag() -> (u32, u32, u32) {
+    (
+        LAST_CTL.load(Ordering::Relaxed),
+        LAST_ADDR.load(Ordering::Relaxed),
+        LAST_LDO.load(Ordering::Relaxed),
+    )
+}
+
 /// The board facts the PHY bring-up needs.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct EfuseInfo {
@@ -73,9 +94,23 @@ pub struct EfuseInfo {
 /// if the efuse never completed a byte read.
 pub fn read<M: Mmio>(mmio: &M) -> Option<EfuseInfo> {
     let phys = dump_physical(mmio)?;
+    // A window that reads back all-ones sets the ready flag on every read, so
+    // every byte "completes" instantly and the poll never stalls: an unreadable
+    // efuse is otherwise indistinguishable from a blank one. Programming the RF
+    // from that map picks a front-end the chip does not have.
+    if phys.iter().all(|&b| b == 0xFF) {
+        LAST_CTL.store(0xFFFF_FFFF, Ordering::Relaxed);
+        LAST_ADDR.store(1, Ordering::Relaxed);
+        return None;
+    }
     let mut log = [0xffu8; EFUSE_SIZE];
     deshuffle(&phys, &mut log);
     let opt = log[RFE_OPTION_OFFSET];
+    // 0xFF is the erased value, so an option byte that reads erased was never
+    // burned and there is no front-end to select. The tables index off this.
+    if opt == 0xFF {
+        return None;
+    }
     let cut = ((mmio.read32(REG_CHIP_VER) >> 12) & 0xf) as u8;
     let mut mac = [0u8; 6];
     mac.copy_from_slice(&log[MAC_ADDR_OFFSET..MAC_ADDR_OFFSET + 6]);
@@ -106,6 +141,13 @@ pub(crate) fn dump_physical<M: Mmio>(mmio: &M) -> Option<[u8; EFUSE_SIZE]> {
             }
             spins -= 1;
             if spins == 0 {
+                LAST_CTL.store(ctl, Ordering::Relaxed);
+                // Stored one past the address so zero keeps meaning "no read has
+                // stalled". A window that reads back all-zero would otherwise be
+                // indistinguishable from a loop that was never entered, and those
+                // are opposite faults.
+                LAST_ADDR.store(addr as u32 + 1, Ordering::Relaxed);
+                LAST_LDO.store(mmio.read32(REG_LDO_EFUSE_CTRL), Ordering::Relaxed);
                 return None;
             }
         }

--- a/userland/capsule_driver_rtl8821ce/src/main.rs
+++ b/userland/capsule_driver_rtl8821ce/src/main.rs
@@ -35,6 +35,7 @@ mod fw;
 mod fwload;
 mod link;
 mod mac;
+mod pcie;
 mod phy;
 mod pwr;
 mod regs;
@@ -75,7 +76,7 @@ pub unsafe extern "C" fn _start() -> ! {
 /// serial-less machine the returned stage is the only way to see this, surfaced
 /// through the panel's status request.
 fn bring_up() -> (Option<Mapped>, Stage) {
-    let mapped = match setup::run() {
+    let mut mapped = match setup::run() {
         Ok(m) => m,
         Err(e) => {
             status::line(b"[rtl8821ce] ");
@@ -94,6 +95,24 @@ fn bring_up() -> (Option<Mapped>, Stage) {
             status::line(b"[rtl8821ce] no response after power-on\n");
             return (Some(mapped), Stage::DeadMmio);
         }
+    }
+    // Hold the link out of L1 before reading anything that matters. An L1 link
+    // gates the chip's internal clocks, and a gated block answers reads with
+    // zeros while the always-on registers keep answering, which reads as a
+    // register window that is half alive. The host had ASPM L1 enabled on this
+    // link, and the chip carries its own enable that only the driver can clear.
+    if !pcie::hold_link_awake(&mapped.regs) {
+        status::line(b"[rtl8821ce] pcie link config did not answer\n");
+    }
+    // Read the board facts here, on a freshly powered MAC, which is where rtw88
+    // takes them. Taken at the end of bring-up instead, after the firmware
+    // download and the MAC tables, the efuse control and LDO registers answered
+    // zero on real silicon while the chip id register a few offsets away answered
+    // normally. A failure here is not fatal to the rest of bring-up: the PHY needs
+    // the RF front-end option, so it reports the efuse stage itself.
+    mapped.efuse = efuse::read(&mapped.regs);
+    if mapped.efuse.is_none() {
+        status::line(b"[rtl8821ce] efuse unreadable on a freshly powered mac\n");
     }
     // With the MAC powered, load the 8051 firmware. On real silicon this runs the
     // reserved-page staging and DDMA; off-silicon the whole path bar the DMA

--- a/userland/capsule_driver_rtl8821ce/src/pcie/dbi.rs
+++ b/userland/capsule_driver_rtl8821ce/src/pcie/dbi.rs
@@ -1,0 +1,71 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! The chip's own view of its PCIe core, reached through the DBI window rather
+//! than through config space. The link-power registers live here and not in the
+//! config header, so a driver that only holds MMIO authority can still reach
+//! them. Values are rtw88 facts (`pci.c`, `pci.h`), reimplemented not copied.
+
+use crate::regs::Mmio;
+
+const REG_DBI_WDATA: usize = 0x03E8;
+const REG_DBI_RDATA: usize = 0x03EC;
+const REG_DBI_FLAG: usize = 0x03F0;
+/// Address bits 11..2 select the dword; bits 15..12 are a byte-enable mask.
+const DBI_ADDR_MASK: u16 = 0x0FFC;
+const DBI_WREN_SHIFT: u16 = 12;
+/// Written to byte 2 of the flag register to start a write, and a read.
+const DBI_WFLAG: u8 = 1;
+const DBI_RFLAG: u8 = 2;
+/// rtw88 retries twenty times with ten microseconds between.
+const RETRIES: u32 = 20;
+
+// Roughly ten microseconds of spinning between flag polls.
+fn settle() {
+    for _ in 0..2048 {
+        core::hint::spin_loop();
+    }
+}
+
+/// Read one byte of the PCIe core's register file. `None` if the transaction
+/// never cleared its flag.
+pub fn read8<M: Mmio>(mmio: &M, addr: u16) -> Option<u8> {
+    mmio.write16(REG_DBI_FLAG, addr & DBI_ADDR_MASK);
+    mmio.write8(REG_DBI_FLAG + 2, DBI_RFLAG);
+    for _ in 0..RETRIES {
+        if mmio.read8(REG_DBI_FLAG + 2) == 0 {
+            return Some(mmio.read8(REG_DBI_RDATA + (addr as usize & 3)));
+        }
+        settle();
+    }
+    None
+}
+
+/// Write one byte of the PCIe core's register file. The byte within the dword is
+/// selected by a write-enable bit rather than by the address alone.
+pub fn write8<M: Mmio>(mmio: &M, addr: u16, data: u8) {
+    let remainder = addr & 3;
+    let write_addr = (addr & DBI_ADDR_MASK) | (1u16 << remainder) << DBI_WREN_SHIFT;
+    mmio.write8(REG_DBI_WDATA + remainder as usize, data);
+    mmio.write16(REG_DBI_FLAG, write_addr);
+    mmio.write8(REG_DBI_FLAG + 2, DBI_WFLAG);
+    for _ in 0..RETRIES {
+        if mmio.read8(REG_DBI_FLAG + 2) == 0 {
+            return;
+        }
+        settle();
+    }
+}

--- a/userland/capsule_driver_rtl8821ce/src/pcie/mod.rs
+++ b/userland/capsule_driver_rtl8821ce/src/pcie/mod.rs
@@ -1,0 +1,47 @@
+// NONOS Operating System
+// Copyright (C) 2026 NONOS Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Link power management. ASPM on this chip is two separate mechanisms: the host
+//! sets the PCIe link control bit, and the chip carries its own software enable.
+//! Clearing the chip's holds the link out of L1 regardless of what the host
+//! asked for, which matters because an L1 link gates the internal clocks and a
+//! gated block answers register reads with zeros while the always-on registers
+//! keep answering normally. Held off for the whole of bring-up, the way rtw88
+//! holds it off whenever it has real work to do. Values are rtw88 facts
+//! (`pci.c`, `pci.h`), reimplemented not copied.
+
+mod dbi;
+
+use crate::regs::Mmio;
+
+/// The chip's PCIe link configuration byte, in its own register file.
+const RTK_PCIE_LINK_CFG: u16 = 0x0719;
+/// The chip's own L1 (ASPM) software enable.
+const BIT_L1_SW_EN: u8 = 1 << 3;
+/// The chip's own CLKREQ software enable. CLKREQ lets the platform stop the
+/// reference clock, which gates the same internal blocks L1 does.
+const BIT_CLKREQ_SW_EN: u8 = 1 << 4;
+
+/// Hold the link out of its low-power states for the duration of bring-up.
+/// Returns false if the chip's PCIe register file did not answer, which is worth
+/// reporting: it means the link state could not be established either way.
+pub fn hold_link_awake<M: Mmio>(mmio: &M) -> bool {
+    let Some(value) = dbi::read8(mmio, RTK_PCIE_LINK_CFG) else {
+        return false;
+    };
+    dbi::write8(mmio, RTK_PCIE_LINK_CFG, value & !(BIT_L1_SW_EN | BIT_CLKREQ_SW_EN));
+    true
+}

--- a/userland/capsule_driver_rtl8821ce/src/phy/rxpath.rs
+++ b/userland/capsule_driver_rtl8821ce/src/phy/rxpath.rs
@@ -143,3 +143,11 @@ fn clr<M: Mmio>(mmio: &M, off: usize, bits: u32) {
 pub fn rfe_is_btg(rfe_option: u8) -> bool {
     matches!(rfe_option & 0x1F, 2 | 4 | 7 | 0x0A | 0x0C | 0x0F)
 }
+
+/// Whether this is a front-end the 8821c actually ships with. rtw88 keeps a table
+/// per option and refuses one it has no entry for. 0x1F in particular is what an
+/// erased or unreadable efuse yields, and driving the RF from it programs the
+/// chip for hardware that is not on this board.
+pub fn rfe_is_supported(rfe_option: u8) -> bool {
+    matches!(rfe_option & 0x1F, 0..=7 | 0x0A | 0x0C | 0x0F)
+}

--- a/userland/capsule_driver_rtl8821ce/src/serve/control.rs
+++ b/userland/capsule_driver_rtl8821ce/src/serve/control.rs
@@ -84,7 +84,21 @@ fn status_reply(stage: Stage, radio: &Radio, out: &mut [u8]) -> Option<usize> {
     out[WIFI_HDR + 13..WIFI_HDR + 17].copy_from_slice(&stats.rx_eth.to_le_bytes());
     out[WIFI_HDR + 17..WIFI_HDR + 21].copy_from_slice(&stats.netif_reqs.to_le_bytes());
     out[WIFI_HDR + 21..WIFI_HDR + 25].copy_from_slice(&stats.rx_err.to_le_bytes());
-    Some(WIFI_HDR + 25)
+    // Then the efuse registers as the last stalled read left them. A bring-up that
+    // stops at the efuse says nothing about why on a machine with no serial
+    // console; these three separate a dead register window from a live one whose
+    // efuse controller is never clocked.
+    let (ctl, addr, ldo) = crate::efuse::diag();
+    out[WIFI_HDR + 25..WIFI_HDR + 29].copy_from_slice(&ctl.to_le_bytes());
+    out[WIFI_HDR + 29..WIFI_HDR + 33].copy_from_slice(&addr.to_le_bytes());
+    out[WIFI_HDR + 33..WIFI_HDR + 37].copy_from_slice(&ldo.to_le_bytes());
+    // And which BAR the window came from. rtw88 hardcodes bar_id 2 for this chip
+    // while this driver takes the first MMIO BAR the broker reports, so an index
+    // other than 2 means the registers are being read somewhere they do not live.
+    let (bar, va) = crate::setup::window();
+    out[WIFI_HDR + 37..WIFI_HDR + 41].copy_from_slice(&bar.to_le_bytes());
+    out[WIFI_HDR + 41..WIFI_HDR + 45].copy_from_slice(&va.to_le_bytes());
+    Some(WIFI_HDR + 45)
 }
 
 // The scan is answered instantly from the background scanner's running picture.

--- a/userland/capsule_driver_rtl8821ce/src/serve/radio.rs
+++ b/userland/capsule_driver_rtl8821ce/src/serve/radio.rs
@@ -66,8 +66,9 @@ pub(super) fn build_radio(mapped: Option<Mapped>, stage: Stage) -> (Radio, Stage
         status::line(b"[rtl8821ce] dma ring mapping failed\n");
         return (Radio::Down, Stage::NoDma);
     };
-    if !phy_setup(&m.regs) {
-        return (Radio::Down, Stage::EfuseFailed);
+    match phy_setup(&m.regs, m.efuse) {
+        Ok(()) => {}
+        Err(stage) => return (Radio::Down, stage),
     }
     let our_mac = read_mac(&m.regs);
     let link = RtlLink::new(m.regs, tx_ring, tx_buffers, rx_ring, rx_buffers, our_mac);
@@ -104,11 +105,31 @@ fn map(device_id: u64, claim_epoch: u64, bytes: usize) -> Option<Grant> {
 // route the antenna into the receive amplifier, set transmit power, and tune the
 // default channel. Without a good efuse read the RF front-end is unknown, so the
 // radio is left unconfigured rather than programmed with the wrong tables.
-fn phy_setup(regs: &Regs) -> bool {
-    let Some(info) = efuse::read(regs) else {
-        status::line(b"[rtl8821ce] efuse read failed, radio not configured\n");
-        return false;
+fn phy_setup(regs: &Regs, efuse: Option<efuse::EfuseInfo>) -> Result<(), Stage> {
+    // Taken during bring-up, on a freshly powered MAC, which is where rtw88 reads
+    // it. Read here instead, after the firmware download and the MAC tables, the
+    // efuse control and LDO registers answered zero on real silicon.
+    // Preferably the read taken during bring-up, on a freshly powered MAC, which
+    // is where rtw88 takes it. If that came back unreadable, try again here, which
+    // is where this driver read it when the radio last came up on real hardware.
+    // Never fall through with a map that failed validation: an all-ones efuse
+    // yields front-end 0x1F, and programming the RF tables from it wedges the chip
+    // hard enough that its register window stops answering at all.
+    let info = match efuse.or_else(|| efuse::read(regs)) {
+        Some(info) => info,
+        None => {
+            status::line(b"[rtl8821ce] efuse read failed, radio not configured\n");
+            return Err(Stage::EfuseFailed);
+        }
     };
+    // rtw88 refuses a front-end it has no table for rather than programming the
+    // nearest one. The radio tables are indexed off this, so a wrong value is not
+    // a degraded radio, it is a chip driven with settings for hardware that is not
+    // on this board.
+    if !rxpath::rfe_is_supported(info.rfe) {
+        status::line(b"[rtl8821ce] unsupported rf front-end, radio not configured\n");
+        return Err(Stage::EfuseFailed);
+    }
     let cond = PhyCond { cut: info.cut, pkg: info.pkg, intf: INTF_PCIE, rfe: info.rfe };
     power_on(regs);
     rxpath::pre_tables(regs);
@@ -121,13 +142,13 @@ fn phy_setup(regs: &Regs) -> bool {
         Some(mac) => program_mac(regs, &mac),
         None => {
             status::line(b"[rtl8821ce] no entropy for station address\n");
-            return false;
+            return Err(Stage::NoStationAddress);
         }
     }
     let rfe_btg = rxpath::rfe_is_btg(info.rfe);
     rxpath::set_channel(regs, DEFAULT_CHANNEL, Bw::W20, rfe_btg);
     status::line(b"[rtl8821ce] phy configured\n");
-    true
+    Ok(())
 }
 
 // Write the six-byte station MAC into the MAC-ID registers so the transmitter

--- a/userland/capsule_driver_rtl8821ce/src/serve/stage.rs
+++ b/userland/capsule_driver_rtl8821ce/src/serve/stage.rs
@@ -35,4 +35,9 @@ pub enum Stage {
     /// The efuse never read back, so the PHY could not be configured for this
     /// board and the radio was left dark rather than programmed with guesses.
     EfuseFailed = 6,
+    /// No entropy for a station address, so the radio was left dark rather than
+    /// transmitting under a predictable one. Separate from `EfuseFailed` because
+    /// both were once reported under that name, and a stage that names the wrong
+    /// step sends every investigation to the wrong register.
+    NoStationAddress = 7,
 }

--- a/userland/capsule_driver_rtl8821ce/src/setup/mod.rs
+++ b/userland/capsule_driver_rtl8821ce/src/setup/mod.rs
@@ -23,13 +23,35 @@ use nonos_libc::{
     MK_PCI_CMD_BUS_MASTER, MK_PCI_CMD_MEMORY_SPACE,
 };
 
+use core::sync::atomic::{AtomicU32, Ordering};
+
 use crate::discover::{find, Found};
 use crate::regs::Regs;
+
+/// Which BAR the register window came from, and the low half of the address it
+/// was mapped at. rtw88 hardcodes bar_id 2 for this chip; this driver takes the
+/// first MMIO BAR the broker reports, so a change in what the broker reports
+/// would silently move the window somewhere that still answers reads. On a
+/// machine with no serial console the panel is the only place to check.
+static BAR_INDEX: AtomicU32 = AtomicU32::new(0xFFFF_FFFF);
+static WINDOW_VA: AtomicU32 = AtomicU32::new(0);
+
+/// The BAR index the window was taken from and the low 32 bits of its address.
+/// An index of `0xFFFFFFFF` means no window has been mapped.
+pub fn window() -> (u32, u32) {
+    (BAR_INDEX.load(Ordering::Relaxed), WINDOW_VA.load(Ordering::Relaxed))
+}
 
 pub struct Mapped {
     pub regs: Regs,
     pub device_id: u64,
     pub claim_epoch: u64,
+    /// The board facts, read straight after power-on and before the firmware
+    /// download and the MAC tables run. rtw88 reads the efuse at that point and
+    /// only brings the MAC up afterwards; taking the read at the end instead found
+    /// the efuse registers answering zero on real silicon, so it is taken here,
+    /// while the chip is still in the state the reference driver reads it in.
+    pub efuse: Option<crate::efuse::EfuseInfo>,
 }
 
 /// Find, claim and map the chip. Returns the register window ready for
@@ -55,5 +77,12 @@ pub fn run() -> Result<Mapped, &'static str> {
     if r < 0 {
         return Err("rtl8821ce: mmio map failed");
     }
-    Ok(Mapped { regs: Regs::new(out.user_va), device_id: dev.device_id, claim_epoch: epoch as u64 })
+    BAR_INDEX.store(dev.bar_index, Ordering::Relaxed);
+    WINDOW_VA.store(out.user_va as u32, Ordering::Relaxed);
+    Ok(Mapped {
+        regs: Regs::new(out.user_va),
+        device_id: dev.device_id,
+        claim_epoch: epoch as u64,
+        efuse: None,
+    })
 }

--- a/userland/capsule_settings/src/settings/paint/paint_wifi.rs
+++ b/userland/capsule_settings/src/settings/paint/paint_wifi.rs
@@ -50,8 +50,52 @@ fn stage_message(stage: DriverStage) -> Option<&'static [u8]> {
         DriverStage::FirmwareFailed => Some(b"Wi-Fi radio: firmware load failed."),
         DriverStage::NoDma => Some(b"Wi-Fi radio: DMA setup failed."),
         DriverStage::EfuseFailed => Some(b"Wi-Fi radio: efuse read failed."),
+        DriverStage::NoStationAddress => Some(b"Wi-Fi radio: no entropy for a station address."),
         DriverStage::Unknown => Some(b"Wi-Fi radio: unknown driver state."),
     }
+}
+
+// The efuse registers behind an efuse-stage failure, one line under the message.
+// The stage name says the read stalled; these say whether the register window is
+// dead (all-ones), unclocked (all-zero), or live with the ready bit never set,
+// which are three different faults with the same name on a machine that has no
+// serial console to ask.
+fn paint_efuse_registers(fb: &mut PaintBuffer, state: &State, stage: DriverStage, y: u32) {
+    if stage != DriverStage::EfuseFailed {
+        return;
+    }
+    let Some(dp) = state.wifi_datapath else {
+        return;
+    };
+    // Which window the registers were read from, always, even when the read
+    // itself never stalled. rtw88 uses BAR 2 on this chip; another index means
+    // the reads landed somewhere the registers do not live.
+    let mut bar = *b"bar=_ va=________";
+    bar[4] = if dp.bar_index > 9 { b'?' } else { b'0' + dp.bar_index as u8 };
+    for (i, byte) in bar[9..17].iter_mut().rev().enumerate() {
+        *byte = HEX[((dp.window_va >> (i * 4)) & 0xF) as usize];
+    }
+    fb.text(LABEL_LEFT, y + ROW_H, &bar, STATUS_FG_IDLE);
+    // The driver stores one past the stalled address, so zero means no read ever
+    // stalled and the failure is upstream of the polling loop entirely.
+    let Some(addr) = dp.efuse_addr.checked_sub(1) else {
+        fb.text(LABEL_LEFT, y, b"efuse: no stalled read recorded", STATUS_FG_IDLE);
+        return;
+    };
+    let mut line = [0u8; 48];
+    let mut o = 0;
+    for (label, value) in [(&b"ctl="[..], dp.efuse_ctl), (b"addr=", addr), (b"ldo=", dp.efuse_ldo)]
+    {
+        line[o..o + label.len()].copy_from_slice(label);
+        o += label.len();
+        for i in (0..8).rev() {
+            line[o] = HEX[((value >> (i * 4)) & 0xF) as usize];
+            o += 1;
+        }
+        line[o] = b' ';
+        o += 1;
+    }
+    fb.text(LABEL_LEFT, y, &line[..o], STATUS_FG_IDLE);
 }
 
 // Write `v` as four lowercase hex digits into `out`.
@@ -246,6 +290,7 @@ fn paint_status(fb: &mut PaintBuffer, state: &State, y: u32) {
     if let Some(stage) = state.wifi_stage {
         if let Some(msg) = stage_message(stage) {
             fb.text(LABEL_LEFT, y, msg, STATUS_FG_IDLE);
+            paint_efuse_registers(fb, state, stage, y + ROW_H);
             return;
         }
     }

--- a/userland/capsule_settings/src/wifi/datapath.rs
+++ b/userland/capsule_settings/src/wifi/datapath.rs
@@ -39,6 +39,17 @@ pub struct DataPath {
     pub rx_eth: u32,
     pub netif_reqs: u32,
     pub rx_err: u32,
+    /// The efuse control, address and LDO registers as the last stalled read left
+    /// them. All zero means no read has stalled since boot, so a radio that
+    /// reports the efuse stage with zeros here never entered the polling loop.
+    pub efuse_ctl: u32,
+    pub efuse_addr: u32,
+    pub efuse_ldo: u32,
+    /// The BAR the register window was taken from and the low half of its
+    /// address. rtw88 uses bar_id 2 on this chip, so anything else means the
+    /// registers are being read from the wrong window.
+    pub bar_index: u32,
+    pub window_va: u32,
 }
 
 /// Query the driver for its data-path counts. `None` when the driver service is
@@ -57,7 +68,7 @@ pub fn driver_datapath() -> Option<DataPath> {
     let mut req = [0u8; WIFI_HDR];
     req[0..4].copy_from_slice(&WIFI_MAGIC.to_le_bytes());
     req[4..6].copy_from_slice(&OP_STATUS.to_le_bytes());
-    let mut resp = [0u8; WIFI_HDR + 25];
+    let mut resp = [0u8; WIFI_HDR + 45];
     let n = mk_ipc_call_timeout(
         port as u64,
         req.as_ptr(),
@@ -70,12 +81,22 @@ pub fn driver_datapath() -> Option<DataPath> {
         return None;
     }
     let b = &resp[WIFI_HDR + 1..];
+    // The efuse words are newer than the counters, so a driver built before them
+    // answers the shorter reply and those three stay zero rather than failing the
+    // whole read.
+    let long = n >= (WIFI_HDR + 45) as i64;
+    let word = |i: usize| u32::from_le_bytes([b[i], b[i + 1], b[i + 2], b[i + 3]]);
     Some(DataPath {
-        tx_ok: u32::from_le_bytes([b[0], b[1], b[2], b[3]]),
-        tx_drop: u32::from_le_bytes([b[4], b[5], b[6], b[7]]),
-        rx_ring: u32::from_le_bytes([b[8], b[9], b[10], b[11]]),
-        rx_eth: u32::from_le_bytes([b[12], b[13], b[14], b[15]]),
-        netif_reqs: u32::from_le_bytes([b[16], b[17], b[18], b[19]]),
-        rx_err: u32::from_le_bytes([b[20], b[21], b[22], b[23]]),
+        tx_ok: word(0),
+        tx_drop: word(4),
+        rx_ring: word(8),
+        rx_eth: word(12),
+        netif_reqs: word(16),
+        rx_err: word(20),
+        efuse_ctl: if long { word(24) } else { 0 },
+        efuse_addr: if long { word(28) } else { 0 },
+        efuse_ldo: if long { word(32) } else { 0 },
+        bar_index: if long { word(36) } else { 0xFFFF_FFFF },
+        window_va: if long { word(40) } else { 0 },
     })
 }

--- a/userland/capsule_settings/src/wifi/scan_client.rs
+++ b/userland/capsule_settings/src/wifi/scan_client.rs
@@ -80,6 +80,9 @@ pub enum DriverStage {
     FirmwareFailed,
     NoDma,
     EfuseFailed,
+    /// The radio came up but no station address could be drawn, so it was left
+    /// dark rather than transmitting under a predictable one.
+    NoStationAddress,
     Unknown,
 }
 
@@ -93,6 +96,7 @@ impl DriverStage {
             4 => DriverStage::FirmwareFailed,
             5 => DriverStage::NoDma,
             6 => DriverStage::EfuseFailed,
+            7 => DriverStage::NoStationAddress,
             _ => DriverStage::Unknown,
         }
     }

--- a/userland/capsule_socks5/src/conn/opened.rs
+++ b/userland/capsule_socks5/src/conn/opened.rs
@@ -19,16 +19,17 @@ use super::machine::Conn;
 use crate::wire::{self, REPLY_LEN};
 
 impl Conn {
-    /// Report the tunnel-open result: success replies and relays, failure
-    /// replies host-unreachable and closes.
-    pub fn opened(&mut self, ok: bool) -> ([u8; REPLY_LEN], usize) {
+    /// Report the tunnel-open result under the reply code the attempt earned:
+    /// success replies and relays, anything else replies with the code that
+    /// says which step refused, and closes.
+    pub fn opened(&mut self, code: u8) -> ([u8; REPLY_LEN], usize) {
         let mut buf = [0u8; REPLY_LEN];
-        if ok {
+        if code == wire::REP_OK {
             let len = wire::reply(wire::REP_OK, &mut buf);
             return (buf, len);
         }
         self.phase = Phase::Closed;
-        let len = wire::reply(wire::REP_HOST_UNREACH, &mut buf);
+        let len = wire::reply(code, &mut buf);
         (buf, len)
     }
 }

--- a/userland/capsule_socks5/src/server/feed.rs
+++ b/userland/capsule_socks5/src/server/feed.rs
@@ -67,14 +67,15 @@ pub fn feed(pid: u32, data: &[u8]) -> Reply {
             // A full table has no id to give. Zero is reserved for "no
             // connection", so using it would open a tunnel that every later
             // frame fails to match, rather than telling the client no.
-            let opened = match server.manager.open(pid) {
-                Some(id) => open_tunnel(id, &dest) == OpenOutcome::Opened,
-                None => false,
+            let outcome = match server.manager.open(pid) {
+                Some(id) => open_tunnel(id, &dest),
+                None => OpenOutcome::BadRequest,
             };
+            let opened = outcome == OpenOutcome::Opened;
             let Some(conn) = server.clients.get(pid) else {
                 return Reply::closed(Vec::new());
             };
-            let (reply, len) = conn.opened(opened);
+            let (reply, len) = conn.opened(outcome.reply_code());
             let bytes = reply[..len].to_vec();
             if opened {
                 Reply::open(bytes)

--- a/userland/capsule_socks5/src/server/open.rs
+++ b/userland/capsule_socks5/src/server/open.rs
@@ -17,10 +17,34 @@
 use crate::conn::Dest;
 use crate::nym::{connect_request, open_session, SendError};
 
+/// Why a tunnel did or did not open. These are kept apart all the way to the
+/// SOCKS reply byte: they fail for unrelated reasons, and collapsing them into
+/// one code leaves a client with nothing to report but "rejected" on a machine
+/// whose only other channel is a serial port it does not have.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum OpenOutcome {
     Opened,
-    NoRoute,
+    /// The mixnet has no session, so nothing can be sent through it at all.
+    NoSession,
+    /// A session exists but no exit has been chosen to carry the destination.
+    NoExit,
+    /// The request was formed and refused on its way out.
+    SendFailed,
+    /// The request could not be built for this destination.
+    BadRequest,
+}
+
+impl OpenOutcome {
+    /// The SOCKS reply code that says this to the client.
+    pub fn reply_code(self) -> u8 {
+        match self {
+            OpenOutcome::Opened => crate::wire::REP_OK,
+            OpenOutcome::NoSession => crate::wire::REP_NET_UNREACH,
+            OpenOutcome::NoExit => crate::wire::REP_HOST_UNREACH,
+            OpenOutcome::SendFailed => crate::wire::REP_CONN_REFUSED,
+            OpenOutcome::BadRequest => crate::wire::REP_GENERAL_FAIL,
+        }
+    }
 }
 
 /// Ask the mixnet to open a tunnel to `dest`.
@@ -32,27 +56,27 @@ pub fn open_tunnel(conn_id: u64, dest: &Dest) -> OpenOutcome {
     super::trace::destination(dest);
     if open_session().is_none() {
         super::trace::open_failed(b"no session", 0);
-        return OpenOutcome::NoRoute;
+        return OpenOutcome::NoSession;
     }
     match connect_request(conn_id, dest) {
         Ok(frame) => match crate::nym::send_through_mixnet(&frame) {
             Ok(()) => OpenOutcome::Opened,
             Err(SendError::Remote(code)) => {
                 super::trace::open_failed(b"send", code);
-                OpenOutcome::NoRoute
+                OpenOutcome::SendFailed
             }
             Err(_) => {
                 super::trace::open_failed(b"send", 0);
-                OpenOutcome::NoRoute
+                OpenOutcome::SendFailed
             }
         },
         Err(SendError::NoExit) => {
             super::trace::open_failed(b"no exit", 0);
-            OpenOutcome::NoRoute
+            OpenOutcome::NoExit
         }
         Err(_) => {
             super::trace::open_failed(b"request", 0);
-            OpenOutcome::NoRoute
+            OpenOutcome::BadRequest
         }
     }
 }

--- a/userland/capsule_socks5/src/wire/mod.rs
+++ b/userland/capsule_socks5/src/wire/mod.rs
@@ -51,6 +51,11 @@ pub const ATYP_IPV6: u8 = 0x04;
 /// Reply codes (the `REP` field).
 pub const REP_OK: u8 = 0x00;
 pub const REP_GENERAL_FAIL: u8 = 0x01;
+/// No route to the network the destination is on. Used when the mixnet itself
+/// is not reachable, which is a different fault from an exit that will not take
+/// the destination, and a client that cannot tell them apart cannot be debugged
+/// on a machine with no console.
+pub const REP_NET_UNREACH: u8 = 0x03;
 pub const REP_HOST_UNREACH: u8 = 0x04;
 pub const REP_CONN_REFUSED: u8 = 0x05;
 pub const REP_CMD_UNSUPP: u8 = 0x07;

--- a/userland/capsule_socks5_proofs/Cargo.lock
+++ b/userland/capsule_socks5_proofs/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "socks5_proofs"
-version = "0.2.0"
+version = "0.3.0"

--- a/userland/capsule_socks5_proofs/src/conn_tests.rs
+++ b/userland/capsule_socks5_proofs/src/conn_tests.rs
@@ -7,7 +7,9 @@
 //! behind the greeting is picked up; and a non-SOCKS5 client is closed.
 
 use crate::conn::{Conn, Dest, Event};
-use crate::wire::{ATYP_DOMAIN, REP_HOST_UNREACH, REP_OK, VER};
+use crate::wire::{
+    ATYP_DOMAIN, REP_CONN_REFUSED, REP_GENERAL_FAIL, REP_HOST_UNREACH, REP_NET_UNREACH, REP_OK, VER,
+};
 
 fn is_reply(ev: &Event, expect: &[u8]) -> bool {
     matches!(ev, Event::ToClient { buf, len } if &buf[..*len] == expect)
@@ -40,7 +42,7 @@ fn connect_opens_a_tunnel_then_replies_and_relays() {
         _ => panic!("expected an open to the IPv4 destination"),
     }
     assert!(c.is_relaying());
-    let (buf, len) = c.opened(true);
+    let (buf, len) = c.opened(REP_OK);
     assert_eq!(&buf[..len], &[VER, REP_OK, 0x00, 0x01, 0, 0, 0, 0, 0, 0]);
     assert!(c.is_relaying(), "a successful open keeps relaying");
 }
@@ -63,14 +65,30 @@ fn connect_to_a_domain_carries_the_name_unresolved() {
 }
 
 #[test]
-fn a_failed_open_replies_host_unreachable_and_closes() {
+fn a_failed_open_replies_the_code_it_was_given_and_closes() {
     let mut c = Conn::new();
     let _ = c.on_client(&[0x05, 0x01, 0x00]);
     let _ = c.on_client(&[0x05, 0x01, 0x00, 0x01, 10, 0, 0, 1, 0x00, 0x50]);
-    let (buf, len) = c.opened(false);
+    let (buf, len) = c.opened(REP_HOST_UNREACH);
     assert_eq!(buf[1], REP_HOST_UNREACH);
     assert_eq!(len, 10);
     assert!(c.is_closed());
+}
+
+/// Each way a tunnel can fail reaches the client as its own code. They were once
+/// one boolean, and a reader who could only be told "rejected" had no way to tell
+/// a mixnet that is not connected from an exit that will not carry the address.
+#[test]
+fn every_refusal_carries_its_own_reason() {
+    for code in [REP_GENERAL_FAIL, REP_NET_UNREACH, REP_HOST_UNREACH, REP_CONN_REFUSED] {
+        let mut c = Conn::new();
+        let _ = c.on_client(&[0x05, 0x01, 0x00]);
+        let _ = c.on_client(&[0x05, 0x01, 0x00, 0x01, 10, 0, 0, 1, 0x00, 0x50]);
+        let (buf, len) = c.opened(code);
+        assert_eq!(buf[1], code, "the reply must carry the code the open earned");
+        assert_eq!(len, 10);
+        assert!(c.is_closed(), "a refused open closes whatever the reason");
+    }
 }
 
 #[test]


### PR DESCRIPTION
Wi-Fi had been dark on one of the test laptops since the thirtieth of July. It was working before that, on the same driver, on the same machine, and nothing in the radio code had been touched in between. This is the hunt for why, the two faults it turned up, and the four unrelated places where the same mistake was waiting.

## The station address needed a capability nobody had granted

Since the thirtieth of July both network drivers draw their station address instead of transmitting the one burned into the card. That is deliberate. A factory hardware address is the first field an access point records, and a system that keeps nothing on disk was still arriving in every building under the same name. Being amnesic and being unlinkable are not the same thing.

The draw goes through the CryptoRandom syscall, and the kernel gates that on CAP_CRYPTO. Neither the Wi-Fi capsule nor the ethernet capsule held it. The syscall was refused, the draw failed closed, and `phy_setup` gave up before the PHY was ever configured. Ethernet broke the same way on the same day, and nobody noticed, because a card with no address fails more quietly than a radio does.

The grant has to be in two places. The manifest declares an upper bound and the spawn site requests it, and the caps installed on the process control block come from the verified manifest. Setting one without the other changes nothing.

## The efuse read could not tell a dead window from a blank one

With the capability granted the driver ran further than it had in five weeks, and wedged the chip.

`dump_physical` only fails when a byte read stalls. A register window that reads back all ones sets the ready flag on every read, so every byte completes immediately, nothing ever stalls, and the map comes back looking like a successful read of a blank part. The board description it produced selected radio front-end 0x1f, which is not a front-end this part is built with. Programming the radio tables from it drives the chip for hardware that is not on the board, and it stops answering its register window at all.

The capability failure had been hiding this for five weeks by never getting far enough to use the result.

An all-ones map is now refused rather than acted on, an erased front-end byte is rejected, and the option is checked against the front-ends the part actually ships with. The read is taken during bring-up on a freshly powered MAC, which is where rtw88 takes it, and falls back to the old point if that comes back unreadable.

Link power management comes with it. ASPM on this chip is two mechanisms, the host's link control bit and the chip's own software enable, and an L1 link gates the internal clocks. The chip's enable is cleared for the duration of bring-up, the way rtw88 holds it off whenever it has real work to do.

## The stage name was lying, and that is what cost the time

Both of those were reported on screen as "Wi-Fi radio: efuse read failed", because `build_radio` collapsed every `phy_setup` failure into that one stage. A capability denial displayed as an efuse fault. Nine hypotheses died against that symptom before the efuse was ruled out, and the efuse had been working the whole time.

`phy_setup` now returns the stage it stopped at, a station address that cannot be drawn has its own stage, and the panel says so. The status reply also carries the efuse control, address and LDO registers as the last stalled read left them, plus the BAR the register window came from. The stalled address is stored one past itself so that zero still means no read ever stalled, which separates a window that reads zero from a loop that was never entered. That machine has no serial port. The panel is the only console it has.

## The same mistake, four more times

Every one of these is a failure path that destroys the information needed to diagnose it.

**Rotating the signing key silently downgraded the image.** The featureless kernel rule took the signing key as a normal prerequisite, so a rotated key was newer than the kernel and the rule fired, building a `microkernel-core` kernel over the output path a feature variant writes. The signer then dual signed and attested it while the log still said `microkernel-full-gui`. A 35MB kernel where 103MB was expected was the only outward sign. The key is order-only now: it has to exist, but its age says nothing about whether that ELF is current.

**`distclean` left the tree unable to link.** It removed `target/` but not the startup object's own target directory, so cargo called the crate fresh, skipped rustc, and `--emit obj=` wrote nothing while exiting zero. Every std capsule then failed to link against an object that was never written. Both directories go now, and the rule fails loudly if the object is missing instead of handing the failure downstream.

**Opening a mixnet tunnel could fail four ways and reported one.** No session, no exit, a gateway refusal, or a request that could not be built all came back as a single boolean, became a single SOCKS reply code, and reached the reader as "socks connect rejected". They have nothing to do with each other and nothing to do with each other's fixes. Each outcome now carries the reply code that names it and the browser prints what it means.

**Images carried the wall clock.** Two builds of one commit differed in hash while being identical in content, because the FAT volume serial, the file modification times and the ISO volume descriptor were all stamped at build time. All three are pinned. Two packagings of one build are now byte identical.

## What reproducibility actually means here, since it was chased for a while

Two builds of the same source produce an identical kernel ELF and a different attested image. The difference is the STARK trailer, and it is randomised because the proof is zero knowledge. A proof that came out the same every time would leak what it hides. No build setting changes that, and none should.

So the published image hash identifies the file we released. It is not something a reader regenerates. What a reader can do is rebuild the kernel from source, compare it, and verify the signatures and the attestations carried in the image, because checking a proof does not require the ability to produce one. That is a different claim from byte identical artefacts, and unlike that one it is true.

`codegen-units` is pinned to one as a precaution against thin LTO deciding its partition boundaries differently between runs. Measured on this tree it made no difference to the output, and the comment in the profile says so rather than taking credit for a fix it did not make.

## A gap in the test matrix, which is the more useful finding

Every runtime job in CI boots QEMU with a virtio network card. VirtualBox presents an Intel card instead. The e1000 driver therefore had no automated coverage at all, which is how a capability regression on the thirtieth of July survived to now, and why two reports from VirtualBox users could not be reproduced by anyone on the team.

There is now a workflow that boots the shipped image under VirtualBox on a Windows host and brings back the serial log, a screenshot and VirtualBox's own log. That last one records which execution engine it was given, which matters because a hosted runner is itself a virtual machine and may not be able to hand out the processor's virtualisation extensions. A run that fails for that reason still answers a question worth asking.

Reproduced locally under VirtualBox while writing this: the card is claimed and mapped, the driver comes up and serves, and the network stack never binds to it. That is not fixed here and is not a regression from this branch.

## Verification

Confirmed on two machines: keyboard and touchpad over i2c-HID, WPA2 association on the RTL8821CE, an address from DHCP, the browser loading real sites, and mixnet routing working over that link.

The mixnet proof crate now asserts the reply code rather than a boolean, and walks every refusal to check each one reaches the client as itself. If someone collapses them back into a single value the proofs fail instead of passing quietly, which is the failure this branch spent an evening paying for.
